### PR TITLE
feat: close search results panel after adding item to list

### DIFF
--- a/docs/superpowers/plans/2026-05-20-search-box-auto-close.md
+++ b/docs/superpowers/plans/2026-05-20-search-box-auto-close.md
@@ -1,0 +1,58 @@
+# Search Box Auto-Close After Add Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the search results panel automatically after a search result is successfully added to the shopping list.
+
+**Architecture:** `handleAddToList` in `islands/items.tsx` already has access to `reset()` from `useSearchBox`. Calling `reset()` on success clears `query.value`, which collapses the results panel via the `hasSearchQuery` computed signal in `SearchBox`. No new abstractions needed.
+
+**Tech Stack:** Deno, Fresh 2, Preact, @preact/signals
+
+---
+
+### Task 1: Call reset() after successful add
+
+**Files:**
+- Modify: `islands/items.tsx:80-83`
+
+- [ ] **Step 1: Update `handleAddToList`**
+
+Replace the existing function:
+
+```ts
+const handleAddToList = async (itemId: string) => {
+  const id = await addToList(itemId);
+  if (id) lastAddedId.value = id;
+};
+```
+
+With:
+
+```ts
+const handleAddToList = async (itemId: string) => {
+  const id = await addToList(itemId);
+  if (id) {
+    lastAddedId.value = id;
+    reset();
+  }
+};
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+deno task check
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Verify manually**
+
+Start the dev server (`deno task dev`), log in, type a search term, click the `+` button on a result. The results panel should close immediately. Type another term to confirm search still works.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add islands/items.tsx
+git commit -m "feat: close search results panel after adding item to list"
+```

--- a/docs/superpowers/specs/2026-05-20-search-box-auto-close-design.md
+++ b/docs/superpowers/specs/2026-05-20-search-box-auto-close-design.md
@@ -1,0 +1,33 @@
+# Search Box Auto-Close After Add
+
+## Summary
+
+After a search result is added to the shopping list, the search results panel closes automatically by resetting the query.
+
+## Current Behavior
+
+`handleAddToList` in `islands/items.tsx` adds the item but leaves `query.value` non-empty, so the results panel remains open.
+
+## Desired Behavior
+
+The results panel closes immediately after a successful add (i.e., when the API returns an id), matching the behavior of `handleCreateItem` which already calls `reset()`.
+
+## Change
+
+In `islands/items.tsx`, update `handleAddToList` to call `reset()` on success:
+
+```ts
+const handleAddToList = async (itemId: string) => {
+  const id = await addToList(itemId);
+  if (id) {
+    lastAddedId.value = id;
+    reset();
+  }
+};
+```
+
+`reset()` is provided by `useSearchBox` and clears `query.value`, which collapses the panel via the `hasSearchQuery` computed in `SearchBox`.
+
+## Scope
+
+Single file, single function. No changes to `SearchBox` API or props.

--- a/hooks/useShoppingList.ts
+++ b/hooks/useShoppingList.ts
@@ -94,6 +94,7 @@ export function useShoppingList(
 
     patchScheduler.cancel(id);
     list.value = list.value.filter((li) => li.id !== id);
+    checkedItems.value = checkedItems.value.filter((li) => li.id !== id);
     exitingItems.value = exitingItems.value.filter((itemId) => itemId !== id);
 
     pendingCount.value++;

--- a/islands/items.tsx
+++ b/islands/items.tsx
@@ -79,7 +79,10 @@ export default function Items(
 
   const handleAddToList = async (itemId: string) => {
     const id = await addToList(itemId);
-    if (id) lastAddedId.value = id;
+    if (id) {
+      lastAddedId.value = id;
+      reset();
+    }
   };
 
   const handleCheckItem = async (id: string) => {


### PR DESCRIPTION
## Summary
- Call `reset()` in `handleAddToList` on successful add, so the search results panel closes automatically
- Fixes inconsistency with `handleCreateItem`, which already called `reset()`
- Also fixes done-list not updating when removing an item (`checkedItems` now filtered in `removeListItem`)

## Test Plan
- [ ] Search for an item, click `+` — results panel should close immediately
- [ ] Verify the new item appears in the list and scroll-to-item still works
- [ ] Search again to confirm search still functions normally
- [ ] Mark an item as done, then click Remove — done list should update immediately

🤖 Generated with [Claude Code](https://claude.ai/claude-code)