### PR TITLE
fix(shopping): Plan-mode sheet UX — scroll fix, shared category picker, search-first add-item

### DIFF
--- a/components/md3/CategoryPickerList.tsx
+++ b/components/md3/CategoryPickerList.tsx
@@ -1,0 +1,72 @@
+// components/md3/CategoryPickerList.tsx
+import { useSignal } from "@preact/signals";
+import type { CategoryInterface } from "@/models/index.ts";
+import { Icon } from "@/components/md3/Icon.tsx";
+import { ListItem } from "@/components/md3/ListItem.tsx";
+
+interface CategoryPickerListProps {
+  categories: CategoryInterface[];
+  /** Currently selected category id; "" means Uncategorized. */
+  selectedId: string;
+  /** Called with the chosen id ("" for Uncategorized). */
+  onSelect: (id: string) => void;
+}
+
+/**
+ * Searchable single-select list of categories, rendered as a Sheet body.
+ * Categories are listed alphabetically — this is a picker, so it favours
+ * findability; shopping "aisle order" applies only in Shop mode, not here.
+ * Owns its own search query, so it resets each time it is (re)mounted.
+ * Shared by the add-item and item-editor flows in islands/items.tsx.
+ */
+export function CategoryPickerList(
+  { categories, selectedId, onSelect }: CategoryPickerListProps,
+) {
+  const query = useSignal("");
+  const q = query.value.trim().toLowerCase();
+  const matches = [...categories]
+    .sort((a, b) =>
+      (a.label ?? "").toLowerCase().localeCompare((b.label ?? "").toLowerCase())
+    )
+    .filter((c) => !q || (c.label ?? "").toLowerCase().includes(q));
+
+  return (
+    <div class="flex flex-col gap-1">
+      <div class="flex items-center gap-2 bg-surface-chigh rounded-[var(--md-shape-full)] h-12 px-4 mb-1">
+        <Icon name="search" size={20} class="text-on-surface-variant" />
+        <input
+          value={query.value}
+          onInput={(e) => {
+            query.value = (e.target as HTMLInputElement).value;
+          }}
+          placeholder="Find a category"
+          class="flex-1 min-w-0 bg-transparent border-0 outline-none md-body-large text-on-surface"
+        />
+      </div>
+      {(!q || "uncategorized".includes(q)) && (
+        <ListItem
+          headline="Uncategorized"
+          onClick={() => onSelect("")}
+          trailing={!selectedId
+            ? <Icon name="check" size={20} class="text-primary" />
+            : undefined}
+        />
+      )}
+      {matches.map((cat) => (
+        <ListItem
+          key={cat.id}
+          headline={cat.label ?? ""}
+          onClick={() => onSelect(cat.id ?? "")}
+          trailing={selectedId === cat.id
+            ? <Icon name="check" size={20} class="text-primary" />
+            : undefined}
+        />
+      ))}
+      {q && matches.length === 0 && (
+        <p class="md-body-medium text-on-surface-variant px-1 py-3.5">
+          No category matches "{query.value.trim()}".
+        </p>
+      )}
+    </div>
+  );
+}

--- a/components/md3/Sheet.tsx
+++ b/components/md3/Sheet.tsx
@@ -82,22 +82,32 @@ export function Sheet({ open, onClose, title, children }: SheetProps) {
           transition: "transform .4s var(--md-emphasized-decel)",
           boxShadow: "0 -8px 40px rgba(0,0,0,.22)",
         }}
-        onTouchStart={onTouchStart}
-        onTouchMove={onTouchMove}
-        onTouchEnd={onTouchEnd}
-        onTouchCancel={reset}
       >
-        <div class="pt-4 pb-3 flex justify-center shrink-0">
-          <div
-            class="rounded-full bg-on-surface-variant"
-            style={{ width: 32, height: 4, opacity: 0.4 }}
-          />
-        </div>
-        {title && (
-          <div class="md-title-large text-on-surface mb-2 shrink-0">
-            {title}
+        {
+          /* Drag zone: handle + title. Dragging here dismisses; the scrollable
+            body below is free to scroll (fixes an upward scroll being read as
+            a drag-down-to-dismiss). */
+        }
+        <div
+          class="shrink-0"
+          style={{ touchAction: "none" }}
+          onTouchStart={onTouchStart}
+          onTouchMove={onTouchMove}
+          onTouchEnd={onTouchEnd}
+          onTouchCancel={reset}
+        >
+          <div class="pt-4 pb-3 flex justify-center">
+            <div
+              class="rounded-full bg-on-surface-variant"
+              style={{ width: 32, height: 4, opacity: 0.4 }}
+            />
           </div>
-        )}
+          {title && (
+            <div class="md-title-large text-on-surface mb-2">
+              {title}
+            </div>
+          )}
+        </div>
         <div
           class="overflow-y-auto -mx-6 px-6 pt-1"
           style={{ overscrollBehavior: "contain" }}

--- a/islands/items.tsx
+++ b/islands/items.tsx
@@ -125,6 +125,9 @@ export default function Items(
   // ── sheet signals ────────────────────────────────────────────────────────
   const addOpen = useSignal(false);
   const editingId = useSignal<string | null>(null);
+  // add-item: searchable category picker mode (replaces the sheet body while open)
+  const catPicking = useSignal(false);
+  const catQuery = useSignal("");
 
   // ── item-editor: honest "Saved" indicator ───────────────────────────────
   // Driven directly by `lastSaved` (bumped only when a debounced list-item write
@@ -154,6 +157,17 @@ export default function Items(
     selectedCategoryId.value = "";
     reset();
   };
+
+  // ── add-item: category selection (compact button + searchable picker) ─────
+  const selectedCatLabel =
+    categories.value.find((c) => c.id === selectedCategoryId.value)?.label ??
+      "Uncategorized";
+  const catQ = catQuery.value.trim().toLowerCase();
+  const catMatches = [...categories.value]
+    .sort((a, b) =>
+      (a.label ?? "").toLowerCase().localeCompare((b.label ?? "").toLowerCase())
+    )
+    .filter((c) => !catQ || (c.label ?? "").toLowerCase().includes(catQ));
 
   // ── item-editor: get current list item being edited ──────────────────────
   const editingListItem = () =>
@@ -544,139 +558,185 @@ export default function Items(
         open={addOpen.value}
         onClose={() => {
           addOpen.value = false;
+          catPicking.value = false;
+          catQuery.value = "";
           reset();
         }}
-        title="Add items"
+        title={catPicking.value ? "Choose category" : "Add items"}
       >
-        {/* Search input */}
-        <div class="relative mb-3">
-          <span class="absolute left-4 top-1/2 -translate-y-1/2 text-on-surface-variant">
-            <Icon name="search" size={20} />
-          </span>
-          <input
-            ref={inputRef}
-            value={query.value}
-            onInput={(e) => {
-              query.value = (e.target as HTMLInputElement).value;
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && query.value.trim()) {
-                const q = query.value.trim();
-                const exact = items.value.some((i) =>
-                  i.name?.toLowerCase() === q.toLowerCase()
-                );
-                if (!exact) handleCreateItem(q);
-              }
-            }}
-            placeholder="Search or add an item…"
-            class="w-full md-body-large text-on-surface bg-surface-chigh border-0 rounded-[var(--md-shape-full)] py-3.5 pl-11 pr-4 outline-none"
-          />
-        </div>
-
-        {/* "Add '<query>'" card — shown when non-empty query and no exact match */}
-        {(() => {
-          const q = query.value.trim();
-          const exact = q
-            ? items.value.some((i) => i.name?.toLowerCase() === q.toLowerCase())
-            : true;
-          if (!q || exact) return null;
-          return (
-            <div class="bg-primary-container text-on-primary-container rounded-[var(--md-shape-lg)] p-3.5 mb-3 flex flex-col gap-3">
-              <div class="flex items-center gap-3.5">
-                <span class="w-9 h-9 rounded-full bg-on-primary-container text-primary-container grid place-items-center shrink-0">
-                  <Icon name="plus" size={20} />
-                </span>
-                <div class="flex-1 min-w-0">
-                  <div class="md-body-large">Add "{q}"</div>
-                  <div class="md-body-small opacity-80">
-                    New item — pick a category
-                  </div>
-                </div>
-              </div>
-
-              {/* Category chips */}
-              <div class="flex gap-2 flex-wrap">
-                <Chip
-                  selected={!selectedCategoryId.value}
-                  onClick={() => {
-                    selectedCategoryId.value = "";
-                  }}
-                >
-                  Uncategorized
-                </Chip>
-                <For each={categories}>
-                  {(cat) => (
-                    <Chip
-                      selected={selectedCategoryId.value === cat.id}
-                      onClick={() => {
-                        selectedCategoryId.value = cat.id ?? "";
-                      }}
-                    >
-                      {cat.label}
-                    </Chip>
-                  )}
-                </For>
-              </div>
-
-              <Button
-                variant="filled"
-                full
-                onClick={() => handleCreateItem(q)}
-                style={{
-                  background: "var(--md-on-primary-container)",
-                  color: "var(--md-primary-container)",
+        {catPicking.value && (
+          <div class="flex flex-col gap-1">
+            <div class="flex items-center gap-2 bg-surface-chigh rounded-[var(--md-shape-full)] h-12 px-4 mb-1">
+              <Icon name="search" size={20} class="text-on-surface-variant" />
+              <input
+                value={catQuery.value}
+                onInput={(e) => {
+                  catQuery.value = (e.target as HTMLInputElement).value;
                 }}
-              >
-                Add to {categories.value.find((c) =>
-                  c.id === selectedCategoryId.value
-                )?.label ?? "Uncategorized"}
-              </Button>
+                placeholder="Find a category"
+                class="flex-1 min-w-0 bg-transparent border-0 outline-none md-body-large text-on-surface"
+              />
             </div>
-          );
-        })()}
+            {(!catQ || "uncategorized".includes(catQ)) && (
+              <ListItem
+                headline="Uncategorized"
+                onClick={() => {
+                  selectedCategoryId.value = "";
+                  catPicking.value = false;
+                  catQuery.value = "";
+                }}
+                trailing={!selectedCategoryId.value
+                  ? <Icon name="check" size={20} class="text-primary" />
+                  : undefined}
+              />
+            )}
+            {catMatches.map((cat) => (
+              <ListItem
+                key={cat.id}
+                headline={cat.label ?? ""}
+                onClick={() => {
+                  selectedCategoryId.value = cat.id ?? "";
+                  catPicking.value = false;
+                  catQuery.value = "";
+                }}
+                trailing={selectedCategoryId.value === cat.id
+                  ? <Icon name="check" size={20} class="text-primary" />
+                  : undefined}
+              />
+            ))}
+            {catQ && catMatches.length === 0 && (
+              <p class="md-body-medium text-on-surface-variant px-1 py-3.5">
+                No category matches "{catQuery.value.trim()}".
+              </p>
+            )}
+          </div>
+        )}
+        {!catPicking.value && (
+          <>
+            {/* Search input */}
+            <div class="relative mb-3">
+              <span class="absolute left-4 top-1/2 -translate-y-1/2 text-on-surface-variant">
+                <Icon name="search" size={20} />
+              </span>
+              <input
+                ref={inputRef}
+                value={query.value}
+                onInput={(e) => {
+                  query.value = (e.target as HTMLInputElement).value;
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && query.value.trim()) {
+                    const q = query.value.trim();
+                    const exact = items.value.some((i) =>
+                      i.name?.toLowerCase() === q.toLowerCase()
+                    );
+                    if (!exact) handleCreateItem(q);
+                  }
+                }}
+                placeholder="Search or add an item…"
+                class="w-full md-body-large text-on-surface bg-surface-chigh border-0 rounded-[var(--md-shape-full)] py-3.5 pl-11 pr-4 outline-none"
+              />
+            </div>
 
-        {/* Catalogue list */}
-        <div class="flex flex-col">
-          {!query.value.trim() && (
-            <div class="md-label-medium text-on-surface-variant uppercase tracking-widest mb-1 px-1">
-              From your catalogue
-            </div>
-          )}
-          <For each={results}>
-            {(item) => {
-              const added = listItemsMap.value.has(item.id ?? "");
+            {/* "Add '<query>'" card — shown when non-empty query and no exact match */}
+            {(() => {
+              const q = query.value.trim();
+              const exact = q
+                ? items.value.some((i) =>
+                  i.name?.toLowerCase() === q.toLowerCase()
+                )
+                : true;
+              if (!q || exact) return null;
               return (
-                <ListItem
-                  key={item.id}
-                  headline={item.name ?? ""}
-                  supporting={categories.value.find((c) =>
-                    c.id === item.categoryId
-                  )?.label ?? ""}
-                  onClick={added
-                    ? undefined
-                    : () => item.id && handleAddToList(item.id)}
-                  trailing={added
-                    ? (
-                      <span class="inline-flex items-center gap-1 text-primary md-label-medium">
-                        <Icon name="check" size={18} /> Added
-                      </span>
-                    )
-                    : (
-                      <span class="text-primary">
-                        <Icon name="plus" size={22} />
-                      </span>
-                    )}
-                />
+                <div class="bg-primary-container text-on-primary-container rounded-[var(--md-shape-lg)] p-3.5 mb-3 flex flex-col gap-3">
+                  <div class="flex items-center gap-3.5">
+                    <span class="w-9 h-9 rounded-full bg-on-primary-container text-primary-container grid place-items-center shrink-0">
+                      <Icon name="plus" size={20} />
+                    </span>
+                    <div class="flex-1 min-w-0">
+                      <div class="md-body-large">Add "{q}"</div>
+                      <div class="md-body-small opacity-80">
+                        New item — pick a category
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Category — opens the searchable picker */}
+                  <Pressable
+                    onClick={() => {
+                      catQuery.value = "";
+                      catPicking.value = true;
+                    }}
+                    color="var(--md-on-primary-container)"
+                    class="flex items-center justify-between gap-2 w-full rounded-[var(--md-shape-md)] border border-on-primary-container/40 px-3.5 py-2.5"
+                  >
+                    <span class="md-body-medium opacity-80">Category</span>
+                    <span class="inline-flex items-center gap-1 md-label-large">
+                      {selectedCatLabel} <Icon name="chevron" size={18} />
+                    </span>
+                  </Pressable>
+
+                  <Button
+                    variant="filled"
+                    full
+                    onClick={() => handleCreateItem(q)}
+                    style={{
+                      background: "var(--md-on-primary-container)",
+                      color: "var(--md-primary-container)",
+                    }}
+                  >
+                    Add to {categories.value.find((c) =>
+                      c.id === selectedCategoryId.value
+                    )?.label ?? "Uncategorized"}
+                  </Button>
+                </div>
               );
-            }}
-          </For>
-          {query.value.trim() && results.value.length === 0 && (
-            <p class="md-body-medium text-on-surface-variant px-1 py-3.5">
-              No catalogue match — use "Add "{query.value.trim()}"" above to
-              create it.
-            </p>
-          )}
-        </div>
+            })()}
+
+            {/* Catalogue list */}
+            <div class="flex flex-col">
+              {!query.value.trim() && (
+                <div class="md-label-medium text-on-surface-variant uppercase tracking-widest mb-1 px-1">
+                  From your catalogue
+                </div>
+              )}
+              <For each={results}>
+                {(item) => {
+                  const added = listItemsMap.value.has(item.id ?? "");
+                  return (
+                    <ListItem
+                      key={item.id}
+                      headline={item.name ?? ""}
+                      supporting={categories.value.find((c) =>
+                        c.id === item.categoryId
+                      )?.label ?? ""}
+                      onClick={added
+                        ? undefined
+                        : () => item.id && handleAddToList(item.id)}
+                      trailing={added
+                        ? (
+                          <span class="inline-flex items-center gap-1 text-primary md-label-medium">
+                            <Icon name="check" size={18} /> Added
+                          </span>
+                        )
+                        : (
+                          <span class="text-primary">
+                            <Icon name="plus" size={22} />
+                          </span>
+                        )}
+                    />
+                  );
+                }}
+              </For>
+              {query.value.trim() && results.value.length === 0 && (
+                <p class="md-body-medium text-on-surface-variant px-1 py-3.5">
+                  No catalogue match — use "Add "{query.value.trim()}"" above to
+                  create it.
+                </p>
+              )}
+            </div>
+          </>
+        )}
       </Sheet>
 
       {/* ══════════════════════ Item-editor sheet ══════════════════════ */}

--- a/islands/items.tsx
+++ b/islands/items.tsx
@@ -11,9 +11,9 @@ import { api } from "@/services/api.ts";
 import { Segmented } from "@/components/md3/Segmented.tsx";
 import { SearchBar } from "@/components/md3/SearchBar.tsx";
 import { Sheet } from "@/components/md3/Sheet.tsx";
+import { CategoryPickerList } from "@/components/md3/CategoryPickerList.tsx";
 import { Card } from "@/components/md3/Card.tsx";
 import { Stepper } from "@/components/md3/Stepper.tsx";
-import { Chip } from "@/components/md3/Chip.tsx";
 import { Button } from "@/components/md3/Button.tsx";
 import { ListItem } from "@/components/md3/ListItem.tsx";
 import { Icon } from "@/components/md3/Icon.tsx";
@@ -125,9 +125,10 @@ export default function Items(
   // ── sheet signals ────────────────────────────────────────────────────────
   const addOpen = useSignal(false);
   const editingId = useSignal<string | null>(null);
-  // add-item: searchable category picker mode (replaces the sheet body while open)
+  // add-item + item-editor: searchable category picker mode (replaces the
+  // respective sheet body while open)
   const catPicking = useSignal(false);
-  const catQuery = useSignal("");
+  const editCatPicking = useSignal(false);
 
   // ── item-editor: honest "Saved" indicator ───────────────────────────────
   // Driven directly by `lastSaved` (bumped only when a debounced list-item write
@@ -162,12 +163,6 @@ export default function Items(
   const selectedCatLabel =
     categories.value.find((c) => c.id === selectedCategoryId.value)?.label ??
       "Uncategorized";
-  const catQ = catQuery.value.trim().toLowerCase();
-  const catMatches = [...categories.value]
-    .sort((a, b) =>
-      (a.label ?? "").toLowerCase().localeCompare((b.label ?? "").toLowerCase())
-    )
-    .filter((c) => !catQ || (c.label ?? "").toLowerCase().includes(catQ));
 
   // ── item-editor: get current list item being edited ──────────────────────
   const editingListItem = () =>
@@ -559,57 +554,19 @@ export default function Items(
         onClose={() => {
           addOpen.value = false;
           catPicking.value = false;
-          catQuery.value = "";
           reset();
         }}
         title={catPicking.value ? "Choose category" : "Add items"}
       >
         {catPicking.value && (
-          <div class="flex flex-col gap-1">
-            <div class="flex items-center gap-2 bg-surface-chigh rounded-[var(--md-shape-full)] h-12 px-4 mb-1">
-              <Icon name="search" size={20} class="text-on-surface-variant" />
-              <input
-                value={catQuery.value}
-                onInput={(e) => {
-                  catQuery.value = (e.target as HTMLInputElement).value;
-                }}
-                placeholder="Find a category"
-                class="flex-1 min-w-0 bg-transparent border-0 outline-none md-body-large text-on-surface"
-              />
-            </div>
-            {(!catQ || "uncategorized".includes(catQ)) && (
-              <ListItem
-                headline="Uncategorized"
-                onClick={() => {
-                  selectedCategoryId.value = "";
-                  catPicking.value = false;
-                  catQuery.value = "";
-                }}
-                trailing={!selectedCategoryId.value
-                  ? <Icon name="check" size={20} class="text-primary" />
-                  : undefined}
-              />
-            )}
-            {catMatches.map((cat) => (
-              <ListItem
-                key={cat.id}
-                headline={cat.label ?? ""}
-                onClick={() => {
-                  selectedCategoryId.value = cat.id ?? "";
-                  catPicking.value = false;
-                  catQuery.value = "";
-                }}
-                trailing={selectedCategoryId.value === cat.id
-                  ? <Icon name="check" size={20} class="text-primary" />
-                  : undefined}
-              />
-            ))}
-            {catQ && catMatches.length === 0 && (
-              <p class="md-body-medium text-on-surface-variant px-1 py-3.5">
-                No category matches "{catQuery.value.trim()}".
-              </p>
-            )}
-          </div>
+          <CategoryPickerList
+            categories={categories.value}
+            selectedId={selectedCategoryId.value}
+            onSelect={(id) => {
+              selectedCategoryId.value = id;
+              catPicking.value = false;
+            }}
+          />
         )}
         {!catPicking.value && (
           <>
@@ -664,7 +621,6 @@ export default function Items(
                   {/* Category — opens the searchable picker */}
                   <Pressable
                     onClick={() => {
-                      catQuery.value = "";
                       catPicking.value = true;
                     }}
                     color="var(--md-on-primary-container)"
@@ -746,8 +702,11 @@ export default function Items(
           const id = editingId.value;
           if (id) flushListItem(id);
           editingId.value = null;
+          editCatPicking.value = false;
         }}
-        title={editingId.value ? getItemName(editingListItem()?.itemId) : ""}
+        title={editCatPicking.value
+          ? "Choose category"
+          : (editingId.value ? getItemName(editingListItem()?.itemId) : "")}
       >
         {(() => {
           const li = editingListItem();
@@ -756,6 +715,23 @@ export default function Items(
           // Find category currently on the catalog item
           const catalogItem = items.value.find((i) => i.id === li.itemId);
           const currentCategoryId = catalogItem?.categoryId ?? "";
+          const currentCatLabel =
+            categories.value.find((c) => c.id === currentCategoryId)?.label ??
+              "Uncategorized";
+
+          // Searchable category picker replaces the editor body while open
+          if (editCatPicking.value) {
+            return (
+              <CategoryPickerList
+                categories={categories.value}
+                selectedId={currentCategoryId}
+                onSelect={(id) => {
+                  handleCategoryChange(id);
+                  editCatPicking.value = false;
+                }}
+              />
+            );
+          }
 
           return (
             <div class="flex flex-col gap-1.5 pb-1">
@@ -784,27 +760,24 @@ export default function Items(
               </div>
               <div class="h-px bg-surface-chigh mx-1" />
 
-              {/* Category */}
+              {/* Category — opens the searchable picker */}
               <div class="px-1 py-1.5">
-                <div class="md-body-large text-on-surface mb-3">Category</div>
-                <div class="flex gap-2 flex-wrap">
-                  <Chip
-                    selected={!currentCategoryId}
-                    onClick={() => handleCategoryChange("")}
-                  >
-                    Uncategorized
-                  </Chip>
-                  <For each={categories}>
-                    {(cat) => (
-                      <Chip
-                        selected={currentCategoryId === cat.id}
-                        onClick={() => cat.id && handleCategoryChange(cat.id)}
-                      >
-                        {cat.label}
-                      </Chip>
-                    )}
-                  </For>
-                </div>
+                <div class="md-body-large text-on-surface mb-2">Category</div>
+                <Pressable
+                  onClick={() => {
+                    editCatPicking.value = true;
+                  }}
+                  class="flex items-center justify-between gap-2 w-full bg-surface-chigh rounded-[var(--md-shape-md)] px-4 py-3"
+                >
+                  <span class="md-body-large text-on-surface">
+                    {currentCatLabel}
+                  </span>
+                  <Icon
+                    name="chevron"
+                    size={18}
+                    class="text-on-surface-variant"
+                  />
+                </Pressable>
               </div>
               <div class="h-px bg-surface-chigh mx-1" />
 

--- a/islands/items.tsx
+++ b/islands/items.tsx
@@ -129,6 +129,9 @@ export default function Items(
   // respective sheet body while open)
   const catPicking = useSignal(false);
   const editCatPicking = useSignal(false);
+  // add-item: user explicitly chose "add as new" even though catalogue
+  // matches exist (promotes the otherwise-subtle create affordance)
+  const wantCreate = useSignal(false);
 
   // ── item-editor: honest "Saved" indicator ───────────────────────────────
   // Driven directly by `lastSaved` (bumped only when a debounced list-item write
@@ -147,6 +150,15 @@ export default function Items(
 
   const { query, results, inputRef, reset } = useSearchBox(catalog, filterFn);
 
+  // Autofocus the search field when the add-item sheet opens — enables a quick
+  // type-to-search flow without an extra tap. Keyed on addOpen only, so
+  // returning from the category picker doesn't steal focus.
+  useEffect(() => {
+    if (!addOpen.value) return;
+    const t = setTimeout(() => inputRef.current?.focus(), 80);
+    return () => clearTimeout(t);
+  }, [addOpen.value]);
+
   // ── add-item handlers ────────────────────────────────────────────────────
   const handleAddToList = async (itemId: string) => {
     await addToList(itemId);
@@ -156,6 +168,7 @@ export default function Items(
   const handleCreateItem = async (searchString: string) => {
     await addToCatalog(searchString, selectedCategoryId.value || undefined);
     selectedCategoryId.value = "";
+    wantCreate.value = false;
     reset();
   };
 
@@ -554,6 +567,7 @@ export default function Items(
         onClose={() => {
           addOpen.value = false;
           catPicking.value = false;
+          wantCreate.value = false;
           reset();
         }}
         title={catPicking.value ? "Choose category" : "Add items"}
@@ -580,6 +594,8 @@ export default function Items(
                 value={query.value}
                 onInput={(e) => {
                   query.value = (e.target as HTMLInputElement).value;
+                  // typing changes the match set — retract an explicit "add new"
+                  wantCreate.value = false;
                 }}
                 onKeyDown={(e) => {
                   if (e.key === "Enter" && query.value.trim()) {
@@ -587,7 +603,10 @@ export default function Items(
                     const exact = items.value.some((i) =>
                       i.name?.toLowerCase() === q.toLowerCase()
                     );
-                    if (!exact) handleCreateItem(q);
+                    // Enter creates only when nothing in the catalogue matches
+                    if (!exact && results.value.length === 0) {
+                      handleCreateItem(q);
+                    }
                   }
                 }}
                 placeholder="Search or add an item…"
@@ -595,102 +614,125 @@ export default function Items(
               />
             </div>
 
-            {/* "Add '<query>'" card — shown when non-empty query and no exact match */}
             {(() => {
               const q = query.value.trim();
-              const exact = q
-                ? items.value.some((i) =>
-                  i.name?.toLowerCase() === q.toLowerCase()
-                )
-                : true;
-              if (!q || exact) return null;
-              return (
-                <div class="bg-primary-container text-on-primary-container rounded-[var(--md-shape-lg)] p-3.5 mb-3 flex flex-col gap-3">
-                  <div class="flex items-center gap-3.5">
-                    <span class="w-9 h-9 rounded-full bg-on-primary-container text-primary-container grid place-items-center shrink-0">
-                      <Icon name="plus" size={20} />
-                    </span>
-                    <div class="flex-1 min-w-0">
-                      <div class="md-body-large">Add "{q}"</div>
-                      <div class="md-body-small opacity-80">
-                        New item — pick a category
-                      </div>
+
+              // Idle: no query yet — prompt to search rather than dumping the
+              // whole catalogue into the sheet.
+              if (!q) {
+                return (
+                  <div class="flex flex-col items-center text-center gap-1 px-6 py-10 text-on-surface-variant">
+                    <Icon name="search" size={28} />
+                    <div class="md-body-medium mt-1">Search your catalogue</div>
+                    <div class="md-body-small opacity-80">
+                      or type something new to add it
                     </div>
                   </div>
+                );
+              }
 
-                  {/* Category — opens the searchable picker */}
-                  <Pressable
-                    onClick={() => {
-                      catPicking.value = true;
-                    }}
-                    color="var(--md-on-primary-container)"
-                    class="flex items-center justify-between gap-2 w-full rounded-[var(--md-shape-md)] border border-on-primary-container/40 px-3.5 py-2.5"
-                  >
-                    <span class="md-body-medium opacity-80">Category</span>
-                    <span class="inline-flex items-center gap-1 md-label-large">
-                      {selectedCatLabel} <Icon name="chevron" size={18} />
-                    </span>
-                  </Pressable>
+              const exact = items.value.some((i) =>
+                i.name?.toLowerCase() === q.toLowerCase()
+              );
+              const hasResults = results.value.length > 0;
+              // "Add new" is prominent only when nothing matches — or when the
+              // user explicitly asked to create one despite matches.
+              const promoteCreate = !exact && (!hasResults || wantCreate.value);
+              const showSubtleCreate = !exact && hasResults &&
+                !wantCreate.value;
 
-                  <Button
-                    variant="filled"
-                    full
-                    onClick={() => handleCreateItem(q)}
-                    style={{
-                      background: "var(--md-on-primary-container)",
-                      color: "var(--md-primary-container)",
-                    }}
-                  >
-                    Add to {categories.value.find((c) =>
-                      c.id === selectedCategoryId.value
-                    )?.label ?? "Uncategorized"}
-                  </Button>
-                </div>
+              return (
+                <>
+                  {/* Prominent "Add '<query>'" card — the CTA when no match */}
+                  {promoteCreate && (
+                    <div class="bg-primary-container text-on-primary-container rounded-[var(--md-shape-lg)] p-3.5 mb-3 flex flex-col gap-3">
+                      <div class="flex items-center gap-3.5">
+                        <span class="w-9 h-9 rounded-full bg-on-primary-container text-primary-container grid place-items-center shrink-0">
+                          <Icon name="plus" size={20} />
+                        </span>
+                        <div class="flex-1 min-w-0">
+                          <div class="md-body-large">Add "{q}"</div>
+                          <div class="md-body-small opacity-80">
+                            New item — pick a category
+                          </div>
+                        </div>
+                      </div>
+
+                      {/* Category — opens the searchable picker */}
+                      <Pressable
+                        onClick={() => {
+                          catPicking.value = true;
+                        }}
+                        color="var(--md-on-primary-container)"
+                        class="flex items-center justify-between gap-2 w-full rounded-[var(--md-shape-md)] border border-on-primary-container/40 px-3.5 py-2.5"
+                      >
+                        <span class="md-body-medium opacity-80">Category</span>
+                        <span class="inline-flex items-center gap-1 md-label-large">
+                          {selectedCatLabel} <Icon name="chevron" size={18} />
+                        </span>
+                      </Pressable>
+
+                      <Button
+                        variant="filled"
+                        full
+                        onClick={() => handleCreateItem(q)}
+                        style={{
+                          background: "var(--md-on-primary-container)",
+                          color: "var(--md-primary-container)",
+                        }}
+                      >
+                        Add to {selectedCatLabel}
+                      </Button>
+                    </div>
+                  )}
+
+                  {/* Matching catalogue items — the main add flow */}
+                  <div class="flex flex-col">
+                    <For each={results}>
+                      {(item) => {
+                        const added = listItemsMap.value.has(item.id ?? "");
+                        return (
+                          <ListItem
+                            key={item.id}
+                            headline={item.name ?? ""}
+                            supporting={categories.value.find((c) =>
+                              c.id === item.categoryId
+                            )?.label ?? ""}
+                            onClick={added
+                              ? undefined
+                              : () => item.id && handleAddToList(item.id)}
+                            trailing={added
+                              ? (
+                                <span class="inline-flex items-center gap-1 text-primary md-label-medium">
+                                  <Icon name="check" size={18} /> Added
+                                </span>
+                              )
+                              : (
+                                <span class="text-primary">
+                                  <Icon name="plus" size={22} />
+                                </span>
+                              )}
+                          />
+                        );
+                      }}
+                    </For>
+                  </div>
+
+                  {/* Subtle "add as new" — offered only when matches exist */}
+                  {showSubtleCreate && (
+                    <Pressable
+                      onClick={() => {
+                        wantCreate.value = true;
+                      }}
+                      class="flex items-center gap-2 w-full text-left rounded-[var(--md-shape-md)] px-3 py-3 mt-1 text-primary md-label-large"
+                    >
+                      <Icon name="plus" size={20} />
+                      Add "{q}" as a new item
+                    </Pressable>
+                  )}
+                </>
               );
             })()}
-
-            {/* Catalogue list */}
-            <div class="flex flex-col">
-              {!query.value.trim() && (
-                <div class="md-label-medium text-on-surface-variant uppercase tracking-widest mb-1 px-1">
-                  From your catalogue
-                </div>
-              )}
-              <For each={results}>
-                {(item) => {
-                  const added = listItemsMap.value.has(item.id ?? "");
-                  return (
-                    <ListItem
-                      key={item.id}
-                      headline={item.name ?? ""}
-                      supporting={categories.value.find((c) =>
-                        c.id === item.categoryId
-                      )?.label ?? ""}
-                      onClick={added
-                        ? undefined
-                        : () => item.id && handleAddToList(item.id)}
-                      trailing={added
-                        ? (
-                          <span class="inline-flex items-center gap-1 text-primary md-label-medium">
-                            <Icon name="check" size={18} /> Added
-                          </span>
-                        )
-                        : (
-                          <span class="text-primary">
-                            <Icon name="plus" size={22} />
-                          </span>
-                        )}
-                    />
-                  );
-                }}
-              </For>
-              {query.value.trim() && results.value.length === 0 && (
-                <p class="md-body-medium text-on-surface-variant px-1 py-3.5">
-                  No catalogue match — use "Add "{query.value.trim()}"" above to
-                  create it.
-                </p>
-              )}
-            </div>
           </>
         )}
       </Sheet>


### PR DESCRIPTION
Real-world UX fixes for the shopping **Plan mode** (List detail), from a household with many categories and a large catalogue.

## 1. Sheet drag-vs-scroll

`components/md3/Sheet.tsx` attached drag-to-dismiss to the whole panel and read *any* downward finger movement as a drag — so scrolling a list *up* closed the sheet. Drag-to-dismiss now engages only from the **header/handle** (a sibling of the scroll body); the body scrolls freely. Scrim-tap and Escape still close. Benefits **every** sheet.

## 2. Shared searchable category picker

Extracted `components/md3/CategoryPickerList.tsx` — a searchable, alphabetical, filterable single-select list that owns its own query (resets each open). Both the **add-item card** and the **item-editor sheet** now show a compact **"Category · X"** button that opens this picker instead of a wall of wrapping chips.
- Add-item commits the choice when the item is created.
- Item-editor commits via the existing `api.items.update` + `refresh` path.

## 3. Faster, less-crowded add-item flow

- **Autofocus** the search field when the sheet opens — type-to-search with no extra tap.
- **Search-first:** no longer dumps the whole catalogue on open; shows an idle "Search your catalogue" hint and renders results only once the user types (sheet stays small with a large catalogue).
- **Quieter "add new":** matching catalogue items are the primary flow, with a *subtle* "Add ‹q› as a new item" link beneath them. The prominent create card (with the category picker) appears only when nothing matches — or when the user taps the subtle link (tracked via a `wantCreate` signal, reset on typing/close). Enter creates only when there's no match.

No data-model or API changes anywhere.

## Verified (live, mobile viewport) — zero console errors, zero failed requests

- **Item-editor:** compact `Category · Uncategorized ›` (chip count 0) → picker "Choose category" → typed "wereld" → filtered to `wereldkeuken` → selected → item regrouped under **WERELDKEUKEN** (persisted).
- **Add-item:** open → search input **focused**, idle hint shown, **0** catalogue rows. Typed "test" → matching items listed + subtle "Add ‹test›…" link (no prominent card). Tapped the link → full create card appears, matches remain. Typed "zzqqxx" (no match) → prominent `Add "zzqqxx"` card with category picker.
- Synthesized downward drag on the sheet **body** → panel stays `translateY(0px)` (no dismiss); header/handle drag still dismisses.
- `deno task check` green · `deno test` 74/74 · `deno task build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
