### PR TITLE
chore: ignore .DS_Store and local handoff archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,9 @@ kv.db-wal
 
 
 .superpowers/
+
+# macOS Finder metadata
+.DS_Store
+
+# Large design handoff archive — kept locally, not committed
+docs/Happie-handoff.zip


### PR DESCRIPTION
Adds two ignore rules so repo junk can't be accidentally staged/committed:

- `.DS_Store` — macOS Finder metadata (was appearing as untracked and got inadvertently staged).
- `docs/Happie-handoff.zip` — a 2.8 MB binary design-handoff archive; kept locally, not in git.

No code or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)