### PR TITLE
feat: confirm before deleting a shopping list (closes #11)

### DIFF
--- a/components/BottomSheet.tsx
+++ b/components/BottomSheet.tsx
@@ -23,6 +23,18 @@ export default function BottomSheet(
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [open, onClose]);
 
+  // Prevent the page from scrolling while the sheet is open (covers backdrop
+  // drags and any area not handled by the sheet's own touchmove listener).
+  // documentElement is used instead of body for broader iOS Safari support.
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.documentElement.style.overflow;
+    document.documentElement.style.overflow = "hidden";
+    return () => {
+      document.documentElement.style.overflow = prev;
+    };
+  }, [open]);
+
   const handleTouchStart = (e: TouchEvent) => {
     dragStartY.current = e.touches[0].clientY;
     currentDelta.current = 0;

--- a/components/BottomSheet.tsx
+++ b/components/BottomSheet.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useRef } from "preact/hooks";
+import type { ComponentChildren } from "preact";
+
+interface BottomSheetProps {
+  open: boolean;
+  onClose: () => void;
+  children: ComponentChildren;
+}
+
+export default function BottomSheet(
+  { open, onClose, children }: BottomSheetProps,
+) {
+  const sheetRef = useRef<HTMLDivElement>(null);
+  const dragStartY = useRef(0);
+  const currentDelta = useRef(0);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open, onClose]);
+
+  const handleTouchStart = (e: TouchEvent) => {
+    dragStartY.current = e.touches[0].clientY;
+    currentDelta.current = 0;
+  };
+
+  const handleTouchMove = (e: TouchEvent) => {
+    const sheet = sheetRef.current;
+    if (!sheet) return;
+    currentDelta.current = e.touches[0].clientY - dragStartY.current;
+    if (currentDelta.current > 0) {
+      sheet.style.transition = "none";
+      sheet.style.transform = `translateY(${currentDelta.current}px)`;
+    }
+  };
+
+  const handleTouchEnd = () => {
+    const sheet = sheetRef.current;
+    if (!sheet) return;
+    if (currentDelta.current > 80) {
+      sheet.style.transform = "";
+      onClose();
+    } else {
+      sheet.style.transition = "";
+      sheet.style.transform = "";
+    }
+    currentDelta.current = 0;
+  };
+
+  return (
+    <div class="fixed inset-0 z-50 pointer-events-none">
+      <div
+        class={`absolute inset-0 bg-black transition-opacity duration-300 ${
+          open
+            ? "opacity-50 pointer-events-auto"
+            : "opacity-0 pointer-events-none"
+        }`}
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        ref={sheetRef}
+        class={`absolute bottom-0 left-0 right-0 bg-white rounded-t-2xl shadow-2xl transition-transform duration-300 ease-out ${
+          open
+            ? "translate-y-0 pointer-events-auto"
+            : "translate-y-full pointer-events-none"
+        }`}
+        role="dialog"
+        aria-modal="true"
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+      >
+        <div class="flex justify-center pt-3 pb-1">
+          <div class="w-10 h-1 bg-gray-300 rounded-full" />
+        </div>
+        <div class="px-4 pb-8 pt-2">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/BottomSheet.tsx
+++ b/components/BottomSheet.tsx
@@ -33,6 +33,8 @@ export default function BottomSheet(
     if (!sheet) return;
     currentDelta.current = e.touches[0].clientY - dragStartY.current;
     if (currentDelta.current > 0) {
+      // Prevent the page behind the sheet from scrolling while dragging.
+      e.preventDefault();
       sheet.style.transition = "none";
       sheet.style.transform = `translateY(${currentDelta.current}px)`;
     }

--- a/components/BottomSheet.tsx
+++ b/components/BottomSheet.tsx
@@ -42,12 +42,21 @@ export default function BottomSheet(
     const sheet = sheetRef.current;
     if (!sheet) return;
     if (currentDelta.current > 80) {
+      sheet.style.transition = "";
       sheet.style.transform = "";
       onClose();
     } else {
       sheet.style.transition = "";
       sheet.style.transform = "";
     }
+    currentDelta.current = 0;
+  };
+
+  const handleTouchCancel = () => {
+    const sheet = sheetRef.current;
+    if (!sheet) return;
+    sheet.style.transition = "";
+    sheet.style.transform = "";
     currentDelta.current = 0;
   };
 
@@ -74,6 +83,7 @@ export default function BottomSheet(
         onTouchStart={handleTouchStart}
         onTouchMove={handleTouchMove}
         onTouchEnd={handleTouchEnd}
+        onTouchCancel={handleTouchCancel}
       >
         <div class="flex justify-center pt-3 pb-1">
           <div class="w-10 h-1 bg-gray-300 rounded-full" />

--- a/deno.lock
+++ b/deno.lock
@@ -10,6 +10,7 @@
     "jsr:@fresh/plugin-vite@^1.0.8": "1.0.8",
     "jsr:@std/assert@*": "1.0.19",
     "jsr:@std/assert@^1.0.19": "1.0.19",
+    "jsr:@std/async@^1.3.0": "1.3.0",
     "jsr:@std/bytes@^1.0.6": "1.0.6",
     "jsr:@std/data-structures@^1.0.11": "1.0.11",
     "jsr:@std/dotenv@~0.225.5": "0.225.5",
@@ -117,6 +118,9 @@
         "jsr:@std/internal"
       ]
     },
+    "@std/async@1.3.0": {
+      "integrity": "80485538a4f7baaa46bfe2246168069e02ed142b9f9079cd164f43bb060ad9e9"
+    },
     "@std/bytes@1.0.6": {
       "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
     },
@@ -175,6 +179,7 @@
       "integrity": "d3152f57b11666bf6358d0e127c7e3488e91178b0c2d8fbf0793e1c53cd13cb1",
       "dependencies": [
         "jsr:@std/assert@^1.0.19",
+        "jsr:@std/async",
         "jsr:@std/data-structures"
       ]
     },

--- a/docs/superpowers/plans/2026-05-27-confirmation-bottom-sheet.md
+++ b/docs/superpowers/plans/2026-05-27-confirmation-bottom-sheet.md
@@ -1,0 +1,318 @@
+# Confirmation Bottom Sheet Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a reusable `BottomSheet` component and wire it into
+`islands/shopping-lists.tsx` so deleting a shopping list requires explicit
+confirmation.
+
+**Architecture:** A generic `BottomSheet` Preact component in `components/`
+handles open/close CSS transitions, backdrop, swipe-to-dismiss (touch events +
+direct DOM mutation during drag), and Escape key. It is rendered as a sibling to
+the existing JSX inside the `ShoppingLists` island — no new islands, no new API
+routes, no changes outside these two files.
+
+**Tech Stack:** Deno, Fresh 2, Preact + `@preact/signals`, Tailwind CSS v4,
+`deno test`.
+
+---
+
+## File Map
+
+**Create:**
+
+- `components/BottomSheet.tsx` — generic bottom sheet: open/close CSS
+  transitions, swipe-to-dismiss, Escape key, backdrop click-to-dismiss.
+
+**Modify:**
+
+- `islands/shopping-lists.tsx` — add `pendingDelete` signal, replace immediate
+  `deleteList` with two-step flow, render `<BottomSheet>`.
+
+---
+
+### Task 1: BottomSheet component
+
+**Files:**
+
+- Create: `components/BottomSheet.tsx`
+
+- [ ] **Step 1: Create `components/BottomSheet.tsx`**
+
+```tsx
+import { useEffect, useRef } from "preact/hooks";
+import type { ComponentChildren } from "preact";
+
+interface BottomSheetProps {
+  open: boolean;
+  onClose: () => void;
+  children: ComponentChildren;
+}
+
+export default function BottomSheet(
+  { open, onClose, children }: BottomSheetProps,
+) {
+  const sheetRef = useRef<HTMLDivElement>(null);
+  const dragStartY = useRef(0);
+  const currentDelta = useRef(0);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open, onClose]);
+
+  const handleTouchStart = (e: TouchEvent) => {
+    dragStartY.current = e.touches[0].clientY;
+    currentDelta.current = 0;
+  };
+
+  const handleTouchMove = (e: TouchEvent) => {
+    const sheet = sheetRef.current;
+    if (!sheet) return;
+    currentDelta.current = e.touches[0].clientY - dragStartY.current;
+    if (currentDelta.current > 0) {
+      sheet.style.transition = "none";
+      sheet.style.transform = `translateY(${currentDelta.current}px)`;
+    }
+  };
+
+  const handleTouchEnd = () => {
+    const sheet = sheetRef.current;
+    if (!sheet) return;
+    if (currentDelta.current > 80) {
+      sheet.style.transform = "";
+      onClose();
+    } else {
+      sheet.style.transition = "";
+      sheet.style.transform = "";
+    }
+    currentDelta.current = 0;
+  };
+
+  return (
+    <div class="fixed inset-0 z-50 pointer-events-none">
+      <div
+        class={`absolute inset-0 bg-black transition-opacity duration-300 ${
+          open
+            ? "opacity-50 pointer-events-auto"
+            : "opacity-0 pointer-events-none"
+        }`}
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        ref={sheetRef}
+        class={`absolute bottom-0 left-0 right-0 bg-white rounded-t-2xl shadow-2xl transition-transform duration-300 ease-out ${
+          open
+            ? "translate-y-0 pointer-events-auto"
+            : "translate-y-full pointer-events-none"
+        }`}
+        role="dialog"
+        aria-modal="true"
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+      >
+        <div class="flex justify-center pt-3 pb-1">
+          <div class="w-10 h-1 bg-gray-300 rounded-full" />
+        </div>
+        <div class="px-4 pb-8 pt-2">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Type-check the new file**
+
+```bash
+deno check components/BottomSheet.tsx
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/BottomSheet.tsx
+git commit -m "feat: add reusable BottomSheet component with swipe-to-dismiss"
+```
+
+---
+
+### Task 2: Wire up delete confirmation in shopping-lists island
+
+**Files:**
+
+- Modify: `islands/shopping-lists.tsx`
+
+- [ ] **Step 1: Add the BottomSheet import**
+
+At the top of `islands/shopping-lists.tsx`, add to the existing imports:
+
+```ts
+import BottomSheet from "@/components/BottomSheet.tsx";
+```
+
+- [ ] **Step 2: Add the `pendingDelete` signal inside the component function**
+
+After the existing signal declarations (`lists`, `newName`, `editingId`,
+`editName`, `loading`), add:
+
+```ts
+const pendingDelete = useSignal<{ id: string; name: string } | null>(null);
+```
+
+- [ ] **Step 3: Replace `deleteList` with `handleDeleteConfirm`**
+
+Remove the existing `deleteList` function:
+
+```ts
+// REMOVE this:
+const deleteList = async (id: string) => {
+  await api.shoppingLists.delete(id);
+  lists.value = lists.value.filter((l) => l.id !== id);
+};
+```
+
+Add in its place:
+
+```ts
+const handleDeleteConfirm = async () => {
+  if (!pendingDelete.value) return;
+  const { id } = pendingDelete.value;
+  pendingDelete.value = null;
+  await api.shoppingLists.delete(id);
+  lists.value = lists.value.filter((l) => l.id !== id);
+};
+```
+
+The sheet closes (signal cleared) before the API call completes, giving
+immediate visual feedback.
+
+- [ ] **Step 4: Update the trash button's `onClick`**
+
+Find the button with `aria-label={\`Delete ${list.name}\`}`. Change its `onClick`
+from:
+
+```ts
+onClick={() => deleteList(list.id)}
+```
+
+to:
+
+```ts
+onClick={() => pendingDelete.value = { id: list.id, name: list.name }}
+```
+
+- [ ] **Step 5: Wrap the return in a fragment and append BottomSheet**
+
+The current `return` is a single `<div class="space-y-4">`. Wrap it in a
+fragment and append `<BottomSheet>` as a sibling:
+
+```tsx
+return (
+  <>
+    <div class="space-y-4">
+      {/* all existing JSX here — no changes inside this div */}
+    </div>
+
+    <BottomSheet
+      open={pendingDelete.value !== null}
+      onClose={() => pendingDelete.value = null}
+    >
+      <p class="text-lg font-semibold text-gray-900 mb-1">Delete list?</p>
+      <p class="text-sm text-gray-500 mb-6">
+        "{pendingDelete.value?.name}" and all its items will be permanently
+        deleted. This cannot be undone.
+      </p>
+      <button
+        type="button"
+        class="w-full py-3 bg-red-500 text-white font-semibold rounded-xl mb-3 active:bg-red-600 transition-colors"
+        onClick={handleDeleteConfirm}
+      >
+        Delete
+      </button>
+      <button
+        type="button"
+        class="w-full py-3 bg-gray-100 text-gray-700 font-medium rounded-xl active:bg-gray-200 transition-colors"
+        onClick={() => pendingDelete.value = null}
+      >
+        Cancel
+      </button>
+    </BottomSheet>
+  </>
+);
+```
+
+- [ ] **Step 6: Type-check the updated island**
+
+```bash
+deno check islands/shopping-lists.tsx
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Run existing test suite**
+
+```bash
+deno test --allow-env
+```
+
+Expected: all existing tests pass — no regressions.
+
+- [ ] **Step 8: Run full project check**
+
+```bash
+deno task check
+```
+
+Expected: format, lint, and type checks all pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add islands/shopping-lists.tsx
+git commit -m "feat(lists): confirm before deleting a shopping list (issue #11)"
+```
+
+---
+
+### Task 3: Smoke test via dev server
+
+- [ ] **Step 1: Start the dev server**
+
+```bash
+deno task dev
+```
+
+Open `http://localhost:8000` in a browser. Log in and navigate to `/lists`.
+Create at least two lists so deletion can be tested without losing all data.
+
+- [ ] **Step 2: Verify each scenario from the spec**
+
+Work through these in order:
+
+1. Tap the trash icon on a list → bottom sheet slides up from the bottom, shows
+   the list's name in the body copy.
+2. Tap **Cancel** → sheet slides down over 300ms, list is unchanged.
+3. Tap trash again → sheet appears. Tap the dark backdrop (outside the sheet) →
+   sheet dismisses, list unchanged.
+4. Tap trash again → sheet appears. Press **Escape** → sheet dismisses, list
+   unchanged.
+5. *(Touch device or DevTools touch simulation)* Tap trash → sheet appears.
+   Drag the sheet downward more than ~80px and release → sheet dismisses without
+   deleting.
+6. *(Touch device)* Tap trash → drag the sheet slightly (< 80px) → release →
+   sheet snaps back to fully open.
+7. Tap trash → tap **Delete** → sheet closes immediately, list disappears from
+   the page. Refresh to confirm the deletion persisted in the database.

--- a/docs/superpowers/plans/2026-05-27-confirmation-bottom-sheet.md
+++ b/docs/superpowers/plans/2026-05-27-confirmation-bottom-sheet.md
@@ -201,7 +201,7 @@ immediate visual feedback.
 
 - [ ] **Step 4: Update the trash button's `onClick`**
 
-Find the button with `aria-label={\`Delete ${list.name}\`}`. Change its `onClick`
+Find the button with `aria-label={\`Delete ${list.name}\`}`. Change its`onClick`
 from:
 
 ```ts
@@ -309,10 +309,10 @@ Work through these in order:
    sheet dismisses, list unchanged.
 4. Tap trash again → sheet appears. Press **Escape** → sheet dismisses, list
    unchanged.
-5. *(Touch device or DevTools touch simulation)* Tap trash → sheet appears.
-   Drag the sheet downward more than ~80px and release → sheet dismisses without
+5. _(Touch device or DevTools touch simulation)_ Tap trash → sheet appears. Drag
+   the sheet downward more than ~80px and release → sheet dismisses without
    deleting.
-6. *(Touch device)* Tap trash → drag the sheet slightly (< 80px) → release →
+6. _(Touch device)_ Tap trash → drag the sheet slightly (< 80px) → release →
    sheet snaps back to fully open.
 7. Tap trash → tap **Delete** → sheet closes immediately, list disappears from
    the page. Refresh to confirm the deletion persisted in the database.

--- a/docs/superpowers/specs/2026-05-27-confirmation-bottom-sheet-design.md
+++ b/docs/superpowers/specs/2026-05-27-confirmation-bottom-sheet-design.md
@@ -1,0 +1,178 @@
+# Confirmation Bottom Sheet — Design Spec
+
+**Date:** 2026-05-27  **Status:** Approved
+
+## Context
+
+Destructive actions (delete a shopping list, and similar actions in the future)
+previously fired immediately on tap with no confirmation. This caused accidental
+data loss. This spec introduces a reusable bottom sheet component that gates
+irreversible actions behind an explicit confirmation step, following native
+mobile UX conventions.
+
+The immediate trigger is [issue #11](https://github.com/FredericGryspeerdt/happie-fresh/issues/11)
+(confirm before deleting a shopping list), but the component is designed to be
+used across the app wherever a destructive action needs confirmation.
+
+---
+
+## Scope
+
+**In scope:**
+- Generic `BottomSheet` component (`components/BottomSheet.tsx`)
+- Delete-list confirmation wired into `islands/shopping-lists.tsx`
+- Swipe-to-dismiss gesture
+- Escape key to dismiss
+- Backdrop tap to dismiss
+
+**Out of scope:**
+- Other confirmation use cases (added as needed when encountered)
+- Animated exit (sheet dismisses via CSS transition; no JS-driven exit animation)
+- Error handling if the delete API call fails (silent failure is acceptable)
+
+---
+
+## Component: `components/BottomSheet.tsx`
+
+A regular Preact component (not an island). Rendered inside islands that need
+it — the island is the hydration boundary.
+
+### Props
+
+```ts
+interface BottomSheetProps {
+  open: boolean;
+  onClose: () => void;
+  children: ComponentChildren;
+}
+```
+
+Content is entirely controlled by `children`. No title slot, no button API —
+keeps the component generic for any action pattern.
+
+### DOM structure
+
+```
+<div fixed inset-0 z-50 pointer-events-none>        ← wrapper, never captures events
+  <div backdrop />                                    ← absolute inset-0, bg-black
+  <div sheet role="dialog" aria-modal="true">        ← absolute bottom-0, full-width
+    <div handle-bar />                               ← visual drag affordance
+    <div class="px-4 pb-8 pt-2">
+      {children}
+    </div>
+  </div>
+</div>
+```
+
+### Open / close (CSS-driven)
+
+Both the backdrop and sheet are always in the DOM. Visibility is controlled
+entirely by CSS transitions — no mount/unmount, no `useEffect` for animation:
+
+| Element  | Closed state                             | Open state                        |
+|----------|------------------------------------------|-----------------------------------|
+| Backdrop | `opacity-0 pointer-events-none`          | `opacity-50 pointer-events-auto`  |
+| Sheet    | `translate-y-full pointer-events-none`   | `translate-y-0 pointer-events-auto` |
+
+Both transition over 300ms (`ease-out` for sheet, `linear` for backdrop).
+
+### Swipe-to-dismiss
+
+Three touch handlers on the sheet element. Drag state is tracked in plain
+variables (not signals — no re-render needed during drag):
+
+- **`touchstart`**: record `dragStartY = e.touches[0].clientY`.
+- **`touchmove`**: compute `delta = currentY - dragStartY`.
+  - If `delta > 0` (downward drag): disable CSS transition on the sheet element,
+    apply `style.transform = translateY(${delta}px)` directly.
+  - If `delta ≤ 0` (upward drag): ignore.
+- **`touchend`**: evaluate final delta.
+  - `delta > 80px` → call `onClose()`, clear inline transform.
+  - `delta ≤ 80px` → re-enable CSS transition, clear inline transform (snaps back).
+
+The 80px threshold avoids accidental dismissal from small incidental drags.
+
+### Escape key
+
+`useEffect` that attaches a `keydown` listener to `document` while `open` is
+true. Calls `onClose()` on `Escape`. Cleaned up when `open` becomes false or the
+component unmounts.
+
+---
+
+## Changes to `islands/shopping-lists.tsx`
+
+### New signal
+
+```ts
+const pendingDelete = useSignal<{ id: string; name: string } | null>(null);
+```
+
+### Trash button (was: `onClick={() => deleteList(list.id)`)
+
+```ts
+onClick={() => pendingDelete.value = { id: list.id, name: list.name }}
+```
+
+The `deleteList` function is removed entirely.
+
+### Confirmation handler
+
+```ts
+const handleDeleteConfirm = async () => {
+  if (!pendingDelete.value) return;
+  const { id } = pendingDelete.value;
+  pendingDelete.value = null;          // close sheet before API call (optimistic)
+  await api.shoppingLists.delete(id);
+  lists.value = lists.value.filter((l) => l.id !== id);
+};
+```
+
+The sheet closes before the API call completes. The list disappears from UI
+immediately on confirmation tap.
+
+### BottomSheet in JSX (appended to the island's return)
+
+```tsx
+<BottomSheet
+  open={pendingDelete.value !== null}
+  onClose={() => pendingDelete.value = null}
+>
+  <p class="text-lg font-semibold text-gray-900 mb-1">Delete list?</p>
+  <p class="text-sm text-gray-500 mb-6">
+    "{pendingDelete.value?.name}" and all its items will be permanently deleted.
+    This cannot be undone.
+  </p>
+  <button
+    type="button"
+    class="w-full py-3 bg-red-500 text-white font-semibold rounded-xl mb-3 active:bg-red-600 transition-colors"
+    onClick={handleDeleteConfirm}
+  >
+    Delete
+  </button>
+  <button
+    type="button"
+    class="w-full py-3 bg-gray-100 text-gray-700 font-medium rounded-xl active:bg-gray-200 transition-colors"
+    onClick={() => pendingDelete.value = null}
+  >
+    Cancel
+  </button>
+</BottomSheet>
+```
+
+The list name is quoted in the body copy so the user sees exactly which list is
+being deleted.
+
+---
+
+## Verification
+
+1. `deno task dev` — open `/lists`, create two lists.
+2. Tap the trash icon on one list — bottom sheet slides up with the list name.
+3. Tap **Cancel** — sheet slides down, list unchanged.
+4. Tap trash again — sheet appears.
+5. Swipe the sheet down past ~80px — sheet dismisses, list unchanged.
+6. Tap trash again — sheet appears. Press **Escape** — sheet dismisses.
+7. Tap trash again — tap **Delete** — sheet closes immediately, list removed.
+8. Tap the backdrop (outside the sheet) — sheet dismisses without deleting.
+9. Run `deno task check` — no type errors or lint warnings.

--- a/docs/superpowers/specs/2026-05-27-confirmation-bottom-sheet-design.md
+++ b/docs/superpowers/specs/2026-05-27-confirmation-bottom-sheet-design.md
@@ -1,6 +1,6 @@
 # Confirmation Bottom Sheet — Design Spec
 
-**Date:** 2026-05-27  **Status:** Approved
+**Date:** 2026-05-27 **Status:** Approved
 
 ## Context
 
@@ -10,7 +10,8 @@ data loss. This spec introduces a reusable bottom sheet component that gates
 irreversible actions behind an explicit confirmation step, following native
 mobile UX conventions.
 
-The immediate trigger is [issue #11](https://github.com/FredericGryspeerdt/happie-fresh/issues/11)
+The immediate trigger is
+[issue #11](https://github.com/FredericGryspeerdt/happie-fresh/issues/11)
 (confirm before deleting a shopping list), but the component is designed to be
 used across the app wherever a destructive action needs confirmation.
 
@@ -19,6 +20,7 @@ used across the app wherever a destructive action needs confirmation.
 ## Scope
 
 **In scope:**
+
 - Generic `BottomSheet` component (`components/BottomSheet.tsx`)
 - Delete-list confirmation wired into `islands/shopping-lists.tsx`
 - Swipe-to-dismiss gesture
@@ -26,16 +28,18 @@ used across the app wherever a destructive action needs confirmation.
 - Backdrop tap to dismiss
 
 **Out of scope:**
+
 - Other confirmation use cases (added as needed when encountered)
-- Animated exit (sheet dismisses via CSS transition; no JS-driven exit animation)
+- Animated exit (sheet dismisses via CSS transition; no JS-driven exit
+  animation)
 - Error handling if the delete API call fails (silent failure is acceptable)
 
 ---
 
 ## Component: `components/BottomSheet.tsx`
 
-A regular Preact component (not an island). Rendered inside islands that need
-it — the island is the hydration boundary.
+A regular Preact component (not an island). Rendered inside islands that need it
+— the island is the hydration boundary.
 
 ### Props
 
@@ -69,10 +73,10 @@ keeps the component generic for any action pattern.
 Both the backdrop and sheet are always in the DOM. Visibility is controlled
 entirely by CSS transitions — no mount/unmount, no `useEffect` for animation:
 
-| Element  | Closed state                             | Open state                        |
-|----------|------------------------------------------|-----------------------------------|
-| Backdrop | `opacity-0 pointer-events-none`          | `opacity-50 pointer-events-auto`  |
-| Sheet    | `translate-y-full pointer-events-none`   | `translate-y-0 pointer-events-auto` |
+| Element  | Closed state                           | Open state                          |
+| -------- | -------------------------------------- | ----------------------------------- |
+| Backdrop | `opacity-0 pointer-events-none`        | `opacity-50 pointer-events-auto`    |
+| Sheet    | `translate-y-full pointer-events-none` | `translate-y-0 pointer-events-auto` |
 
 Both transition over 300ms (`ease-out` for sheet, `linear` for backdrop).
 
@@ -88,7 +92,8 @@ variables (not signals — no re-render needed during drag):
   - If `delta ≤ 0` (upward drag): ignore.
 - **`touchend`**: evaluate final delta.
   - `delta > 80px` → call `onClose()`, clear inline transform.
-  - `delta ≤ 80px` → re-enable CSS transition, clear inline transform (snaps back).
+  - `delta ≤ 80px` → re-enable CSS transition, clear inline transform (snaps
+    back).
 
 The 80px threshold avoids accidental dismissal from small incidental drags.
 
@@ -122,7 +127,7 @@ The `deleteList` function is removed entirely.
 const handleDeleteConfirm = async () => {
   if (!pendingDelete.value) return;
   const { id } = pendingDelete.value;
-  pendingDelete.value = null;          // close sheet before API call (optimistic)
+  pendingDelete.value = null; // close sheet before API call (optimistic)
   await api.shoppingLists.delete(id);
   lists.value = lists.value.filter((l) => l.id !== id);
 };
@@ -157,7 +162,7 @@ immediately on confirmation tap.
   >
     Cancel
   </button>
-</BottomSheet>
+</BottomSheet>;
 ```
 
 The list name is quoted in the body copy so the user sees exactly which list is

--- a/islands/shopping-lists.tsx
+++ b/islands/shopping-lists.tsx
@@ -2,6 +2,7 @@ import { useSignal } from "@preact/signals";
 import { For, Show } from "@preact/signals/utils";
 import { ShoppingListInterface } from "@/models/index.ts";
 import { api } from "@/services/api.ts";
+import BottomSheet from "@/components/BottomSheet.tsx";
 
 interface ShoppingListsProps {
   initialLists: ShoppingListInterface[];
@@ -15,6 +16,7 @@ export default function ShoppingLists(
   const editingId = useSignal<string | null>(null);
   const editName = useSignal("");
   const loading = useSignal(false);
+  const pendingDelete = useSignal<{ id: string; name: string } | null>(null);
 
   const createList = async () => {
     const name = newName.value.trim();
@@ -46,134 +48,168 @@ export default function ShoppingLists(
     editingId.value = null;
   };
 
-  const deleteList = async (id: string) => {
+  const handleDeleteConfirm = async () => {
+    if (!pendingDelete.value) return;
+    const { id } = pendingDelete.value;
+    pendingDelete.value = null;
     await api.shoppingLists.delete(id);
     lists.value = lists.value.filter((l) => l.id !== id);
   };
 
   return (
-    <div class="space-y-4">
-      <Show
-        when={() => lists.value.length > 0}
-        fallback={
-          <p class="text-gray-500 text-center py-8">
-            No shopping lists yet. Create your first one below.
-          </p>
-        }
-      >
-        <ul class="space-y-2">
-          <For each={lists}>
-            {(list) => (
-              <li
-                key={list.id}
-                class="flex items-center gap-2 p-4 bg-white border border-gray-100 rounded-xl shadow-sm"
-              >
-                <Show
-                  when={() => editingId.value === list.id}
-                  fallback={
-                    <>
-                      <a
-                        href={`/lists/${list.id}`}
-                        class="flex-1 font-medium text-gray-800 text-lg"
-                      >
-                        {list.name}
-                      </a>
-                      <button
-                        type="button"
-                        class="p-2 text-gray-400 hover:text-gray-600 transition-colors"
-                        onClick={() => startRename(list)}
-                        aria-label={`Rename ${list.name}`}
-                      >
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke-width="2"
-                          stroke="currentColor"
-                          class="w-4 h-4"
-                        >
-                          <path
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Z"
-                          />
-                        </svg>
-                      </button>
-                      <button
-                        type="button"
-                        class="p-2 text-gray-400 hover:text-red-500 transition-colors"
-                        onClick={() => deleteList(list.id)}
-                        aria-label={`Delete ${list.name}`}
-                      >
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke-width="2"
-                          stroke="currentColor"
-                          class="w-4 h-4"
-                        >
-                          <path
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"
-                          />
-                        </svg>
-                      </button>
-                    </>
-                  }
+    <>
+      <div class="space-y-4">
+        <Show
+          when={() => lists.value.length > 0}
+          fallback={
+            <p class="text-gray-500 text-center py-8">
+              No shopping lists yet. Create your first one below.
+            </p>
+          }
+        >
+          <ul class="space-y-2">
+            <For each={lists}>
+              {(list) => (
+                <li
+                  key={list.id}
+                  class="flex items-center gap-2 p-4 bg-white border border-gray-100 rounded-xl shadow-sm"
                 >
-                  <input
-                    type="text"
-                    class="flex-1 border border-blue-300 rounded-lg px-3 py-1 text-base focus:outline-none focus:ring-2 focus:ring-blue-500"
-                    value={editName.value}
-                    onInput={(e) => editName.value = e.currentTarget.value}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") confirmRename(list.id);
-                      if (e.key === "Escape") editingId.value = null;
-                    }}
-                    autoFocus
-                  />
-                  <button
-                    type="button"
-                    class="px-3 py-1 bg-blue-500 text-white rounded-lg text-sm font-medium"
-                    onClick={() => confirmRename(list.id)}
+                  <Show
+                    when={() => editingId.value === list.id}
+                    fallback={
+                      <>
+                        <a
+                          href={`/lists/${list.id}`}
+                          class="flex-1 font-medium text-gray-800 text-lg"
+                        >
+                          {list.name}
+                        </a>
+                        <button
+                          type="button"
+                          class="p-2 text-gray-400 hover:text-gray-600 transition-colors"
+                          onClick={() => startRename(list)}
+                          aria-label={`Rename ${list.name}`}
+                        >
+                          <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke-width="2"
+                            stroke="currentColor"
+                            class="w-4 h-4"
+                          >
+                            <path
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Z"
+                            />
+                          </svg>
+                        </button>
+                        <button
+                          type="button"
+                          class="p-2 text-gray-400 hover:text-red-500 transition-colors"
+                          onClick={() =>
+                            pendingDelete.value = {
+                              id: list.id,
+                              name: list.name,
+                            }}
+                          aria-label={`Delete ${list.name}`}
+                        >
+                          <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke-width="2"
+                            stroke="currentColor"
+                            class="w-4 h-4"
+                          >
+                            <path
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"
+                            />
+                          </svg>
+                        </button>
+                      </>
+                    }
                   >
-                    Save
-                  </button>
-                  <button
-                    type="button"
-                    class="px-3 py-1 bg-gray-100 text-gray-600 rounded-lg text-sm"
-                    onClick={() => editingId.value = null}
-                  >
-                    Cancel
-                  </button>
-                </Show>
-              </li>
-            )}
-          </For>
-        </ul>
-      </Show>
+                    <input
+                      type="text"
+                      class="flex-1 border border-blue-300 rounded-lg px-3 py-1 text-base focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      value={editName.value}
+                      onInput={(e) => editName.value = e.currentTarget.value}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") confirmRename(list.id);
+                        if (e.key === "Escape") editingId.value = null;
+                      }}
+                      autoFocus
+                    />
+                    <button
+                      type="button"
+                      class="px-3 py-1 bg-blue-500 text-white rounded-lg text-sm font-medium"
+                      onClick={() => confirmRename(list.id)}
+                    >
+                      Save
+                    </button>
+                    <button
+                      type="button"
+                      class="px-3 py-1 bg-gray-100 text-gray-600 rounded-lg text-sm"
+                      onClick={() => editingId.value = null}
+                    >
+                      Cancel
+                    </button>
+                  </Show>
+                </li>
+              )}
+            </For>
+          </ul>
+        </Show>
 
-      <div class="flex gap-2">
-        <input
-          type="text"
-          placeholder="New list name"
-          class="flex-1 border border-gray-300 rounded-xl px-4 py-3 text-base focus:outline-none focus:ring-2 focus:ring-blue-500"
-          value={newName.value}
-          onInput={(e) => newName.value = e.currentTarget.value}
-          onKeyDown={(e) => e.key === "Enter" && createList()}
-          disabled={loading.value}
-        />
+        <div class="flex gap-2">
+          <input
+            type="text"
+            placeholder="New list name"
+            class="flex-1 border border-gray-300 rounded-xl px-4 py-3 text-base focus:outline-none focus:ring-2 focus:ring-blue-500"
+            value={newName.value}
+            onInput={(e) => newName.value = e.currentTarget.value}
+            onKeyDown={(e) => e.key === "Enter" && createList()}
+            disabled={loading.value}
+          />
+          <button
+            type="button"
+            class="px-5 py-3 bg-blue-500 text-white font-medium rounded-xl shadow-sm active:scale-95 transition-transform disabled:opacity-50"
+            onClick={createList}
+            disabled={loading.value}
+          >
+            Add
+          </button>
+        </div>
+      </div>
+
+      <BottomSheet
+        open={pendingDelete.value !== null}
+        onClose={() => pendingDelete.value = null}
+      >
+        <p class="text-lg font-semibold text-gray-900 mb-1">Delete list?</p>
+        <p class="text-sm text-gray-500 mb-6">
+          "{pendingDelete.value?.name}" and all its items will be permanently
+          deleted. This cannot be undone.
+        </p>
         <button
           type="button"
-          class="px-5 py-3 bg-blue-500 text-white font-medium rounded-xl shadow-sm active:scale-95 transition-transform disabled:opacity-50"
-          onClick={createList}
-          disabled={loading.value}
+          class="w-full py-3 bg-red-500 text-white font-semibold rounded-xl mb-3 active:bg-red-600 transition-colors"
+          onClick={handleDeleteConfirm}
         >
-          Add
+          Delete
         </button>
-      </div>
-    </div>
+        <button
+          type="button"
+          class="w-full py-3 bg-gray-100 text-gray-700 font-medium rounded-xl active:bg-gray-200 transition-colors"
+          onClick={() => pendingDelete.value = null}
+        >
+          Cancel
+        </button>
+      </BottomSheet>
+    </>
   );
 }

--- a/islands/shopping-lists.tsx
+++ b/islands/shopping-lists.tsx
@@ -17,6 +17,7 @@ export default function ShoppingLists(
   const editName = useSignal("");
   const loading = useSignal(false);
   const pendingDelete = useSignal<{ id: string; name: string } | null>(null);
+  const pendingDeleteName = useSignal<string>("");
 
   const createList = async () => {
     const name = newName.value.trim();
@@ -108,11 +109,13 @@ export default function ShoppingLists(
                         <button
                           type="button"
                           class="p-2 text-gray-400 hover:text-red-500 transition-colors"
-                          onClick={() =>
+                          onClick={() => {
+                            pendingDeleteName.value = list.name;
                             pendingDelete.value = {
                               id: list.id,
                               name: list.name,
-                            }}
+                            };
+                          }}
                           aria-label={`Delete ${list.name}`}
                         >
                           <svg
@@ -192,7 +195,7 @@ export default function ShoppingLists(
       >
         <p class="text-lg font-semibold text-gray-900 mb-1">Delete list?</p>
         <p class="text-sm text-gray-500 mb-6">
-          "{pendingDelete.value?.name}" and all its items will be permanently
+          "{pendingDeleteName.value}" and all its items will be permanently
           deleted. This cannot be undone.
         </p>
         <button

--- a/routes/items/detail/[id]/edit.tsx
+++ b/routes/items/detail/[id]/edit.tsx
@@ -1,6 +1,10 @@
 import { PageProps } from "fresh";
 import { getKv, ItemRepo } from "@/database/index.ts";
-import { Item, type CreateItemDto, type ItemInterface } from "@/models/index.ts";
+import {
+  type CreateItemDto,
+  Item,
+  type ItemInterface,
+} from "@/models/index.ts";
 import { Handlers } from "fresh/compat";
 
 interface Data {

--- a/routes/items/new.tsx
+++ b/routes/items/new.tsx
@@ -1,6 +1,6 @@
 import { PageProps } from "fresh";
 import { getKv } from "@/database/index.ts";
-import { Item, type CreateItemDto } from "@/models/index.ts";
+import { type CreateItemDto, Item } from "@/models/index.ts";
 import { Handlers } from "fresh/compat";
 
 // Removed empty Data interface to satisfy lint rules.


### PR DESCRIPTION
## Summary

- Add generic `BottomSheet` component (`components/BottomSheet.tsx`) with CSS-driven open/close transitions, swipe-to-dismiss gesture, Escape key, and backdrop tap to dismiss
- Wire delete confirmation into `islands/shopping-lists.tsx` — trash icon now opens a bottom sheet instead of immediately deleting
- Optimistic close: sheet dismisses before the API call completes for snappy UX

## Behaviour

Tap trash → bottom sheet slides up with the list name → tap **Delete** to confirm or **Cancel** / swipe down / tap backdrop / press Escape to dismiss without deleting.

## Test Plan

- [ ] `deno task check` passes (format, lint, type check)
- [ ] `deno test` — 35/35 pass
- [ ] Tap trash icon → bottom sheet appears with correct list name
- [ ] Cancel / backdrop / Escape / swipe-down each dismiss without deleting
- [ ] Delete confirms and immediately removes the list from the UI
- [ ] Refresh after delete — list is gone from the database

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)