### PR TITLE
fix: resolve TS2416 errors — Item implements CreateItemDto instead of ItemInterface

### DIFF
--- a/models/item/index.ts
+++ b/models/item/index.ts
@@ -1,5 +1,5 @@
-import { ItemInterface } from "./item.interface.ts";
+import { CreateItemDto, ItemInterface } from "./item.interface.ts";
 import { Item } from "./item.model.ts";
 
 export { Item };
-export type { ItemInterface };
+export type { CreateItemDto, ItemInterface };

--- a/models/item/item.model.ts
+++ b/models/item/item.model.ts
@@ -1,8 +1,7 @@
-import { ItemInterface } from "./item.interface.ts";
+import { CreateItemDto } from "./item.interface.ts";
 
-export class Item implements ItemInterface {
-  id?: string;
-  name?: string;
+export class Item implements CreateItemDto {
+  name: string;
   categoryId?: string;
   constructor(name: string, categoryId?: string) {
     this.name = name;

--- a/routes/items/detail/[id]/edit.tsx
+++ b/routes/items/detail/[id]/edit.tsx
@@ -1,6 +1,6 @@
 import { PageProps } from "fresh";
 import { getKv, ItemRepo } from "@/database/index.ts";
-import { Item, type ItemInterface } from "@/models/index.ts";
+import { Item, type CreateItemDto, type ItemInterface } from "@/models/index.ts";
 import { Handlers } from "fresh/compat";
 
 interface Data {
@@ -23,7 +23,7 @@ export const handler: Handlers<Data> = {
 
     // save the item to the db
 
-    const item: ItemInterface = new Item(name || "unknown");
+    const item: CreateItemDto = new Item(name || "unknown");
 
     const newItem = await ItemRepo.create(item);
 

--- a/routes/items/new.tsx
+++ b/routes/items/new.tsx
@@ -1,6 +1,6 @@
 import { PageProps } from "fresh";
 import { getKv } from "@/database/index.ts";
-import { Item, type ItemInterface } from "@/models/index.ts";
+import { Item, type CreateItemDto } from "@/models/index.ts";
 import { Handlers } from "fresh/compat";
 
 // Removed empty Data interface to satisfy lint rules.
@@ -18,7 +18,7 @@ export const handler: Handlers = {
     // save the item to the db
 
     const id = 111;
-    const item: ItemInterface = new Item(name || "unknown");
+    const item: CreateItemDto = new Item(name || "unknown");
     const kv = await getKv();
     const _result = await kv.set(["items", id], item);
 


### PR DESCRIPTION
## What changed

- `Item` class now implements `CreateItemDto` (`Omit<ItemInterface, 'id'>`) instead of `ItemInterface`
- Removed the phantom `id?: string` property that was never assigned
- Made `name: string` non-optional to match the constructor signature
- Exported `CreateItemDto` from `models/item/index.ts`
- Updated local variable annotations in the two route files from `ItemInterface` to `CreateItemDto`

## Why

`deno check` was reporting two TS2416 errors on `Item`:

```
error TS2416: Property 'id' in type 'Item' is not assignable to the same property in base type 'ItemInterface'.
error TS2416: Property 'name' in type 'Item' is not assignable to the same property in base type 'ItemInterface'.
```

The root cause: `Item` is used exclusively as a **creation DTO** — it is constructed with a `name` (and optional `categoryId`) and passed to `ItemRepo.create()`, which generates the `id`. It never had an `id` of its own. Declaring it `implements ItemInterface` (which requires `id: string`) was incorrect; the codebase already has `CreateItemDto = Omit<ItemInterface, 'id'>` for exactly this purpose.

## Reviewer notes

- No behaviour change — this is a type-level fix only
- `deno check hooks/useShoppingList.ts` now passes cleanly
- The two route handlers (`routes/items/new.tsx`, `routes/items/detail/[id]/edit.tsx`) had the same mistyped annotation corrected

🤖 Generated with [Claude Code](https://claude.com/claude-code)