### PR TITLE
feat(shopping): Add items FAB + full-screen search flow

### DIFF
--- a/components/md3/CatalogueAddRow.test.tsx
+++ b/components/md3/CatalogueAddRow.test.tsx
@@ -43,10 +43,13 @@ Deno.test("CatalogueAddRow — added with onRemove shows a remove control", () =
   assertStringIncludes(html, "Remove Milk");
 });
 
-// Backward-compat: both real callers pass only { name, added, onAdd }. With no
-// quantity/onQtyChange/onEdit the row must fall back to a static "✓ Added" label
-// and stay inert — ListItem renders a plain <div> (no "md-press" host) when it
-// has no onClick, whereas the interactive path wraps body in a Pressable.
+// Defensive fallback: no current caller exercises this path (the sole caller,
+// islands/add-items.tsx, always passes quantity/onEdit alongside added). With no
+// quantity/onQtyChange/onEdit the row must still fall back to a static "✓ Added"
+// label and stay inert — ListItem renders a plain <div> (no "md-press" host) when
+// it has no onClick, whereas the interactive path wraps body in a Pressable. This
+// test guards that contract so the static fallback keeps working if a future
+// caller (or this one) ever omits quantity.
 Deno.test("CatalogueAddRow — added fallback: static Added label, inert, no stepper/remove", () => {
   const html = render(h(CatalogueAddRow, {
     name: "Eggs",

--- a/components/md3/CatalogueAddRow.test.tsx
+++ b/components/md3/CatalogueAddRow.test.tsx
@@ -3,7 +3,7 @@ import { render } from "npm:preact-render-to-string@^6.6.3";
 import { h } from "preact";
 import { CatalogueAddRow } from "./CatalogueAddRow.tsx";
 
-Deno.test("CatalogueAddRow — name, category, and Add affordance", () => {
+Deno.test("CatalogueAddRow — un-added: name, category, Add affordance", () => {
   const html = render(h(CatalogueAddRow, {
     name: "Butter",
     categoryLabel: "Dairy",
@@ -12,15 +12,49 @@ Deno.test("CatalogueAddRow — name, category, and Add affordance", () => {
   }));
   assertStringIncludes(html, "Butter");
   assertStringIncludes(html, "Dairy");
-  assert(!html.includes("Added"));
+  assert(!html.includes("Decrease quantity")); // no stepper when un-added
+  assert(!html.includes("Added")); // un-added row never shows the Added affordance
 });
 
-Deno.test("CatalogueAddRow — Added state", () => {
+Deno.test("CatalogueAddRow — added: inline quantity stepper", () => {
   const html = render(h(CatalogueAddRow, {
     name: "Bread",
     added: true,
     onAdd: () => {},
+    quantity: 2,
+    onQtyChange: () => {},
+    onEdit: () => {},
   }));
   assertStringIncludes(html, "Bread");
-  assertStringIncludes(html, "Added");
+  assertStringIncludes(html, "Decrease quantity"); // Stepper present
+  assertStringIncludes(html, "Increase quantity");
+});
+
+Deno.test("CatalogueAddRow — added with onRemove shows a remove control", () => {
+  const html = render(h(CatalogueAddRow, {
+    name: "Milk",
+    added: true,
+    onAdd: () => {},
+    quantity: 1,
+    onQtyChange: () => {},
+    onEdit: () => {},
+    onRemove: () => {},
+  }));
+  assertStringIncludes(html, "Remove Milk");
+});
+
+// Backward-compat: both real callers pass only { name, added, onAdd }. With no
+// quantity/onQtyChange/onEdit the row must fall back to a static "✓ Added" label
+// and stay inert — ListItem renders a plain <div> (no "md-press" host) when it
+// has no onClick, whereas the interactive path wraps body in a Pressable.
+Deno.test("CatalogueAddRow — added fallback: static Added label, inert, no stepper/remove", () => {
+  const html = render(h(CatalogueAddRow, {
+    name: "Eggs",
+    added: true,
+    onAdd: () => {},
+  }));
+  assertStringIncludes(html, "Added"); // static fallback label
+  assert(!html.includes("Decrease quantity")); // no stepper
+  assert(!html.includes("Remove ")); // no remove control
+  assert(!html.includes("md-press")); // inert: no interactive Pressable wrapper
 });

--- a/components/md3/CatalogueAddRow.tsx
+++ b/components/md3/CatalogueAddRow.tsx
@@ -1,39 +1,86 @@
-// components/md3/CatalogueAddRow.tsx
 import { Icon } from "@/components/md3/Icon.tsx";
 import { ListItem } from "@/components/md3/ListItem.tsx";
+import { Stepper } from "@/components/md3/Stepper.tsx";
+import { Pressable } from "@/components/md3/Pressable.tsx";
 
 interface CatalogueAddRowProps {
   name: string;
   categoryLabel?: string;
   added: boolean;
   onAdd: () => void;
+  /** When added: inline quantity + tap-to-edit affordances. */
+  quantity?: number;
+  onQtyChange?: (v: number) => void;
+  onEdit?: () => void;
+  /** Added-section variant only: a remove-from-list control. */
+  onRemove?: () => void;
 }
 
 /**
- * A catalogue item row in the add flows: name + category, with an add / Added
- * state. Shared by the quick-add sheet (islands/items.tsx) and the full-screen
- * add page (islands/add-items.tsx). Tapping an un-added row calls onAdd
- * (optimistic); an added row is inert.
+ * A catalogue item row on the full-screen add page. Un-added: the whole row
+ * adds the item (optimistic). Added: the row is tappable to edit (note/qty) and
+ * carries an inline quantity stepper; the Added-section variant also shows a
+ * remove control. The Stepper stops event propagation, so stepping never
+ * triggers the row's edit tap.
+ *
+ * Backward-compat: an added row with no `quantity`/`onQtyChange` falls back to a
+ * static "✓ Added" label and is inert (no tap-to-edit), matching the original
+ * quick-add callers that pass only `{ name, added, onAdd }`.
  */
 export function CatalogueAddRow(
-  { name, categoryLabel, added, onAdd }: CatalogueAddRowProps,
+  {
+    name,
+    categoryLabel,
+    added,
+    onAdd,
+    quantity,
+    onQtyChange,
+    onEdit,
+    onRemove,
+  }: CatalogueAddRowProps,
 ) {
+  if (!added) {
+    return (
+      <ListItem
+        headline={name}
+        supporting={categoryLabel ?? ""}
+        onClick={onAdd}
+        trailing={
+          <span class="text-primary">
+            <Icon name="plus" size={22} />
+          </span>
+        }
+      />
+    );
+  }
+
+  const canStep = quantity != null && !!onQtyChange;
   return (
     <ListItem
       headline={name}
       supporting={categoryLabel ?? ""}
-      onClick={added ? undefined : onAdd}
-      trailing={added
-        ? (
-          <span class="inline-flex items-center gap-1 text-primary md-label-medium">
-            <Icon name="check" size={18} /> Added
-          </span>
-        )
-        : (
-          <span class="text-primary">
-            <Icon name="plus" size={22} />
-          </span>
-        )}
+      onClick={onEdit}
+      trailing={
+        <div class="flex items-center gap-1.5">
+          {onRemove && (
+            <Pressable
+              onClick={onRemove}
+              stop
+              aria-label={`Remove ${name}`}
+              class="w-8 h-8 grid place-items-center rounded-full text-on-surface-variant"
+            >
+              <Icon name="x" size={18} />
+            </Pressable>
+          )}
+          {canStep
+            ? <Stepper value={quantity!} onChange={onQtyChange!} />
+            : (
+              <span class="inline-flex items-center gap-1 text-primary md-label-medium">
+                <Icon name="check" size={18} /> Added
+              </span>
+            )}
+        </div>
+      }
     />
   );
 }

--- a/database/shopping-list-item.repo.test.ts
+++ b/database/shopping-list-item.repo.test.ts
@@ -1,0 +1,36 @@
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import { mergeDefinedPatch } from "@/database/shopping-list-item.repo.ts";
+
+/** Minimal shape covering the fields exercised below. Typed explicitly (rather
+ *  than inferred from each literal) so patches touching a key `current` didn't
+ *  set — e.g. `checked` in the second test — still type-check against `T`. */
+interface TestItem {
+  quantity: number;
+  note: string;
+  checked: boolean;
+}
+
+Deno.test("mergeDefinedPatch — a note-only patch preserves quantity and checked", () => {
+  const current: Partial<TestItem> = {
+    quantity: 2,
+    note: "old",
+    checked: false,
+  };
+  const result = mergeDefinedPatch(current, { note: "new" });
+  assertEquals(result, { quantity: 2, note: "new", checked: false });
+});
+
+Deno.test("mergeDefinedPatch — explicit undefined values are ignored", () => {
+  const current: Partial<TestItem> = { quantity: 2, note: "x" };
+  const result = mergeDefinedPatch(current, {
+    quantity: undefined,
+    checked: true,
+  });
+  assertEquals(result, { quantity: 2, note: "x", checked: true });
+});
+
+Deno.test("mergeDefinedPatch — defined falsy values still apply", () => {
+  const current: Partial<TestItem> = { checked: true };
+  const result = mergeDefinedPatch(current, { checked: false });
+  assertEquals(result, { checked: false });
+});

--- a/database/shopping-list-item.repo.ts
+++ b/database/shopping-list-item.repo.ts
@@ -1,6 +1,20 @@
 import { ShoppingListItemInterface } from "@/models/index.ts";
 import { getKv } from "./db.ts";
 
+/** Merge a partial patch onto `current`, ignoring keys whose value is undefined,
+ *  so a partial update never clobbers omitted fields. Defined falsy values
+ *  (false, 0, "") still apply. */
+export function mergeDefinedPatch<T extends object>(
+  current: T,
+  patch: Partial<T>,
+): T {
+  const next = { ...current };
+  for (const [k, v] of Object.entries(patch)) {
+    if (v !== undefined) (next as Record<string, unknown>)[k] = v;
+  }
+  return next;
+}
+
 export class ShoppingListItemRepo {
   static async add(
     listId: string,
@@ -38,7 +52,7 @@ export class ShoppingListItemRepo {
     const key = ["shopping_list_items", listId, id];
     const current = await kv.get<ShoppingListItemInterface>(key);
     if (!current.value) return null;
-    const next = { ...current.value, ...patch } as ShoppingListItemInterface;
+    const next = mergeDefinedPatch(current.value, patch);
     await kv.set(key, next);
     return next;
   }

--- a/docs/superpowers/plans/2026-07-19-add-items-fab-search-flow.md
+++ b/docs/superpowers/plans/2026-07-19-add-items-fab-search-flow.md
@@ -1,0 +1,1156 @@
+# Add-Items FAB + Full-Screen Search Flow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the list page's dummy-search-and-sheet with an "Add items" FAB
+that opens a dedicated full-screen search page, and make that page a fast
+search → add → tweak (quantity/note) loop with a pinned "Added (N)" section.
+
+**Architecture:** A new shell app-bar mode `{ mode: "none" }` lets a route own
+the whole viewport (no top bar, no bottom nav). The add-items island renders its
+own sticky MD3 search bar and drives all adds/edits through the existing
+`useShoppingList` hook. No new data model or API.
+
+**Tech Stack:** Deno + Fresh 2 (SSR + islands) + Preact + `@preact/signals` +
+Deno KV + Tailwind v4. MD3 components in `components/md3/*`.
+
+**Spec:** `docs/superpowers/specs/2026-07-19-add-items-fab-search-flow-design.md`
+
+## Global Constraints
+
+- **No data-model or API changes.** Reuse existing repos, `services/api.ts`, and
+  `hooks/useShoppingList.ts` / `hooks/useSearchBox.ts`. No new endpoints, no KV
+  schema edits.
+- **Preact JSX:** `class` not `className`. Imports use the `@/` alias.
+- **Signals in islands:** local state via `useSignal()`; the `signal()`-based
+  `useShoppingList` is instantiated once via `useMemo(() => useHook(...), [])`;
+  never call `signal()` in a component body; re-render-driving `.value` reads
+  stay at the top level of the component body.
+- **Icons:** only names from the `IconName` union in `components/md3/Icon.tsx`
+  (this feature uses `back`, `search`, `x`, `check`, `chevron`, `plus` — all
+  already present; no new icons).
+- **Query param:** read as `ctx.url.searchParams.get("q") ?? ""`.
+- **Commits:** Conventional Commits; end every commit message with
+  `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+- **Gates green before each commit:** `deno task check` (fmt + lint + type),
+  `deno test`, `deno task build`. LSP errors for `@/`, `jsr:`, `npm:`, `Deno`,
+  or JSX are false positives — the authority is `deno task check`.
+- **Never** commit `.DS_Store`, `deno.lock` churn (revert with
+  `git checkout deno.lock` if it changes), or anything under `docs/happie/`.
+
+---
+
+## File Structure
+
+**Modified**
+- `utils/define.ts` — add `AppBarNone` + `AppBar` union; `StateInterface.appBar`
+  becomes `AppBar`.
+- `routes/_app.tsx` — pass the `AppBar` union straight to `AppChrome`.
+- `islands/shell/AppChrome.tsx` — render no chrome for `mode: "none"`.
+- `routes/shopping/[id]/add.tsx` — `appBar: { mode: "none" }`; drop `p-4`.
+- `components/md3/CatalogueAddRow.tsx` — added-state (inline `Stepper`,
+  tap-to-edit, optional remove).
+- `islands/add-items.tsx` — full rewrite: sticky search bar, clean search-first
+  idle, results with add/added rows, compact editor sheet, "Added (N)" section.
+- `islands/items.tsx` — remove `SearchBar` + quick-add sheet + machinery; add
+  the FAB (Plan mode); empty-state copy.
+
+**New**
+- `islands/shell/AppChrome.test.tsx` — covers `mode: "none"` vs `mode: "detail"`.
+
+**Tests updated**
+- `components/md3/CatalogueAddRow.test.tsx`, `islands/add-items.test.tsx`,
+  `islands/items.test.tsx`.
+
+**Reused unchanged**
+- `islands/shell/Fab.tsx`, `hooks/useShoppingList.ts`, `hooks/useSearchBox.ts`,
+  `components/md3/{Sheet,Stepper,CategoryPickerList,ListItem,Icon,Pressable,Button}.tsx`.
+
+## Pre-Flight Notes (read before Task 1)
+
+- `useShoppingList` returns (this feature uses): `addToList(itemId) →
+  Promise<listItemId|null>`, `addToCatalog(name, categoryId?) →
+  Promise<listItemId|null>` (creates the catalogue item **and** adds it),
+  `updateListItem(listItemId, patch)`, `flushListItem(listItemId)`,
+  `removeListItem(listItemId)`, `getItemName(itemId)`, `listItemsMap` (computed
+  `Map<itemId, listItem>`), `list`, `categories`, `items`, `selectedCategoryId`.
+- **Both adders return the LIST-ITEM id.** The "Added (N)" section is therefore
+  keyed by list-item id, and results-row added-state is derived from
+  `listItemsMap.value.get(itemId)`.
+- `Stepper` calls `e.stopPropagation()` on its buttons, so it can sit inside a
+  tap-to-edit row without triggering the row's tap.
+- Tests: `import { assert, assertEquals, assertStringIncludes } from
+  "jsr:@std/assert@^1.0.19";`, `import { render } from
+  "npm:preact-render-to-string@^6.6.3";`, `import { h } from "preact";`, render
+  via `render(h(Component, props))`. `preact-render-to-string` HTML-escapes `"`
+  in JSX text (`Create "{q}"` serializes as `Create &quot;Tofu&quot;`).
+
+---
+
+## Task 1: Shell `mode: "none"` — full-screen route surface
+
+**Files:**
+- Modify: `utils/define.ts`
+- Modify: `routes/_app.tsx`
+- Modify: `islands/shell/AppChrome.tsx`
+- Create: `islands/shell/AppChrome.test.tsx`
+
+**Interfaces:**
+- Produces: `AppBar = AppBarDetail | AppBarNone` (`utils/define.ts`);
+  `AppBarNone = { mode: "none" }`. Consumed by Task 4's `add.tsx`.
+- This task does **not** touch any route's runtime behavior yet (no route sets
+  `mode: "none"` until Task 4) — existing detail/section bars are unchanged.
+
+- [ ] **Step 1: Write the failing test** — `islands/shell/AppChrome.test.tsx`
+
+```tsx
+import { assertEquals, assertStringIncludes } from "jsr:@std/assert@^1.0.19";
+import { render } from "npm:preact-render-to-string@^6.6.3";
+import { h } from "preact";
+import AppChrome from "./AppChrome.tsx";
+
+Deno.test("AppChrome — mode:none renders no chrome (full-screen route)", () => {
+  const html = render(
+    h(AppChrome, { appBar: { mode: "none" }, sectionTitle: "Shopping" }),
+  );
+  assertEquals(html, "");
+});
+
+Deno.test("AppChrome — mode:detail renders a back + title bar", () => {
+  const html = render(
+    h(AppChrome, {
+      appBar: { mode: "detail", title: "Add items", backUrl: "/shopping/l1" },
+      sectionTitle: "Shopping",
+    }),
+  );
+  assertStringIncludes(html, "Add items");
+  assertStringIncludes(html, "/shopping/l1");
+});
+```
+
+- [ ] **Step 2: Run it — expect FAIL**
+
+Run: `deno test islands/shell/AppChrome.test.tsx`
+Expected: FAIL — `AppChrome` doesn't yet accept `appBar: { mode: "none" }`
+(type error / non-empty output for the none case).
+
+- [ ] **Step 3: Extend the app-bar type** — `utils/define.ts`
+
+Replace the `AppBarDetail`/`StateInterface` block with:
+
+```ts
+export interface AppBarDetail {
+  mode: "detail";
+  title: string;
+  backUrl: string;
+}
+
+/** The route owns the whole viewport — the shell renders no top bar and no
+ *  bottom navigation (e.g. the full-screen add-items search). */
+export interface AppBarNone {
+  mode: "none";
+}
+
+export type AppBar = AppBarDetail | AppBarNone;
+
+export interface StateInterface {
+  userId?: string;
+  householdId?: string;
+  items?: ItemInterface[];
+  shoppingList?: ShoppingListItemInterface[];
+  error?: string;
+  appBar?: AppBar;
+}
+```
+
+- [ ] **Step 4: Pass the union through** — `routes/_app.tsx`
+
+Change the `AppChrome` invocation so it forwards the whole union instead of the
+flattened `{ title, backUrl }`:
+
+```tsx
+{state?.userId && (
+  <AppChrome
+    activeId={activeTab?.id}
+    appBar={state.appBar}
+    sectionTitle={activeTab?.label ?? "Happie"}
+  />
+)}
+```
+
+- [ ] **Step 5: Handle `mode: "none"`** — `islands/shell/AppChrome.tsx`
+
+Replace the file with:
+
+```tsx
+import { useSignal } from "@preact/signals";
+import TopAppBar from "./TopAppBar.tsx";
+import NavigationBar from "./NavigationBar.tsx";
+import MoreSheet from "./MoreSheet.tsx";
+import { NAV_CONFIG } from "@/config/navigation.ts";
+import { appBarAction } from "@/utils/app-bar.ts";
+import { IconButton } from "@/components/md3/IconButton.tsx";
+import type { AppBar } from "@/utils/define.ts";
+
+interface AppChromeProps {
+  activeId?: string;
+  appBar?: AppBar;
+  sectionTitle: string;
+}
+
+export default function AppChrome(
+  { activeId, appBar, sectionTitle }: AppChromeProps,
+) {
+  const moreOpen = useSignal(false);
+
+  // Full-screen routes (e.g. the add-items search) own the whole viewport:
+  // no top bar and no bottom navigation.
+  if (appBar?.mode === "none") return null;
+
+  const detail = appBar?.mode === "detail" ? appBar : null;
+
+  return (
+    <>
+      {detail
+        ? (
+          <TopAppBar
+            title={detail.title}
+            backUrl={detail.backUrl}
+            trailing={appBarAction.value
+              ? (
+                <IconButton
+                  name={appBarAction.value.icon}
+                  aria-label={appBarAction.value.label}
+                  onClick={appBarAction.value.onClick}
+                />
+              )
+              : undefined}
+          />
+        )
+        : <TopAppBar title={sectionTitle} />}
+      <NavigationBar
+        items={NAV_CONFIG}
+        activeId={activeId}
+        onMore={() => moreOpen.value = true}
+      />
+      <MoreSheet
+        open={moreOpen.value}
+        onClose={() => moreOpen.value = false}
+      />
+    </>
+  );
+}
+```
+
+- [ ] **Step 6: Run the test — expect PASS**
+
+Run: `deno test islands/shell/AppChrome.test.tsx`
+Expected: PASS (both cases).
+
+- [ ] **Step 7: Gates**
+
+Run: `deno task check && deno test && deno task build`
+Expected: all green. If `deno.lock` changed, `git checkout deno.lock`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add utils/define.ts routes/_app.tsx islands/shell/AppChrome.tsx islands/shell/AppChrome.test.tsx
+git commit -m "feat(shell): add mode:none app-bar for full-screen routes" \
+  -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `CatalogueAddRow` added-state (inline stepper + tap-to-edit)
+
+**Files:**
+- Modify: `components/md3/CatalogueAddRow.tsx`
+- Modify: `components/md3/CatalogueAddRow.test.tsx`
+
+**Interfaces:**
+- Produces: `CatalogueAddRow` props
+  `{ name, categoryLabel?, added, onAdd, quantity?, onQtyChange?, onEdit?,
+  onRemove? }`. Consumed by Task 4's `add-items.tsx`.
+- Un-added → whole row calls `onAdd`, trailing `+`. Added → row calls `onEdit`,
+  trailing = inline `Stepper` (+ optional remove control when `onRemove` is
+  given). Falls back to a static "✓ Added" if `quantity`/`onQtyChange` are
+  absent.
+
+- [ ] **Step 1: Update the tests** — `components/md3/CatalogueAddRow.test.tsx`
+
+Replace the file with:
+
+```tsx
+import { assert, assertStringIncludes } from "jsr:@std/assert@^1.0.19";
+import { render } from "npm:preact-render-to-string@^6.6.3";
+import { h } from "preact";
+import { CatalogueAddRow } from "./CatalogueAddRow.tsx";
+
+Deno.test("CatalogueAddRow — un-added: name, category, Add affordance", () => {
+  const html = render(h(CatalogueAddRow, {
+    name: "Butter",
+    categoryLabel: "Dairy",
+    added: false,
+    onAdd: () => {},
+  }));
+  assertStringIncludes(html, "Butter");
+  assertStringIncludes(html, "Dairy");
+  assert(!html.includes("Decrease quantity")); // no stepper when un-added
+});
+
+Deno.test("CatalogueAddRow — added: inline quantity stepper", () => {
+  const html = render(h(CatalogueAddRow, {
+    name: "Bread",
+    added: true,
+    onAdd: () => {},
+    quantity: 2,
+    onQtyChange: () => {},
+    onEdit: () => {},
+  }));
+  assertStringIncludes(html, "Bread");
+  assertStringIncludes(html, "Decrease quantity"); // Stepper present
+  assertStringIncludes(html, "Increase quantity");
+});
+
+Deno.test("CatalogueAddRow — added with onRemove shows a remove control", () => {
+  const html = render(h(CatalogueAddRow, {
+    name: "Milk",
+    added: true,
+    onAdd: () => {},
+    quantity: 1,
+    onQtyChange: () => {},
+    onEdit: () => {},
+    onRemove: () => {},
+  }));
+  assertStringIncludes(html, "Remove Milk");
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `deno test components/md3/CatalogueAddRow.test.tsx`
+Expected: FAIL (added-state has no stepper / no remove control yet).
+
+- [ ] **Step 3: Implement** — replace `components/md3/CatalogueAddRow.tsx`
+
+```tsx
+import { Icon } from "@/components/md3/Icon.tsx";
+import { ListItem } from "@/components/md3/ListItem.tsx";
+import { Stepper } from "@/components/md3/Stepper.tsx";
+import { Pressable } from "@/components/md3/Pressable.tsx";
+
+interface CatalogueAddRowProps {
+  name: string;
+  categoryLabel?: string;
+  added: boolean;
+  onAdd: () => void;
+  /** When added: inline quantity + tap-to-edit affordances. */
+  quantity?: number;
+  onQtyChange?: (v: number) => void;
+  onEdit?: () => void;
+  /** Added-section variant only: a remove-from-list control. */
+  onRemove?: () => void;
+}
+
+/**
+ * A catalogue item row on the full-screen add page. Un-added: the whole row
+ * adds the item (optimistic). Added: the row is tappable to edit (note/qty) and
+ * carries an inline quantity stepper; the Added-section variant also shows a
+ * remove control. The Stepper stops event propagation, so stepping never
+ * triggers the row's edit tap.
+ */
+export function CatalogueAddRow(
+  {
+    name,
+    categoryLabel,
+    added,
+    onAdd,
+    quantity,
+    onQtyChange,
+    onEdit,
+    onRemove,
+  }: CatalogueAddRowProps,
+) {
+  if (!added) {
+    return (
+      <ListItem
+        headline={name}
+        supporting={categoryLabel ?? ""}
+        onClick={onAdd}
+        trailing={
+          <span class="text-primary">
+            <Icon name="plus" size={22} />
+          </span>
+        }
+      />
+    );
+  }
+
+  const canStep = quantity != null && !!onQtyChange;
+  return (
+    <ListItem
+      headline={name}
+      supporting={categoryLabel ?? ""}
+      onClick={onEdit}
+      trailing={
+        <div class="flex items-center gap-1.5">
+          {onRemove && (
+            <Pressable
+              onClick={onRemove}
+              stop
+              aria-label={`Remove ${name}`}
+              class="w-8 h-8 grid place-items-center rounded-full text-on-surface-variant"
+            >
+              <Icon name="x" size={18} />
+            </Pressable>
+          )}
+          {canStep
+            ? <Stepper value={quantity!} onChange={onQtyChange!} />
+            : (
+              <span class="inline-flex items-center gap-1 text-primary md-label-medium">
+                <Icon name="check" size={18} /> Added
+              </span>
+            )}
+        </div>
+      }
+    />
+  );
+}
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `deno test components/md3/CatalogueAddRow.test.tsx`
+Expected: PASS (all three).
+
+- [ ] **Step 5: Gates**
+
+Run: `deno task check && deno test && deno task build`
+Expected: green. `git checkout deno.lock` if it churned.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add components/md3/CatalogueAddRow.tsx components/md3/CatalogueAddRow.test.tsx
+git commit -m "feat(md3): CatalogueAddRow added-state with inline stepper + tap-to-edit" \
+  -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: List page — "Add items" FAB, retire the quick-add sheet
+
+**Files:**
+- Modify: `islands/items.tsx`
+- Modify: `islands/items.test.tsx`
+
+**Interfaces:**
+- Consumes: `islands/shell/Fab.tsx` (`{ icon?, label?, onClick, "aria-label" }`).
+- The FAB navigates to `/shopping/${listId}/add` (the page reworked in Task 4).
+  The item-editor and list-options sheets are untouched.
+
+- [ ] **Step 1: Update the tests** — `islands/items.test.tsx`
+
+Replace the file with:
+
+```tsx
+import { assert, assertStringIncludes } from "jsr:@std/assert@^1.0.19";
+import { render } from "npm:preact-render-to-string@^6.6.3";
+import { h } from "preact";
+import Items from "./items.tsx";
+
+const base = {
+  listId: "l1",
+  listName: "Test list",
+  items: [],
+  shoppingList: [],
+  categories: [],
+};
+
+Deno.test("Items — renders Plan and Shop mode toggle", () => {
+  const html = render(h(Items, base));
+  assertStringIncludes(html, "Plan");
+  assertStringIncludes(html, "Shop");
+});
+
+Deno.test("Items — Plan mode shows the Add items FAB, no quick-add sheet", () => {
+  const html = render(h(Items, base));
+  assertStringIncludes(html, "Add items"); // FAB label
+  assert(!html.includes("Search your catalogue")); // old quick-add sheet gone
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `deno test islands/items.test.tsx`
+Expected: FAIL — the current island still renders the quick-add sheet
+("Search your catalogue") and no FAB.
+
+- [ ] **Step 3: Edit imports** — `islands/items.tsx`
+
+- Change the hooks import to drop `useSearchBox`:
+  ```tsx
+  import { useShoppingList } from "@/hooks/index.ts";
+  ```
+- **Remove** these two import lines:
+  ```tsx
+  import { SearchBar } from "@/components/md3/SearchBar.tsx";
+  import { CatalogueAddRow } from "@/components/md3/CatalogueAddRow.tsx";
+  ```
+- **Add** (next to the other island imports):
+  ```tsx
+  import Fab from "@/islands/shell/Fab.tsx";
+  ```
+
+- [ ] **Step 4: Trim the hook destructure**
+
+In the `useMemo(() => useShoppingList(...))` destructure, **remove** `addToList,`
+and `listItemsMap,`. Keep everything else (`items`, `categories`, `getItemName`
+are still used by the item-editor sheet).
+
+- [ ] **Step 5: Delete the quick-add machinery**
+
+Remove all of the following from the component body:
+- `const addOpen = useSignal(false);`
+- the search/filter block:
+  ```tsx
+  const filterFn = (searchString: string, item: ItemInterface) => { ... };
+  const { query, results, inputRef, reset } = useSearchBox(catalog, filterFn);
+  ```
+- the autofocus `useEffect` that focuses `inputRef` when `addOpen.value` changes.
+- `const handleAddToList = async (itemId: string) => { ... };`
+- `const openAddPage = (q?: string) => { ... };`
+- the `<SearchBar placeholder="Add item or search catalogue…" ... />` block at
+  the top of Plan mode.
+- the **entire** quick-add `<Sheet open={addOpen.value} ... title="Add items"
+  size={...}> ... </Sheet>` block (the one containing the "Full screen"
+  handoff, the search input, and the "Create …" pressable).
+
+- [ ] **Step 6: Update the empty-state copy**
+
+Change the Plan-mode empty message from:
+```tsx
+Tap the search bar to add items.
+```
+to:
+```tsx
+Tap Add items to get started.
+```
+
+- [ ] **Step 7: Add the FAB (Plan mode only)**
+
+Immediately before the closing Snackbar (`<Snackbar data={snackData.value} />`),
+add:
+
+```tsx
+{/* FAB — opens the full-screen add page (Plan mode only) */}
+{mode.value === "plan" && (
+  <div
+    class="fixed right-4 z-30"
+    style={{ bottom: "calc(96px + env(safe-area-inset-bottom))" }}
+  >
+    <Fab
+      icon="plus"
+      label="Add items"
+      aria-label="Add items"
+      onClick={() => {
+        globalThis.location.href = `/shopping/${listId}/add`;
+      }}
+    />
+  </div>
+)}
+```
+
+- [ ] **Step 8: Run — expect PASS**
+
+Run: `deno test islands/items.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 9: Gates**
+
+Run: `deno task check && deno test && deno task build`
+Expected: green (in particular, no "unused variable"/"unused import" lint errors
+— that confirms every removed symbol was fully cleaned up). `git checkout
+deno.lock` if it churned.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add islands/items.tsx islands/items.test.tsx
+git commit -m "feat(shopping): replace list quick-add sheet with an Add items FAB" \
+  -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Add page — full-screen search + tweak + "Added (N)" section
+
+**Files:**
+- Modify: `routes/shopping/[id]/add.tsx`
+- Modify: `islands/add-items.tsx` (full rewrite)
+- Modify: `islands/add-items.test.tsx`
+
+**Interfaces:**
+- Consumes: `AppBar` union / `{ mode: "none" }` (Task 1); `CatalogueAddRow`
+  added-state props (Task 2); `useShoppingList` (see Pre-Flight Notes),
+  `useSearchBox(catalog, filterFn, initialQuery)`, `Sheet`, `Stepper`,
+  `CategoryPickerList`, `Button`, `Pressable`, `Icon`.
+
+- [ ] **Step 1: Update the tests** — `islands/add-items.test.tsx`
+
+Replace the file with:
+
+```tsx
+import { assert, assertStringIncludes } from "jsr:@std/assert@^1.0.19";
+import { render } from "npm:preact-render-to-string@^6.6.3";
+import { h } from "preact";
+import AddItems from "./add-items.tsx";
+
+const base = {
+  listId: "l1",
+  listName: "Groceries",
+  items: [{ id: "i1", name: "Butter", categoryId: "d" }],
+  shoppingList: [],
+  categories: [
+    { id: "d", label: "Dairy", order: 0 },
+    { id: "b", label: "Bakery", order: 1 },
+  ],
+};
+
+Deno.test("AddItems — idle: search-first hint, no chips, no rows", () => {
+  const html = render(h(AddItems, { ...base, initialQuery: "" }));
+  assertStringIncludes(html, "Search your catalogue"); // idle hint
+  assertStringIncludes(html, "Adding to Groceries"); // context line
+  assert(!html.includes("Butter")); // no catalogue rows when idle
+  assert(!html.includes("Bakery")); // category chips are gone
+});
+
+Deno.test("AddItems — a back link to the list is always present", () => {
+  const html = render(h(AddItems, { ...base, initialQuery: "" }));
+  assertStringIncludes(html, `href="/shopping/l1"`);
+});
+
+Deno.test("AddItems — a matching query lists the catalogue item", () => {
+  const html = render(h(AddItems, { ...base, initialQuery: "But" }));
+  assertStringIncludes(html, "Butter");
+});
+
+Deno.test("AddItems — a no-match query shows the Create card", () => {
+  const html = render(h(AddItems, { ...base, initialQuery: "Tofu" }));
+  // preact-render-to-string HTML-escapes the literal quotes in Create "{q}".
+  assertStringIncludes(html, "Create &quot;Tofu&quot;");
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `deno test islands/add-items.test.tsx`
+Expected: FAIL — the current island renders chips (so "Bakery" appears when
+idle) and no back link / no "Search your catalogue" hint.
+
+- [ ] **Step 3: Turn the route into a full-screen surface** — `routes/shopping/[id]/add.tsx`
+
+Change the app-bar assignment and drop the `p-4`:
+
+```tsx
+    // Full-screen search surface: the island owns the top bar and there is no
+    // bottom nav. The shell renders no chrome for mode:"none".
+    ctx.state.appBar = { mode: "none" };
+```
+
+```tsx
+export default define.page<typeof handler>(function AddItemsPage({ data }) {
+  return (
+    <main class="max-w-md mx-auto">
+      <AddItemsIsland
+        listId={data.list.id}
+        listName={data.list.name}
+        items={data.items}
+        shoppingList={data.shoppingList}
+        categories={data.categories}
+        initialQuery={data.initialQuery}
+      />
+    </main>
+  );
+});
+```
+
+- [ ] **Step 4: Rewrite the island** — replace `islands/add-items.tsx`
+
+```tsx
+import { useEffect, useMemo } from "preact/hooks";
+import { useComputed, useSignal } from "@preact/signals";
+import { For } from "@preact/signals/utils";
+import {
+  CategoryInterface,
+  ItemInterface,
+  ShoppingListItemInterface,
+} from "@/models/index.ts";
+import { useSearchBox, useShoppingList } from "@/hooks/index.ts";
+import { Icon } from "@/components/md3/Icon.tsx";
+import { Button } from "@/components/md3/Button.tsx";
+import { Pressable } from "@/components/md3/Pressable.tsx";
+import { Sheet } from "@/components/md3/Sheet.tsx";
+import { Stepper } from "@/components/md3/Stepper.tsx";
+import { CategoryPickerList } from "@/components/md3/CategoryPickerList.tsx";
+import { CatalogueAddRow } from "@/components/md3/CatalogueAddRow.tsx";
+
+interface AddItemsProps {
+  listId: string;
+  listName: string;
+  items: Required<ItemInterface>[];
+  shoppingList: ShoppingListItemInterface[];
+  categories: CategoryInterface[];
+  initialQuery: string;
+}
+
+export default function AddItems(
+  {
+    listId,
+    listName,
+    items: catalog,
+    shoppingList,
+    categories: initialCategories,
+    initialQuery,
+  }: AddItemsProps,
+) {
+  // Instantiate the signal()-based hook exactly once (see CLAUDE.md).
+  const {
+    addToList,
+    addToCatalog,
+    updateListItem,
+    flushListItem,
+    removeListItem,
+    getItemName,
+    listItemsMap,
+    list,
+    categories,
+    items,
+    selectedCategoryId,
+  } = useMemo(
+    () => useShoppingList(listId, catalog, shoppingList, initialCategories),
+    [],
+  );
+
+  const filterFn = (searchString: string, item: ItemInterface) => {
+    if (searchString.trim() === "") return false;
+    return !!item?.name?.toLowerCase().includes(searchString.toLowerCase());
+  };
+  const { query, results, inputRef } = useSearchBox(
+    catalog,
+    filterFn,
+    initialQuery,
+  );
+
+  // List-item ids added during this visit — the "Added (N)" building cart.
+  const addedThisVisit = useSignal<string[]>([]);
+  // Create-flow category picker sub-screen.
+  const catPicking = useSignal(false);
+  // Compact editor sheet — holds the list-item id being edited (qty + note).
+  const editingId = useSignal<string | null>(null);
+  // "Added (N)" section collapse state (collapsed by default).
+  const addedOpen = useSignal(false);
+
+  // Autofocus the search field on mount for a quick type-to-search flow.
+  useEffect(() => {
+    const t = setTimeout(() => inputRef.current?.focus(), 80);
+    return () => clearTimeout(t);
+  }, []);
+
+  const trackAdded = (liId: string | null) => {
+    if (liId) addedThisVisit.value = [...addedThisVisit.value, liId];
+  };
+
+  const handleAdd = async (itemId: string) => {
+    trackAdded(await addToList(itemId));
+  };
+
+  const handleCreate = async (name: string) => {
+    trackAdded(await addToCatalog(name, selectedCategoryId.value || undefined));
+    selectedCategoryId.value = "";
+    query.value = "";
+    inputRef.current?.focus();
+  };
+
+  const handleRemove = async (liId: string) => {
+    addedThisVisit.value = addedThisVisit.value.filter((id) => id !== liId);
+    if (editingId.value === liId) editingId.value = null;
+    await removeListItem(liId);
+  };
+
+  const closeEditor = () => {
+    const id = editingId.value;
+    if (id) flushListItem(id);
+    editingId.value = null;
+  };
+
+  const q = query.value.trim();
+  const selectedCatLabel =
+    categories.value.find((c) => c.id === selectedCategoryId.value)?.label ??
+      "Uncategorized";
+
+  // Memoized so each row does a Map lookup, not an O(n) find over categories.
+  const catLabelById = useComputed(() =>
+    new Map(categories.value.map((c) => [c.id, c.label ?? ""]))
+  );
+
+  // Render a catalogue item as a row: un-added → Add; added → inline stepper +
+  // tap-to-edit. `withRemove` adds a remove control (Added section only).
+  const catalogueRow = (item: ItemInterface, withRemove: boolean) => {
+    const li = listItemsMap.value.get(item.id ?? "");
+    return (
+      <CatalogueAddRow
+        key={item.id}
+        name={item.name ?? ""}
+        categoryLabel={catLabelById.value.get(item.categoryId ?? "") ?? ""}
+        added={!!li}
+        onAdd={() => {
+          if (item.id) handleAdd(item.id);
+        }}
+        quantity={li?.quantity ?? 1}
+        onQtyChange={(v) => {
+          if (li?.id) updateListItem(li.id, { quantity: v });
+        }}
+        onEdit={() => {
+          if (li?.id) editingId.value = li.id;
+        }}
+        onRemove={withRemove && li?.id ? () => handleRemove(li.id!) : undefined}
+      />
+    );
+  };
+
+  // ── Create-flow category picker sub-screen (replaces the body) ──────────
+  if (catPicking.value) {
+    return (
+      <div class="flex flex-col">
+        <header
+          class="bg-surface sticky top-0 z-20"
+          style={{ paddingTop: "env(safe-area-inset-top)" }}
+        >
+          <div class="flex items-center gap-1 px-1" style={{ height: 56 }}>
+            <Pressable
+              onClick={() => (catPicking.value = false)}
+              aria-label="Back to search"
+              class="grid place-items-center text-on-surface-variant rounded-full shrink-0"
+              style={{ width: 40, height: 40 }}
+            >
+              <Icon name="back" size={22} />
+            </Pressable>
+            <div class="md-title-large text-on-surface">Choose category</div>
+          </div>
+        </header>
+        <div class="px-4 pt-1 pb-28">
+          <CategoryPickerList
+            categories={categories.value}
+            selectedId={selectedCategoryId.value}
+            onSelect={(id) => {
+              selectedCategoryId.value = id;
+              catPicking.value = false;
+            }}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  // ── "Added (N)" building-cart rows (newest first) ───────────────────────
+  const addedRows = addedThisVisit.value
+    .map((liId) => list.value.find((li) => li.id === liId))
+    .filter((li): li is ShoppingListItemInterface => !!li)
+    .reverse();
+
+  const editingLi = editingId.value
+    ? list.value.find((li) => li.id === editingId.value) ?? null
+    : null;
+
+  return (
+    <div class="flex flex-col">
+      {/* Sticky search top bar — this island owns the top region */}
+      <header
+        class="bg-surface sticky top-0 z-20"
+        style={{ paddingTop: "env(safe-area-inset-top)" }}
+      >
+        <div class="flex items-center gap-1 px-1" style={{ height: 56 }}>
+          <a
+            href={`/shopping/${listId}`}
+            aria-label="Back"
+            class="md-press grid place-items-center text-on-surface-variant rounded-full shrink-0"
+            style={{ width: 40, height: 40 }}
+          >
+            <span class="md-state" />
+            <Icon name="back" size={22} />
+          </a>
+          <div class="relative flex-1">
+            <span class="absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant">
+              <Icon name="search" size={20} />
+            </span>
+            <input
+              ref={inputRef}
+              value={query.value}
+              onInput={(e) => {
+                query.value = (e.target as HTMLInputElement).value;
+              }}
+              placeholder="Search or add an item…"
+              class="w-full md-body-large text-on-surface bg-surface-chigh border-0 rounded-[var(--md-shape-full)] py-2.5 pl-10 pr-10 outline-none"
+            />
+            {q && (
+              <Pressable
+                onClick={() => {
+                  query.value = "";
+                  inputRef.current?.focus();
+                }}
+                aria-label="Clear search"
+                class="absolute right-2 top-1/2 -translate-y-1/2 grid place-items-center text-on-surface-variant rounded-full"
+                style={{ width: 32, height: 32 }}
+              >
+                <Icon name="x" size={18} />
+              </Pressable>
+            )}
+          </div>
+        </div>
+      </header>
+
+      <div class="px-4 pt-2 pb-28 flex flex-col gap-2">
+        {/* Context line */}
+        <div class="md-label-medium text-on-surface-variant px-1">
+          Adding to {listName}
+        </div>
+
+        {/* Added (N) — the building cart, collapsed by default */}
+        {addedRows.length > 0 && (
+          <div class="rounded-[var(--md-shape-lg)] bg-surface-chigh overflow-hidden">
+            <Pressable
+              as="div"
+              onClick={() => (addedOpen.value = !addedOpen.value)}
+              class="flex items-center gap-2 px-4 py-3"
+            >
+              <Icon name="check" size={18} class="text-primary" />
+              <span class="md-title-small text-on-surface flex-1">
+                Added · {addedRows.length}
+              </span>
+              <span
+                class="text-on-surface-variant"
+                style={{
+                  transform: addedOpen.value ? "rotate(90deg)" : "rotate(0)",
+                  transition: "transform .15s",
+                  display: "inline-flex",
+                }}
+              >
+                <Icon name="chevron" size={18} />
+              </span>
+            </Pressable>
+            {addedOpen.value && (
+              <div class="flex flex-col pb-1">
+                {addedRows.map((li) => {
+                  const item = items.value.find((i) => i.id === li.itemId);
+                  return item ? catalogueRow(item, true) : null;
+                })}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Main content: idle hint, or create card + live results */}
+        {q
+          ? (() => {
+            // Two intentional predicates: the create card gates on an EXACT
+            // (case-insensitive) match, while `results` is useSearchBox's
+            // SUBSTRING filter — both can legitimately show at once. Do not
+            // unify these.
+            const exact = items.value.some((i) =>
+              i.name?.toLowerCase() === q.toLowerCase()
+            );
+            return (
+              <>
+                {!exact && (
+                  <div class="bg-primary-container text-on-primary-container rounded-[var(--md-shape-lg)] p-3.5 mb-1 flex flex-col gap-3">
+                    <div class="flex items-center gap-3.5">
+                      <span class="w-9 h-9 rounded-full bg-on-primary-container text-primary-container grid place-items-center shrink-0">
+                        <Icon name="plus" size={20} />
+                      </span>
+                      <div class="flex-1 min-w-0">
+                        <div class="md-body-large">Create "{q}"</div>
+                        <div class="md-body-small opacity-80">
+                          New item — pick a category
+                        </div>
+                      </div>
+                    </div>
+                    <Pressable
+                      onClick={() => (catPicking.value = true)}
+                      color="var(--md-on-primary-container)"
+                      class="flex items-center justify-between gap-2 w-full rounded-[var(--md-shape-md)] border border-on-primary-container/40 px-3.5 py-2.5"
+                    >
+                      <span class="md-body-medium opacity-80">Category</span>
+                      <span class="inline-flex items-center gap-1 md-label-large">
+                        {selectedCatLabel} <Icon name="chevron" size={18} />
+                      </span>
+                    </Pressable>
+                    <Button
+                      variant="filled"
+                      full
+                      onClick={() => handleCreate(q)}
+                      style={{
+                        background: "var(--md-on-primary-container)",
+                        color: "var(--md-primary-container)",
+                      }}
+                    >
+                      Add to {selectedCatLabel}
+                    </Button>
+                  </div>
+                )}
+                <div class="flex flex-col">
+                  <For each={results}>{(item) => catalogueRow(item, false)}</For>
+                </div>
+              </>
+            );
+          })()
+          : (
+            <div class="flex flex-col items-center text-center gap-1 px-6 py-16 text-on-surface-variant">
+              <Icon name="search" size={30} />
+              <div class="md-body-large text-on-surface mt-2">
+                Search your catalogue
+              </div>
+              <div class="md-body-medium opacity-80">
+                Find an item to add, or create a new one.
+              </div>
+            </div>
+          )}
+      </div>
+
+      {/* Compact editor sheet — quantity + note */}
+      <Sheet
+        open={editingId.value !== null}
+        onClose={closeEditor}
+        title={editingLi ? getItemName(editingLi.itemId) : ""}
+      >
+        {editingLi && (
+          <div class="flex flex-col gap-1.5 pb-1">
+            <div class="flex items-center justify-between px-1 py-1.5">
+              <span class="md-body-large text-on-surface">Quantity</span>
+              <Stepper
+                value={editingLi.quantity ?? 1}
+                onChange={(v) => updateListItem(editingLi.id!, { quantity: v })}
+              />
+            </div>
+            <div class="h-px bg-surface-chigh mx-1" />
+            <div class="px-1 py-1.5">
+              <div class="md-body-large text-on-surface mb-2">Note</div>
+              <textarea
+                value={editingLi.note ?? ""}
+                onInput={(e) =>
+                  updateListItem(editingLi.id!, {
+                    note: (e.target as HTMLTextAreaElement).value,
+                  })}
+                rows={2}
+                placeholder="e.g. the red ones, big pack, any brand…"
+                class="w-full md-body-large text-on-surface bg-surface-chigh border-0 rounded-[var(--md-shape-lg)] py-3 px-4 outline-none resize-none"
+              />
+            </div>
+            <Button variant="filled" full onClick={closeEditor} class="mt-2.5">
+              Done
+            </Button>
+            <Button
+              variant="error"
+              full
+              onClick={() => handleRemove(editingLi.id!)}
+              class="mt-2"
+            >
+              Remove from list
+            </Button>
+          </div>
+        )}
+      </Sheet>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Run — expect PASS**
+
+Run: `deno test islands/add-items.test.tsx`
+Expected: PASS (all four).
+
+- [ ] **Step 6: Gates**
+
+Run: `deno task check && deno test && deno task build`
+Expected: green (whole suite). `git checkout deno.lock` if it churned.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add routes/shopping/[id]/add.tsx islands/add-items.tsx islands/add-items.test.tsx
+git commit -m "feat(shopping): full-screen search add page with inline tweak + Added cart" \
+  -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Live QA + final gates
+
+**Files:** none (verification only; small fixes committed if QA turns them up).
+
+- [ ] **Step 1: Whole-suite gates**
+
+Run: `deno task check && deno test && deno task build`
+Expected: all green; test count increased (new AppChrome tests + reworked
+CatalogueAddRow / add-items / items tests).
+
+- [ ] **Step 2: Start the dev server and log in**
+
+Start the dev server (via the preview tool / `deno task dev`), log in
+`admin` / `admin`, open a seeded list at `/shopping/<id>`.
+
+- [ ] **Step 3: Verify the flow (mobile viewport)**
+
+Confirm, and capture a screenshot of the add page:
+1. Plan mode shows the **"Add items" FAB** (bottom-right, above the nav); no
+   search bar at the top of the list. Shop mode shows **no FAB**.
+2. Tapping the FAB opens `/shopping/<id>/add` as a **full-screen search**: no
+   shell top bar, **no bottom nav**, a sticky search bar (back arrow + input +
+   clear), autofocused.
+3. Idle shows the **"Search your catalogue"** hint — **no category chips**.
+4. Typing lists matching items **below the bar**; tapping one **adds** it (row
+   flips to a stepper); the **"Added · N"** header appears and increments.
+5. The added row's **inline stepper** changes quantity; tapping the row opens
+   the **editor sheet** (quantity + note); **Done** closes it; the note/qty
+   persist.
+6. Expanding **"Added · N"** lists this visit's items; **remove (×)** drops one
+   and decrements N; N=0 hides the section.
+7. A no-match query shows **Create "<q>"** → category picker → **Add** creates +
+   adds + resets to idle, and the item appears in "Added".
+8. **Back** returns to the list; added items appear grouped with the right
+   quantities/notes.
+9. `read_console_messages` / `preview_logs` show **no errors**; adds/edits fire
+   successful requests (`read_network_requests`).
+
+- [ ] **Step 4: Address any QA findings**
+
+If QA surfaces a defect, fix the source, re-run the gates, and commit with a
+`fix(...)` message (+ the co-author trailer). If QA is clean, no commit.
+
+- [ ] **Step 5: Finish the branch**
+
+Use superpowers:finishing-a-development-branch to push and open the PR (base
+branch: `feat/fullscreen-add-items` while PR #26 is open; otherwise `develop`).
+PR body ends with `🤖 Generated with [Claude Code](https://claude.com/claude-code)`.
+
+---
+
+## Self-Review (author checklist — done before handing off)
+
+- **Spec coverage:** FAB entry (T3) ✓; retire quick-add sheet (T3) ✓;
+  `mode: "none"` full-screen surface, no top bar + no bottom nav (T1 + T4) ✓;
+  sticky island search bar (T4) ✓; clean search-first idle, no chips (T4) ✓;
+  add → inline qty + tap-for-note editor sheet (T2 + T4) ✓; pinned "Added (N)"
+  (T4) ✓; create-on-no-match kept (T4) ✓; no API/data changes ✓; tests (all
+  tasks) ✓.
+- **Placeholder scan:** every code step carries complete code or an exact edit;
+  no TBD/TODO.
+- **Type consistency:** `CatalogueAddRow` props defined in T2 are exactly those
+  consumed by `catalogueRow` in T4; `AppBar`/`mode: "none"` defined in T1 is
+  what `add.tsx` sets in T4; both adders return the list-item id, which is what
+  `addedThisVisit` / `listItemsMap` / the editor all key on.

--- a/docs/superpowers/specs/2026-07-19-add-items-fab-search-flow-design.md
+++ b/docs/superpowers/specs/2026-07-19-add-items-fab-search-flow-design.md
@@ -1,0 +1,233 @@
+# Add-Items FAB + Full-Screen Search Flow — Design
+
+**Date:** 2026-07-19
+**Branch base:** builds on `feat/fullscreen-add-items` (PR #26 — the dedicated
+`/shopping/[id]/add` route + fixed-height sheet). This iteration reworks the
+*entry* into that page and the page itself.
+**Module:** Shopping list (first module of the Happie household platform).
+
+## Goal
+
+Replace the list page's "dummy search bar that opens a bottom sheet" with a
+Floating Action Button that opens a dedicated, full-screen **search-to-add**
+page, and make that page a fast loop: **search → add → tweak quantity/note →
+repeat → back**, without a round-trip to the list.
+
+## Background — current state
+
+- **List page** (`islands/items.tsx`, Plan mode): a `SearchBar` that, on tap,
+  opens a quick-add bottom `Sheet`. The sheet has its own search input, live
+  results, and hand-off controls to the full-screen page. There is also an
+  **item-editor sheet** (quantity, category, note, remove) and a
+  **list-options sheet** (rename, share, clear, delete).
+- **Add page** (`routes/shopping/[id]/add.tsx` + `islands/add-items.tsx`):
+  reached from the quick-add sheet. Shell renders a `detail` top app bar
+  ("Add items" + back) and the app-wide bottom `NavigationBar`. Idle state
+  shows **category filter chips**; typing shows a create-on-no-match card +
+  substring results.
+- **Shell** (`islands/shell/AppChrome.tsx`): renders `TopAppBar` (detail bar
+  when `ctx.state.appBar` is set, else a section-title bar) and **always**
+  renders `NavigationBar`. `ctx.state.appBar` is typed `AppBarDetail`
+  (`{ mode: "detail"; title; backUrl }`) in `utils/define.ts` — the `mode`
+  discriminator was built to extend.
+- **Data:** `useShoppingList(listId, catalog, shoppingList, categories)` already
+  owns all list state and mutations (`addToList` → new list-item id,
+  `addToCatalog(name, categoryId?)` → creates catalogue item **and** adds it,
+  `updateListItem`, `flushListItem`, `removeListItem`, `getItemName`,
+  `listItemsMap`, `list`, `groupedList`). **No new data model or API is
+  needed.**
+
+## User journey
+
+1. On a list (Plan mode), tap the **"Add items"** FAB → full-screen add page.
+2. Type into the search bar → **results appear in a list below it**.
+3. Tap a result → it's **added** (quantity 1), optimistically. The row flips to
+   an "added" state.
+4. Bump **quantity** with the inline stepper on the added row (instant, no
+   sheet). Or tap the added row → a compact **editor sheet** (quantity + note)
+   → type a note → **Done**.
+5. Everything added this visit collects in a pinned **"Added (N)"** section,
+   reachable to re-tweak after you've searched for something else.
+6. No match? A **"Create '<query>'"** card lets you pick a category and add a
+   brand-new catalogue item.
+7. Tap **back** (in the search bar) → return to the list. Nothing to save —
+   adds and edits were already committed.
+
+## Design
+
+### 1. Entry: FAB on the list, retire the quick-add sheet
+
+`islands/items.tsx`:
+
+- **Remove** the `SearchBar` (which opened the quick-add sheet) and the entire
+  **quick-add `Sheet`** with its machinery: the in-sheet `useSearchBox` usage
+  (`query`, `results`, `inputRef`, `reset`, `filterFn`), `handleAddToList`, the
+  autofocus effect keyed on `addOpen`, `openAddPage`, and the `addOpen` signal.
+  Drop now-unused imports (`SearchBar`, `CatalogueAddRow`, `useSearchBox`) and
+  hook returns used only by the sheet (`addToList`, `listItemsMap`). Keep
+  `items`, `categories`, `getItemName` — still used by the item-editor sheet.
+- The **item-editor sheet** and **list-options sheet** are untouched.
+- **Add** an extended FAB, reusing `islands/shell/Fab.tsx`, shown **only in Plan
+  mode**, placed exactly like the lists index
+  (`islands/shopping-lists.tsx`): a wrapper `fixed right-4 z-30` at
+  `bottom: calc(96px + env(safe-area-inset-bottom))`, containing
+  `<Fab icon="plus" label="Add items" aria-label="Add items"
+  onClick={() => globalThis.location.href = ` + "`/shopping/${listId}/add`" + `} />`.
+- **Empty-state copy:** "Tap the search bar to add items." → "Tap **Add items**
+  to get started."
+
+### 2. Full-screen search surface — shell `{ mode: "none" }`
+
+The search query lives in the add island, so the *island* owns the top bar and
+the shell renders no chrome on this route.
+
+- `utils/define.ts`: extend the union.
+  ```ts
+  export interface AppBarDetail { mode: "detail"; title: string; backUrl: string }
+  export interface AppBarNone { mode: "none" } // route owns the full screen
+  export type AppBar = AppBarDetail | AppBarNone;
+  // StateInterface.appBar?: AppBar
+  ```
+- `routes/_app.tsx`: pass the discriminated `state.appBar` through to
+  `AppChrome` (instead of the flattened `{ title, backUrl }`).
+- `islands/shell/AppChrome.tsx`: prop becomes `appBar?: AppBar`.
+  - `appBar?.mode === "none"` → render **nothing** (no `TopAppBar`, no
+    `NavigationBar`, no `MoreSheet`).
+  - `appBar?.mode === "detail"` → today's detail bar + nav + more sheet.
+  - `undefined` → section-title bar + nav + more sheet (unchanged).
+- `routes/shopping/[id]/add.tsx`: set `ctx.state.appBar = { mode: "none" }` and
+  drop the `p-4` on `<main>` (the island manages full-width layout). Keep the
+  `?q=` read (`initialQuery`) — harmless and lets future entry points prefill.
+
+The app-wide `body { padding-bottom: calc(80px + safe-area) }` in `_app.tsx`
+stays; the small dead space below the last result on a nav-less page is
+harmless.
+
+### 3. Add page body — clean search-first
+
+`islands/add-items.tsx` renders (top to bottom):
+
+- **Sticky search top bar** (island's first element): a leading **back arrow**
+  (`<a href={` + "`/shopping/${listId}`" + `}>` with `Icon name="back"`, matching
+  `TopAppBar`), the text `input` (autofocused on mount), and a trailing
+  **clear (×)** shown only when there's text. Styling mirrors `TopAppBar`:
+  `bg-surface`, ~56px row, `padding-top: env(safe-area-inset-top)`,
+  `position: sticky; top: 0; z-index` above the list so results scroll under it.
+- **Context line:** "Adding to {listName}".
+- **Pinned "Added (N)" section** (see §5) — visible only when N ≥ 1.
+- **Main content:**
+  - **Idle** (empty query): a centered **hint** — `Icon name="search"` +
+    "Search your catalogue" + the subline "Find an item to add, or create a
+    new one." **No category chips** — remove `filterCatId`,
+    `chipCats`, `chipRow`, and the chip/category branch.
+  - **Typing:** the **create-on-no-match** card (kept as-is: exact-match gate →
+    category picker sub-view → `addToCatalog`) followed by the **live results
+    list** (substring match, one row per catalogue item).
+
+### 4. Add → tweak: inline quantity + note editor sheet
+
+- **Results row** (evolve `CatalogueAddRow`, now add-page-only): when the item
+  is **not** on the list, trailing shows an **"Add"** affordance. Once added,
+  the trailing shows a compact **`Stepper`** bound to the list item's quantity
+  (`updateListItem(listItemId, { quantity })`), and the **row body becomes
+  tappable** to open the editor sheet. This covers the immediate "add then
+  tweak" case while the query is unchanged.
+- **Editor sheet** (new, compact — reuses `Sheet` + `Stepper`): opened via an
+  `editingId` signal in the add island. Fields: **quantity** stepper + **note**
+  `textarea` + **Done** + **Remove from list**. `flushListItem(id)` on Done and
+  on close. **No category field here** — you don't re-file an item mid-add
+  (category is set at create time or on the list page). This is intentionally
+  *not* the list page's full editor (which carries category + a saved pill);
+  the field sets genuinely differ, so we keep a small focused sheet rather than
+  a flag-riddled shared component.
+
+### 5. Pinned "Added (N)" section — the building cart
+
+- Track items added **this visit** in a signal `addedThisVisit:
+  Set<itemId>`. `handleAdd`/`handleCreate` add the returned item id; **Remove**
+  deletes it (and calls `removeListItem`).
+- Render as a **collapsible** block pinned under the search bar, **collapsed by
+  default**, header "Added · N" with a chevron. It replaces the old
+  "· N added" counter (the count lives in the header now). Newest add first.
+- Expanded rows: name + inline **`Stepper`** (quantity) + tap-to-edit (opens the
+  §4 sheet) + a **remove (×)**. Rows read from the hook's list state filtered to
+  `addedThisVisit`, so quantities/notes stay in sync with edits made anywhere.
+- An item can briefly appear both in the results (as "added") and in this
+  section — expected, like a store's product list + cart. Collapsed-by-default
+  keeps that duplication out of sight until the user opens it.
+
+## Components
+
+**New**
+- Add-page **editor sheet** (inline in `add-items.tsx`): `Sheet` with `Stepper`
+  + note `textarea` + Done + Remove.
+- **"Added (N)"** collapsible section (inline in `add-items.tsx`).
+
+**Changed**
+- `utils/define.ts` — `AppBar` union (`detail | none`).
+- `routes/_app.tsx` — thread the union to `AppChrome`.
+- `islands/shell/AppChrome.tsx` — handle `mode: "none"` (render no chrome).
+- `routes/shopping/[id]/add.tsx` — `appBar: { mode: "none" }`; drop `p-4`.
+- `islands/add-items.tsx` — sticky search bar; remove chips; add editor sheet +
+  Added section; wire `updateListItem`/`flushListItem`/`removeListItem`/
+  `getItemName`.
+- `islands/items.tsx` — remove `SearchBar` + quick-add sheet; add FAB; empty
+  copy.
+- `components/md3/CatalogueAddRow.tsx` — added-state (inline `Stepper` +
+  tappable body); optional `onRemove`.
+
+**Reused unchanged**
+- `islands/shell/Fab.tsx`, `hooks/useShoppingList.ts`, `hooks/useSearchBox.ts`,
+  `components/md3/{Sheet,Stepper,CategoryPickerList,Icon,Pressable,Button}.tsx`.
+
+## Data flow — no API changes
+
+All mutations go through the existing `useShoppingList` instance in the add
+island: `addToList` / `addToCatalog` (add), `updateListItem` (quantity/note,
+debounced), `flushListItem` (commit on Done/close), `removeListItem` (remove).
+The list page re-reads state on navigation back (server-rendered), so adds/edits
+are reflected. No repositories, `services/api.ts`, endpoints, or KV schema
+change.
+
+## Edge cases & error handling
+
+- **Idle with prior adds:** hint shows below the pinned "Added (N)" header.
+- **Add then keep typing:** the added row filters out of results when it no
+  longer matches — that's why the "Added (N)" section exists (persistent home).
+- **Remove the last added item:** "Added (N)" header hides when N returns to 0.
+- **Create then edit:** `addToCatalog` returns the new id; it enters
+  `addedThisVisit` like any add and is immediately tweakable.
+- **Optimistic failure:** unchanged from today's hook behavior (out of scope —
+  a shared rollback/snackbar is already tracked as a separate follow-up).
+- **Back navigation:** a plain link; no unsaved state to guard.
+
+## Testing
+
+- `islands/items.test.tsx` — assert the **FAB "Add items"** renders in Plan
+  mode and the quick-add `SearchBar`/sheet strings are **gone**.
+- `islands/add-items.test.tsx` — assert the **sticky search bar** + **idle hint**
+  render, **category chips are gone**, typing yields results + the create card,
+  and (SSR-level) the "Added" section header appears when seeded with a visit
+  add. Keep assertions SSR-render-level (the suite has no DOM/nav harness).
+- `components/md3/CatalogueAddRow.test.tsx` — cover the added-state (stepper +
+  tappable) alongside the not-added "Add" state.
+- Gates: `deno task check` && `deno test` && `deno task build`, then live QA in
+  the browser (admin/admin, seeded KV, mobile viewport).
+
+## Out of scope (v1)
+
+- Hiding/adjusting the app-wide `body` bottom padding for the nav-less page.
+- Sharing one editor component across the list and add pages (field sets
+  differ; revisit only if they converge).
+- A shared optimistic-rollback + failure snackbar (already a separate
+  follow-up).
+- Sticky "Added (N)" header (v1 scrolls with content; revisit in QA).
+- Recency/frequency-ranked suggestions in the idle state.
+
+## Resolved decisions
+
+- Idle = **clean search-first** (no chips).
+- Search bar = **the top bar** (canonical MD3 full-screen search).
+- Bottom nav = **hidden** on the add page (fully immersive).
+- Add→tweak = **inline quantity + tap-for-note sheet**, with a **pinned
+  "Added (N)"** section.

--- a/islands/add-items.test.tsx
+++ b/islands/add-items.test.tsx
@@ -27,9 +27,12 @@ Deno.test("AddItems — a back link to the list is always present", () => {
   assertStringIncludes(html, `href="/shopping/l1"`);
 });
 
-Deno.test("AddItems — a matching query lists the catalogue item", () => {
+Deno.test("AddItems — matching query: results first, Create action below", () => {
   const html = render(h(AddItems, { ...base, initialQuery: "But" }));
   assertStringIncludes(html, "Butter");
+  // "But" has no exact match, so the Create action shows too — but BELOW the
+  // results: existing matches lead, create-new is the fallback.
+  assert(html.indexOf("Butter") < html.indexOf("Create &quot;But&quot;"));
 });
 
 Deno.test("AddItems — a no-match query shows the Create card", () => {

--- a/islands/add-items.test.tsx
+++ b/islands/add-items.test.tsx
@@ -27,16 +27,18 @@ Deno.test("AddItems — a back link to the list is always present", () => {
   assertStringIncludes(html, `href="/shopping/l1"`);
 });
 
-Deno.test("AddItems — matching query: results first, Create action below", () => {
+Deno.test("AddItems — matching query: results first, then a slim Create row (not the card)", () => {
   const html = render(h(AddItems, { ...base, initialQuery: "But" }));
   assertStringIncludes(html, "Butter");
-  // "But" has no exact match, so the Create action shows too — but BELOW the
-  // results: existing matches lead, create-new is the fallback.
+  // "But" has no exact match, so a Create affordance shows too — but BELOW the
+  // results and as a slim row, NOT the prominent card.
   assert(html.indexOf("Butter") < html.indexOf("Create &quot;But&quot;"));
+  assert(!html.includes("New item")); // de-emphasized: slim row, not the full card
 });
 
-Deno.test("AddItems — a no-match query shows the Create card", () => {
+Deno.test("AddItems — no-match query shows the full Create card", () => {
   const html = render(h(AddItems, { ...base, initialQuery: "Tofu" }));
   // preact-render-to-string HTML-escapes the literal quotes in Create "{q}".
   assertStringIncludes(html, "Create &quot;Tofu&quot;");
+  assertStringIncludes(html, "New item"); // no matches → the prominent card
 });

--- a/islands/add-items.test.tsx
+++ b/islands/add-items.test.tsx
@@ -14,12 +14,17 @@ const base = {
   ],
 };
 
-Deno.test("AddItems — idle shows category chips and no item rows", () => {
+Deno.test("AddItems — idle: search-first hint, no chips, no rows", () => {
   const html = render(h(AddItems, { ...base, initialQuery: "" }));
-  assertStringIncludes(html, "Dairy");
-  assertStringIncludes(html, "Bakery");
-  assertStringIncludes(html, "Adding to Groceries");
+  assertStringIncludes(html, "Search your catalogue"); // idle hint
+  assertStringIncludes(html, "Adding to Groceries"); // context line
   assert(!html.includes("Butter")); // no catalogue rows when idle
+  assert(!html.includes("Bakery")); // category chips are gone
+});
+
+Deno.test("AddItems — a back link to the list is always present", () => {
+  const html = render(h(AddItems, { ...base, initialQuery: "" }));
+  assertStringIncludes(html, `href="/shopping/l1"`);
 });
 
 Deno.test("AddItems — a matching query lists the catalogue item", () => {
@@ -27,10 +32,8 @@ Deno.test("AddItems — a matching query lists the catalogue item", () => {
   assertStringIncludes(html, "Butter");
 });
 
-Deno.test("AddItems — a query with no match shows the Create card", () => {
+Deno.test("AddItems — a no-match query shows the Create card", () => {
   const html = render(h(AddItems, { ...base, initialQuery: "Tofu" }));
-  // preact-render-to-string HTML-escapes literal quote characters in JSX text
-  // (Create "{q}" → Create &quot;Tofu&quot;); this is correct/safe serialization,
-  // so the assertion matches the escaped form rather than fighting it.
+  // preact-render-to-string HTML-escapes the literal quotes in Create "{q}".
   assertStringIncludes(html, "Create &quot;Tofu&quot;");
 });

--- a/islands/add-items.tsx
+++ b/islands/add-items.tsx
@@ -9,8 +9,9 @@ import {
 import { useSearchBox, useShoppingList } from "@/hooks/index.ts";
 import { Icon } from "@/components/md3/Icon.tsx";
 import { Button } from "@/components/md3/Button.tsx";
-import { Chip } from "@/components/md3/Chip.tsx";
 import { Pressable } from "@/components/md3/Pressable.tsx";
+import { Sheet } from "@/components/md3/Sheet.tsx";
+import { Stepper } from "@/components/md3/Stepper.tsx";
 import { CategoryPickerList } from "@/components/md3/CategoryPickerList.tsx";
 import { CatalogueAddRow } from "@/components/md3/CatalogueAddRow.tsx";
 
@@ -37,7 +38,12 @@ export default function AddItems(
   const {
     addToList,
     addToCatalog,
+    updateListItem,
+    flushListItem,
+    removeListItem,
+    getItemName,
     listItemsMap,
+    list,
     categories,
     items,
     selectedCategoryId,
@@ -56,11 +62,14 @@ export default function AddItems(
     initialQuery,
   );
 
-  // null = no chip filter; "" = the Uncategorized chip; else a category id.
-  const filterCatId = useSignal<string | null>(null);
-  const addedCount = useSignal(0);
-  // Category-picker sub-view (mirrors the sheet's proven pattern, with room).
+  // List-item ids added during this visit — the "Added (N)" building cart.
+  const addedThisVisit = useSignal<string[]>([]);
+  // Create-flow category picker sub-screen.
   const catPicking = useSignal(false);
+  // Compact editor sheet — holds the list-item id being edited (qty + note).
+  const editingId = useSignal<string | null>(null);
+  // "Added (N)" section collapse state (collapsed by default).
+  const addedOpen = useSignal(false);
 
   // Autofocus the search field on mount for a quick type-to-search flow.
   useEffect(() => {
@@ -68,17 +77,31 @@ export default function AddItems(
     return () => clearTimeout(t);
   }, []);
 
+  const trackAdded = (liId: string | null) => {
+    if (liId) addedThisVisit.value = [...addedThisVisit.value, liId];
+  };
+
   const handleAdd = async (itemId: string) => {
-    const id = await addToList(itemId);
-    if (id) addedCount.value++;
+    trackAdded(await addToList(itemId));
   };
 
   const handleCreate = async (name: string) => {
-    const id = await addToCatalog(name, selectedCategoryId.value || undefined);
-    if (id) addedCount.value++;
+    trackAdded(await addToCatalog(name, selectedCategoryId.value || undefined));
     selectedCategoryId.value = "";
     query.value = "";
     inputRef.current?.focus();
+  };
+
+  const handleRemove = async (liId: string) => {
+    addedThisVisit.value = addedThisVisit.value.filter((id) => id !== liId);
+    if (editingId.value === liId) editingId.value = null;
+    await removeListItem(liId);
+  };
+
+  const closeEditor = () => {
+    const id = editingId.value;
+    if (id) flushListItem(id);
+    editingId.value = null;
   };
 
   const q = query.value.trim();
@@ -86,183 +109,279 @@ export default function AddItems(
     categories.value.find((c) => c.id === selectedCategoryId.value)?.label ??
       "Uncategorized";
 
-  // Memoized so the large-catalogue hot path (every row, every render) does a
-  // Map lookup instead of an O(n) `.find` scan over all categories.
+  // Memoized so each row does a Map lookup, not an O(n) find over categories.
   const catLabelById = useComputed(() =>
     new Map(categories.value.map((c) => [c.id, c.label ?? ""]))
   );
 
-  const chipCats = useComputed(() =>
-    [...categories.value].sort((a, b) =>
-      (a.label ?? "").toLowerCase().localeCompare(
-        (b.label ?? "").toLowerCase(),
-      )
-    )
-  );
-
-  const row = (item: ItemInterface) => (
-    <CatalogueAddRow
-      key={item.id}
-      name={item.name ?? ""}
-      categoryLabel={catLabelById.value.get(item.categoryId ?? "") ?? ""}
-      added={listItemsMap.value.has(item.id ?? "")}
-      onAdd={() => item.id && handleAdd(item.id)}
-    />
-  );
-
-  const chipRow = (
-    <div
-      class="flex gap-2 overflow-x-auto px-1 pb-1"
-      style={{ scrollbarWidth: "none" }}
-    >
-      {chipCats.value.map((c) => (
-        <Chip
-          key={c.id}
-          selected={filterCatId.value === c.id}
-          onClick={() => {
-            filterCatId.value = filterCatId.value === c.id
-              ? null
-              : (c.id ?? null);
-          }}
-        >
-          {c.label}
-        </Chip>
-      ))}
-      <Chip
-        selected={filterCatId.value === ""}
-        onClick={() => {
-          filterCatId.value = filterCatId.value === "" ? null : "";
+  // Render a catalogue item as a row: un-added → Add; added → inline stepper +
+  // tap-to-edit. `withRemove` adds a remove control (Added section only).
+  const catalogueRow = (item: ItemInterface, withRemove: boolean) => {
+    const li = listItemsMap.value.get(item.id ?? "");
+    return (
+      <CatalogueAddRow
+        key={item.id}
+        name={item.name ?? ""}
+        categoryLabel={catLabelById.value.get(item.categoryId ?? "") ?? ""}
+        added={!!li}
+        onAdd={() => {
+          if (item.id) handleAdd(item.id);
         }}
-      >
-        Uncategorized
-      </Chip>
-    </div>
-  );
+        quantity={li?.quantity ?? 1}
+        onQtyChange={(v) => {
+          if (li?.id) updateListItem(li.id, { quantity: v });
+        }}
+        onEdit={() => {
+          if (li?.id) editingId.value = li.id;
+        }}
+        onRemove={withRemove && li?.id ? () => handleRemove(li.id!) : undefined}
+      />
+    );
+  };
 
-  // ── Category-picker sub-view (replaces the body while choosing) ──
+  // ── Create-flow category picker sub-screen (replaces the body) ──────────
   if (catPicking.value) {
     return (
-      <div class="flex flex-col gap-2 pb-24">
-        <div class="md-title-medium text-on-surface px-1">Choose category</div>
-        <CategoryPickerList
-          categories={categories.value}
-          selectedId={selectedCategoryId.value}
-          onSelect={(id) => {
-            selectedCategoryId.value = id;
-            catPicking.value = false;
-          }}
-        />
+      <div class="flex flex-col">
+        <header
+          class="bg-surface sticky top-0 z-20"
+          style={{ paddingTop: "env(safe-area-inset-top)" }}
+        >
+          <div class="flex items-center gap-1 px-1" style={{ height: 56 }}>
+            <Pressable
+              onClick={() => (catPicking.value = false)}
+              aria-label="Back to search"
+              class="grid place-items-center text-on-surface-variant rounded-full shrink-0"
+              style={{ width: 40, height: 40 }}
+            >
+              <Icon name="back" size={22} />
+            </Pressable>
+            <div class="md-title-large text-on-surface">Choose category</div>
+          </div>
+        </header>
+        <div class="px-4 pt-1 pb-28">
+          <CategoryPickerList
+            categories={categories.value}
+            selectedId={selectedCategoryId.value}
+            onSelect={(id) => {
+              selectedCategoryId.value = id;
+              catPicking.value = false;
+            }}
+          />
+        </div>
       </div>
     );
   }
 
+  // ── "Added (N)" building-cart rows (newest first) ───────────────────────
+  const addedRows = addedThisVisit.value
+    .map((liId) => list.value.find((li) => li.id === liId))
+    .filter((li): li is ShoppingListItemInterface => !!li)
+    .reverse();
+
+  const editingLi = editingId.value
+    ? list.value.find((li) => li.id === editingId.value) ?? null
+    : null;
+
   return (
-    <div class="flex flex-col gap-3 pb-24">
-      {/* Search field */}
-      <div class="relative">
-        <span class="absolute left-4 top-1/2 -translate-y-1/2 text-on-surface-variant">
-          <Icon name="search" size={20} />
-        </span>
-        <input
-          ref={inputRef}
-          value={query.value}
-          onInput={(e) => {
-            query.value = (e.target as HTMLInputElement).value;
-            filterCatId.value = null; // typing overrides the chip filter
-          }}
-          placeholder="Search or add an item…"
-          class="w-full md-body-large text-on-surface bg-surface-chigh border-0 rounded-[var(--md-shape-full)] py-3.5 pl-11 pr-4 outline-none"
-        />
-      </div>
+    <div class="flex flex-col">
+      {/* Sticky search top bar — this island owns the top region */}
+      <header
+        class="bg-surface sticky top-0 z-20"
+        style={{ paddingTop: "env(safe-area-inset-top)" }}
+      >
+        <div class="flex items-center gap-1 px-1" style={{ height: 56 }}>
+          <a
+            href={`/shopping/${listId}`}
+            aria-label="Back"
+            class="md-press grid place-items-center text-on-surface-variant rounded-full shrink-0"
+            style={{ width: 40, height: 40 }}
+          >
+            <span class="md-state" />
+            <Icon name="back" size={22} />
+          </a>
+          <div class="relative flex-1">
+            <span class="absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant">
+              <Icon name="search" size={20} />
+            </span>
+            <input
+              ref={inputRef}
+              value={query.value}
+              onInput={(e) => {
+                query.value = (e.target as HTMLInputElement).value;
+              }}
+              placeholder="Search or add an item…"
+              class="w-full md-body-large text-on-surface bg-surface-chigh border-0 rounded-[var(--md-shape-full)] py-2.5 pl-10 pr-10 outline-none"
+            />
+            {q && (
+              <Pressable
+                onClick={() => {
+                  query.value = "";
+                  inputRef.current?.focus();
+                }}
+                aria-label="Clear search"
+                class="absolute right-2 top-1/2 -translate-y-1/2 grid place-items-center text-on-surface-variant rounded-full"
+                style={{ width: 32, height: 32 }}
+              >
+                <Icon name="x" size={18} />
+              </Pressable>
+            )}
+          </div>
+        </div>
+      </header>
 
-      {/* Running count sub-header */}
-      <div class="md-label-medium text-on-surface-variant px-1">
-        Adding to {listName}
-        {addedCount.value > 0 ? ` · ${addedCount.value} added` : ""}
-      </div>
+      <div class="px-4 pt-2 pb-28 flex flex-col gap-2">
+        {/* Context line */}
+        <div class="md-label-medium text-on-surface-variant px-1">
+          Adding to {listName}
+        </div>
 
-      {(() => {
-        // Typing → text search across the whole catalogue.
-        if (q) {
-          // Intentionally two different predicates: the create card gates on
-          // an EXACT (case-insensitive) match, while `results` below comes
-          // from useSearchBox's SUBSTRING filter — so both can legitimately
-          // show at once (e.g. "Milk" exact-matches while "Milkshake" still
-          // shows as a substring result). Do not unify these.
-          const exact = items.value.some((i) =>
-            i.name?.toLowerCase() === q.toLowerCase()
-          );
-          return (
-            <>
-              {!exact && (
-                <div class="bg-primary-container text-on-primary-container rounded-[var(--md-shape-lg)] p-3.5 mb-1 flex flex-col gap-3">
-                  <div class="flex items-center gap-3.5">
-                    <span class="w-9 h-9 rounded-full bg-on-primary-container text-primary-container grid place-items-center shrink-0">
-                      <Icon name="plus" size={20} />
-                    </span>
-                    <div class="flex-1 min-w-0">
-                      <div class="md-body-large">Create "{q}"</div>
-                      <div class="md-body-small opacity-80">
-                        New item — pick a category
+        {/* Added (N) — the building cart, collapsed by default */}
+        {addedRows.length > 0 && (
+          <div class="rounded-[var(--md-shape-lg)] bg-surface-chigh overflow-hidden">
+            <Pressable
+              as="div"
+              onClick={() => (addedOpen.value = !addedOpen.value)}
+              class="flex items-center gap-2 px-4 py-3"
+            >
+              <Icon name="check" size={18} class="text-primary" />
+              <span class="md-title-small text-on-surface flex-1">
+                Added · {addedRows.length}
+              </span>
+              <span
+                class="text-on-surface-variant"
+                style={{
+                  transform: addedOpen.value ? "rotate(90deg)" : "rotate(0)",
+                  transition: "transform .15s",
+                  display: "inline-flex",
+                }}
+              >
+                <Icon name="chevron" size={18} />
+              </span>
+            </Pressable>
+            {addedOpen.value && (
+              <div class="flex flex-col pb-1">
+                {addedRows.map((li) => {
+                  const item = items.value.find((i) => i.id === li.itemId);
+                  return item ? catalogueRow(item, true) : null;
+                })}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Main content: idle hint, or create card + live results */}
+        {q
+          ? (() => {
+            // Two intentional predicates: the create card gates on an EXACT
+            // (case-insensitive) match, while `results` is useSearchBox's
+            // SUBSTRING filter — both can legitimately show at once. Do not
+            // unify these.
+            const exact = items.value.some((i) =>
+              i.name?.toLowerCase() === q.toLowerCase()
+            );
+            return (
+              <>
+                {!exact && (
+                  <div class="bg-primary-container text-on-primary-container rounded-[var(--md-shape-lg)] p-3.5 mb-1 flex flex-col gap-3">
+                    <div class="flex items-center gap-3.5">
+                      <span class="w-9 h-9 rounded-full bg-on-primary-container text-primary-container grid place-items-center shrink-0">
+                        <Icon name="plus" size={20} />
+                      </span>
+                      <div class="flex-1 min-w-0">
+                        <div class="md-body-large">Create "{q}"</div>
+                        <div class="md-body-small opacity-80">
+                          New item — pick a category
+                        </div>
                       </div>
                     </div>
+                    <Pressable
+                      onClick={() => (catPicking.value = true)}
+                      color="var(--md-on-primary-container)"
+                      class="flex items-center justify-between gap-2 w-full rounded-[var(--md-shape-md)] border border-on-primary-container/40 px-3.5 py-2.5"
+                    >
+                      <span class="md-body-medium opacity-80">Category</span>
+                      <span class="inline-flex items-center gap-1 md-label-large">
+                        {selectedCatLabel} <Icon name="chevron" size={18} />
+                      </span>
+                    </Pressable>
+                    <Button
+                      variant="filled"
+                      full
+                      onClick={() => handleCreate(q)}
+                      style={{
+                        background: "var(--md-on-primary-container)",
+                        color: "var(--md-primary-container)",
+                      }}
+                    >
+                      Add to {selectedCatLabel}
+                    </Button>
                   </div>
-                  <Pressable
-                    onClick={() => {
-                      catPicking.value = true;
-                    }}
-                    color="var(--md-on-primary-container)"
-                    class="flex items-center justify-between gap-2 w-full rounded-[var(--md-shape-md)] border border-on-primary-container/40 px-3.5 py-2.5"
-                  >
-                    <span class="md-body-medium opacity-80">Category</span>
-                    <span class="inline-flex items-center gap-1 md-label-large">
-                      {selectedCatLabel} <Icon name="chevron" size={18} />
-                    </span>
-                  </Pressable>
-                  <Button
-                    variant="filled"
-                    full
-                    onClick={() => handleCreate(q)}
-                    style={{
-                      background: "var(--md-on-primary-container)",
-                      color: "var(--md-primary-container)",
-                    }}
-                  >
-                    Add to {selectedCatLabel}
-                  </Button>
+                )}
+                <div class="flex flex-col">
+                  <For each={results}>
+                    {(item) => catalogueRow(item, false)}
+                  </For>
                 </div>
-              )}
-              <div class="flex flex-col">
-                <For each={results}>{(item) => row(item)}</For>
+              </>
+            );
+          })()
+          : (
+            <div class="flex flex-col items-center text-center gap-1 px-6 py-16 text-on-surface-variant">
+              <Icon name="search" size={30} />
+              <div class="md-body-large text-on-surface mt-2">
+                Search your catalogue
               </div>
-            </>
-          );
-        }
-
-        // Chip selected → that category's catalogue items.
-        if (filterCatId.value !== null) {
-          const catId = filterCatId.value;
-          const inCat = items.value.filter((i) =>
-            catId === "" ? !i.categoryId : i.categoryId === catId
-          );
-          return (
-            <>
-              {chipRow}
-              <div class="flex flex-col">
-                {inCat.map((item) => row(item))}
+              <div class="md-body-medium opacity-80">
+                Find an item to add, or create a new one.
               </div>
-              {inCat.length === 0 && (
-                <p class="md-body-medium text-on-surface-variant px-1 py-3.5">
-                  Nothing in this category yet.
-                </p>
-              )}
-            </>
-          );
-        }
+            </div>
+          )}
+      </div>
 
-        // Idle → chips only.
-        return chipRow;
-      })()}
+      {/* Compact editor sheet — quantity + note */}
+      <Sheet
+        open={editingId.value !== null}
+        onClose={closeEditor}
+        title={editingLi ? getItemName(editingLi.itemId) : ""}
+      >
+        {editingLi && (
+          <div class="flex flex-col gap-1.5 pb-1">
+            <div class="flex items-center justify-between px-1 py-1.5">
+              <span class="md-body-large text-on-surface">Quantity</span>
+              <Stepper
+                value={editingLi.quantity ?? 1}
+                onChange={(v) => updateListItem(editingLi.id!, { quantity: v })}
+              />
+            </div>
+            <div class="h-px bg-surface-chigh mx-1" />
+            <div class="px-1 py-1.5">
+              <div class="md-body-large text-on-surface mb-2">Note</div>
+              <textarea
+                value={editingLi.note ?? ""}
+                onInput={(e) =>
+                  updateListItem(editingLi.id!, {
+                    note: (e.target as HTMLTextAreaElement).value,
+                  })}
+                rows={2}
+                placeholder="e.g. the red ones, big pack, any brand…"
+                class="w-full md-body-large text-on-surface bg-surface-chigh border-0 rounded-[var(--md-shape-lg)] py-3 px-4 outline-none resize-none"
+              />
+            </div>
+            <Button variant="filled" full onClick={closeEditor} class="mt-2.5">
+              Done
+            </Button>
+            <Button
+              variant="error"
+              full
+              onClick={() => handleRemove(editingLi.id!)}
+              class="mt-2"
+            >
+              Remove from list
+            </Button>
+          </div>
+        )}
+      </Sheet>
     </div>
   );
 }

--- a/islands/add-items.tsx
+++ b/islands/add-items.tsx
@@ -269,7 +269,7 @@ export default function AddItems(
           </div>
         )}
 
-        {/* Main content: idle hint, or create card + live results */}
+        {/* Main content: idle hint, or live results + create-new fallback */}
         {q
           ? (() => {
             // Two intentional predicates: the create card gates on an EXACT
@@ -281,8 +281,16 @@ export default function AddItems(
             );
             return (
               <>
+                <div class="flex flex-col">
+                  {results.value.map((item) => catalogueRow(item, false))}
+                </div>
+                {
+                  /* Create-new action stays BELOW the results: existing matches
+                    lead while the user types, and this is the fallback (and the
+                    only thing shown when nothing matches). */
+                }
                 {!exact && (
-                  <div class="bg-primary-container text-on-primary-container rounded-[var(--md-shape-lg)] p-3.5 mb-1 flex flex-col gap-3">
+                  <div class="bg-primary-container text-on-primary-container rounded-[var(--md-shape-lg)] p-3.5 mt-1 flex flex-col gap-3">
                     <div class="flex items-center gap-3.5">
                       <span class="w-9 h-9 rounded-full bg-on-primary-container text-primary-container grid place-items-center shrink-0">
                         <Icon name="plus" size={20} />
@@ -317,9 +325,6 @@ export default function AddItems(
                     </Button>
                   </div>
                 )}
-                <div class="flex flex-col">
-                  {results.value.map((item) => catalogueRow(item, false))}
-                </div>
               </>
             );
           })()

--- a/islands/add-items.tsx
+++ b/islands/add-items.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo } from "preact/hooks";
 import { useComputed, useSignal } from "@preact/signals";
-import { For } from "@preact/signals/utils";
 import {
   CategoryInterface,
   ItemInterface,
@@ -319,9 +318,7 @@ export default function AddItems(
                   </div>
                 )}
                 <div class="flex flex-col">
-                  <For each={results}>
-                    {(item) => catalogueRow(item, false)}
-                  </For>
+                  {results.value.map((item) => catalogueRow(item, false))}
                 </div>
               </>
             );

--- a/islands/add-items.tsx
+++ b/islands/add-items.tsx
@@ -69,6 +69,9 @@ export default function AddItems(
   const editingId = useSignal<string | null>(null);
   // "Added (N)" section collapse state (collapsed by default).
   const addedOpen = useSignal(false);
+  // Create-new affordance: a slim row while matches exist; tapping it expands to
+  // the full category-picker card (which also shows outright when nothing matches).
+  const createExpanded = useSignal(false);
 
   // Autofocus the search field on mount for a quick type-to-search flow.
   useEffect(() => {
@@ -88,6 +91,7 @@ export default function AddItems(
     trackAdded(await addToCatalog(name, selectedCategoryId.value || undefined));
     selectedCategoryId.value = "";
     query.value = "";
+    createExpanded.value = false;
     inputRef.current?.focus();
   };
 
@@ -208,6 +212,7 @@ export default function AddItems(
               value={query.value}
               onInput={(e) => {
                 query.value = (e.target as HTMLInputElement).value;
+                createExpanded.value = false; // typing re-collapses the create row
               }}
               placeholder="Search or add an item…"
               class="w-full md-body-large text-on-surface bg-surface-chigh border-0 rounded-[var(--md-shape-full)] py-2.5 pl-10 pr-10 outline-none"
@@ -285,46 +290,59 @@ export default function AddItems(
                   {results.value.map((item) => catalogueRow(item, false))}
                 </div>
                 {
-                  /* Create-new action stays BELOW the results: existing matches
-                    lead while the user types, and this is the fallback (and the
-                    only thing shown when nothing matches). */
+                  /* Create-new action stays BELOW the results. It's a slim row
+                    when there are matches (de-emphasized), and upgrades to the
+                    full category-picker card when there are no matches — or when
+                    the user taps the slim row to engage. */
                 }
-                {!exact && (
-                  <div class="bg-primary-container text-on-primary-container rounded-[var(--md-shape-lg)] p-3.5 mt-1 flex flex-col gap-3">
-                    <div class="flex items-center gap-3.5">
-                      <span class="w-9 h-9 rounded-full bg-on-primary-container text-primary-container grid place-items-center shrink-0">
-                        <Icon name="plus" size={20} />
-                      </span>
-                      <div class="flex-1 min-w-0">
-                        <div class="md-body-large">Create "{q}"</div>
-                        <div class="md-body-small opacity-80">
-                          New item — pick a category
+                {!exact &&
+                  (results.value.length > 0 && !createExpanded.value
+                    ? (
+                      <Pressable
+                        onClick={() => (createExpanded.value = true)}
+                        class="flex items-center gap-2 w-full text-left rounded-[var(--md-shape-md)] px-3 py-3 mt-1 text-primary md-label-large"
+                      >
+                        <Icon name="plus" size={20} /> Create "{q}"
+                      </Pressable>
+                    )
+                    : (
+                      <div class="bg-primary-container text-on-primary-container rounded-[var(--md-shape-lg)] p-3.5 mt-1 flex flex-col gap-3">
+                        <div class="flex items-center gap-3.5">
+                          <span class="w-9 h-9 rounded-full bg-on-primary-container text-primary-container grid place-items-center shrink-0">
+                            <Icon name="plus" size={20} />
+                          </span>
+                          <div class="flex-1 min-w-0">
+                            <div class="md-body-large">Create "{q}"</div>
+                            <div class="md-body-small opacity-80">
+                              New item — pick a category
+                            </div>
+                          </div>
                         </div>
+                        <Pressable
+                          onClick={() => (catPicking.value = true)}
+                          color="var(--md-on-primary-container)"
+                          class="flex items-center justify-between gap-2 w-full rounded-[var(--md-shape-md)] border border-on-primary-container/40 px-3.5 py-2.5"
+                        >
+                          <span class="md-body-medium opacity-80">
+                            Category
+                          </span>
+                          <span class="inline-flex items-center gap-1 md-label-large">
+                            {selectedCatLabel} <Icon name="chevron" size={18} />
+                          </span>
+                        </Pressable>
+                        <Button
+                          variant="filled"
+                          full
+                          onClick={() => handleCreate(q)}
+                          style={{
+                            background: "var(--md-on-primary-container)",
+                            color: "var(--md-primary-container)",
+                          }}
+                        >
+                          Add to {selectedCatLabel}
+                        </Button>
                       </div>
-                    </div>
-                    <Pressable
-                      onClick={() => (catPicking.value = true)}
-                      color="var(--md-on-primary-container)"
-                      class="flex items-center justify-between gap-2 w-full rounded-[var(--md-shape-md)] border border-on-primary-container/40 px-3.5 py-2.5"
-                    >
-                      <span class="md-body-medium opacity-80">Category</span>
-                      <span class="inline-flex items-center gap-1 md-label-large">
-                        {selectedCatLabel} <Icon name="chevron" size={18} />
-                      </span>
-                    </Pressable>
-                    <Button
-                      variant="filled"
-                      full
-                      onClick={() => handleCreate(q)}
-                      style={{
-                        background: "var(--md-on-primary-container)",
-                        color: "var(--md-primary-container)",
-                      }}
-                    >
-                      Add to {selectedCatLabel}
-                    </Button>
-                  </div>
-                )}
+                    ))}
               </>
             );
           })()

--- a/islands/items.test.tsx
+++ b/islands/items.test.tsx
@@ -1,32 +1,24 @@
-import { assertStringIncludes } from "jsr:@std/assert@^1.0.19";
+import { assert, assertStringIncludes } from "jsr:@std/assert@^1.0.19";
 import { render } from "npm:preact-render-to-string@^6.6.3";
 import { h } from "preact";
 import Items from "./items.tsx";
 
+const base = {
+  listId: "l1",
+  listName: "Test list",
+  items: [],
+  shoppingList: [],
+  categories: [],
+};
+
 Deno.test("Items — renders Plan and Shop mode toggle", () => {
-  const html = render(
-    h(Items, {
-      listId: "l1",
-      listName: "Test list",
-      items: [],
-      shoppingList: [],
-      categories: [],
-    }),
-  );
+  const html = render(h(Items, base));
   assertStringIncludes(html, "Plan");
   assertStringIncludes(html, "Shop");
 });
 
-Deno.test("Items — add sheet is search-first with a full-screen handoff", () => {
-  const html = render(
-    h(Items, {
-      listId: "l1",
-      listName: "Test list",
-      items: [],
-      shoppingList: [],
-      categories: [],
-    }),
-  );
-  assertStringIncludes(html, "Search your catalogue"); // idle hint
-  assertStringIncludes(html, "Full screen"); // expand handoff
+Deno.test("Items — Plan mode shows the Add items FAB, no quick-add sheet", () => {
+  const html = render(h(Items, base));
+  assertStringIncludes(html, "Add items"); // FAB label
+  assert(!html.includes("Search your catalogue")); // old quick-add sheet gone
 });

--- a/islands/items.tsx
+++ b/islands/items.tsx
@@ -6,13 +6,11 @@ import {
   ItemInterface,
   ShoppingListItemInterface,
 } from "@/models/index.ts";
-import { useSearchBox, useShoppingList } from "@/hooks/index.ts";
+import { useShoppingList } from "@/hooks/index.ts";
 import { api } from "@/services/api.ts";
 import { Segmented } from "@/components/md3/Segmented.tsx";
-import { SearchBar } from "@/components/md3/SearchBar.tsx";
 import { Sheet } from "@/components/md3/Sheet.tsx";
 import { CategoryPickerList } from "@/components/md3/CategoryPickerList.tsx";
-import { CatalogueAddRow } from "@/components/md3/CatalogueAddRow.tsx";
 import { Card } from "@/components/md3/Card.tsx";
 import { Stepper } from "@/components/md3/Stepper.tsx";
 import { Button } from "@/components/md3/Button.tsx";
@@ -23,6 +21,7 @@ import { Pressable } from "@/components/md3/Pressable.tsx";
 import { Progress } from "@/components/md3/Progress.tsx";
 import { RoundCheck } from "@/components/md3/RoundCheck.tsx";
 import { Snackbar } from "@/components/md3/Snackbar.tsx";
+import Fab from "@/islands/shell/Fab.tsx";
 
 interface ItemsProps {
   listId: string;
@@ -46,7 +45,6 @@ export default function Items(
   // re-render would recreate all signals from SSR props, discarding local state.
   const {
     updateListItem,
-    addToList,
     removeListItem,
     checkItem,
     uncheckItem,
@@ -55,7 +53,6 @@ export default function Items(
     groupedList,
     list,
     checkedItems,
-    listItemsMap,
     categories,
     items,
     lastSaved,
@@ -122,7 +119,6 @@ export default function Items(
   }, []);
 
   // ── sheet signals ────────────────────────────────────────────────────────
-  const addOpen = useSignal(false);
   const editingId = useSignal<string | null>(null);
   // item-editor: searchable category picker mode (replaces the sheet body
   // while open)
@@ -136,34 +132,6 @@ export default function Items(
   // per keystroke. (A signal written from inside a useSignalEffect did NOT
   // re-render this island, so the pill is driven by this top-level read instead.)
   const savedBaseline = useRef(0);
-
-  // ── search / filter for add-item sheet ──────────────────────────────────
-  const filterFn = (searchString: string, item: ItemInterface) => {
-    if (searchString.trim() === "") return false;
-    return !!item?.name?.toLowerCase().includes(searchString.toLowerCase());
-  };
-
-  const { query, results, inputRef, reset } = useSearchBox(catalog, filterFn);
-
-  // Autofocus the search field when the add-item sheet opens — enables a quick
-  // type-to-search flow without an extra tap. Keyed on addOpen only, so
-  // returning from the category picker doesn't steal focus.
-  useEffect(() => {
-    if (!addOpen.value) return;
-    const t = setTimeout(() => inputRef.current?.focus(), 80);
-    return () => clearTimeout(t);
-  }, [addOpen.value]);
-
-  // ── add-item handlers ────────────────────────────────────────────────────
-  const handleAddToList = async (itemId: string) => {
-    await addToList(itemId);
-    // keep sheet open so multiple items can be added quickly
-  };
-
-  const openAddPage = (q?: string) => {
-    const suffix = q ? `?q=${encodeURIComponent(q)}` : "";
-    globalThis.location.href = `/shopping/${listId}/add${suffix}`;
-  };
 
   // ── item-editor: get current list item being edited ──────────────────────
   const editingListItem = () =>
@@ -209,19 +177,6 @@ export default function Items(
       {/* ── Plan mode ── */}
       {mode.value === "plan" && (
         <div class="flex flex-col gap-4">
-          {/* SearchBar opens the add-item sheet */}
-          <SearchBar
-            placeholder="Add item or search catalogue…"
-            onClick={() => {
-              addOpen.value = true;
-            }}
-            trailing={
-              <span class="text-primary">
-                <Icon name="plus" size={22} />
-              </span>
-            }
-          />
-
           {/* Grouped list */}
           <For each={groupedList}>
             {(group) => (
@@ -282,7 +237,7 @@ export default function Items(
 
           {groupedList.value.length === 0 && (
             <p class="md-body-large text-on-surface-variant text-center py-8">
-              Tap the search bar to add items.
+              Tap Add items to get started.
             </p>
           )}
         </div>
@@ -549,104 +504,6 @@ export default function Items(
         </div>
       </Sheet>
 
-      {/* ══════════════════════ Add-item sheet (quick) ══════════════════════ */}
-      <Sheet
-        open={addOpen.value}
-        onClose={() => {
-          addOpen.value = false;
-          reset();
-        }}
-        title="Add items"
-        size={query.value.trim() ? "large" : "auto"}
-      >
-        {/* Hand off to the full-screen add page */}
-        <div class="flex justify-end -mt-1 mb-1">
-          <Pressable
-            onClick={() => openAddPage(query.value.trim())}
-            class="inline-flex items-center gap-1.5 md-label-large text-primary rounded-[var(--md-shape-full)] px-3 py-1.5"
-          >
-            <Icon name="expand" size={18} /> Full screen
-          </Pressable>
-        </div>
-
-        {/* Search input */}
-        <div class="relative mb-3">
-          <span class="absolute left-4 top-1/2 -translate-y-1/2 text-on-surface-variant">
-            <Icon name="search" size={20} />
-          </span>
-          <input
-            ref={inputRef}
-            value={query.value}
-            onInput={(e) => {
-              query.value = (e.target as HTMLInputElement).value;
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && query.value.trim()) {
-                const qq = query.value.trim();
-                // EXACT (case-insensitive) match, distinct from `results`'
-                // SUBSTRING filter below — intentional, do not unify.
-                const exact = items.value.some((i) =>
-                  i.name?.toLowerCase() === qq.toLowerCase()
-                );
-                if (!exact && results.value.length === 0) openAddPage(qq);
-              }
-            }}
-            placeholder="Search or add an item…"
-            class="w-full md-body-large text-on-surface bg-surface-chigh border-0 rounded-[var(--md-shape-full)] py-3.5 pl-11 pr-4 outline-none"
-          />
-        </div>
-
-        {(() => {
-          const qq = query.value.trim();
-          if (!qq) {
-            return (
-              <div class="flex flex-col items-center text-center gap-1 px-6 py-10 text-on-surface-variant">
-                <Icon name="search" size={28} />
-                <div class="md-body-medium mt-1">Search your catalogue</div>
-                <div class="md-body-small opacity-80">
-                  or open full screen to add something new
-                </div>
-              </div>
-            );
-          }
-          // Intentionally two different predicates: the create affordance
-          // below gates on an EXACT (case-insensitive) match, while `results`
-          // comes from useSearchBox's SUBSTRING filter — so both can
-          // legitimately show at once. Do not unify these.
-          const exact = items.value.some((i) =>
-            i.name?.toLowerCase() === qq.toLowerCase()
-          );
-          return (
-            <>
-              <div class="flex flex-col">
-                <For each={results}>
-                  {(item) => (
-                    <CatalogueAddRow
-                      key={item.id}
-                      name={item.name ?? ""}
-                      categoryLabel={categories.value.find((c) =>
-                        c.id === item.categoryId
-                      )?.label ?? ""}
-                      added={listItemsMap.value.has(item.id ?? "")}
-                      onAdd={() => item.id && handleAddToList(item.id)}
-                    />
-                  )}
-                </For>
-              </div>
-              {!exact && (
-                <Pressable
-                  onClick={() => openAddPage(qq)}
-                  class="flex items-center gap-2 w-full text-left rounded-[var(--md-shape-md)] px-3 py-3 mt-1 text-primary md-label-large"
-                >
-                  <Icon name="plus" size={20} />{" "}
-                  Create "{qq}" — opens full screen
-                </Pressable>
-              )}
-            </>
-          );
-        })()}
-      </Sheet>
-
       {/* ══════════════════════ Item-editor sheet ══════════════════════ */}
       <Sheet
         open={editingId.value !== null}
@@ -779,6 +636,24 @@ export default function Items(
           );
         })()}
       </Sheet>
+
+      {/* FAB — opens the full-screen add page (Plan mode only) */}
+      {mode.value === "plan" && (
+        <div
+          class="fixed right-4 z-30"
+          style={{ bottom: "calc(96px + env(safe-area-inset-bottom))" }}
+        >
+          <Fab
+            icon="plus"
+            label="Add items"
+            aria-label="Add items"
+            onClick={() => {
+              globalThis.location.href = `/shopping/${listId}/add`;
+            }}
+          />
+        </div>
+      )}
+
       {/* ══════════════════════ Snackbar ══════════════════════ */}
       <Snackbar data={snackData.value} />
     </div>

--- a/islands/shell/AppChrome.test.tsx
+++ b/islands/shell/AppChrome.test.tsx
@@ -1,0 +1,22 @@
+import { assertEquals, assertStringIncludes } from "jsr:@std/assert@^1.0.19";
+import { render } from "npm:preact-render-to-string@^6.6.3";
+import { h } from "preact";
+import AppChrome from "./AppChrome.tsx";
+
+Deno.test("AppChrome — mode:none renders no chrome (full-screen route)", () => {
+  const html = render(
+    h(AppChrome, { appBar: { mode: "none" }, sectionTitle: "Shopping" }),
+  );
+  assertEquals(html, "");
+});
+
+Deno.test("AppChrome — mode:detail renders a back + title bar", () => {
+  const html = render(
+    h(AppChrome, {
+      appBar: { mode: "detail", title: "Add items", backUrl: "/shopping/l1" },
+      sectionTitle: "Shopping",
+    }),
+  );
+  assertStringIncludes(html, "Add items");
+  assertStringIncludes(html, "/shopping/l1");
+});

--- a/islands/shell/AppChrome.tsx
+++ b/islands/shell/AppChrome.tsx
@@ -5,10 +5,11 @@ import MoreSheet from "./MoreSheet.tsx";
 import { NAV_CONFIG } from "@/config/navigation.ts";
 import { appBarAction } from "@/utils/app-bar.ts";
 import { IconButton } from "@/components/md3/IconButton.tsx";
+import type { AppBar } from "@/utils/define.ts";
 
 interface AppChromeProps {
   activeId?: string;
-  appBar?: { title: string; backUrl: string };
+  appBar?: AppBar;
   sectionTitle: string;
 }
 
@@ -16,13 +17,20 @@ export default function AppChrome(
   { activeId, appBar, sectionTitle }: AppChromeProps,
 ) {
   const moreOpen = useSignal(false);
+
+  // Full-screen routes (e.g. the add-items search) own the whole viewport:
+  // no top bar and no bottom navigation.
+  if (appBar?.mode === "none") return null;
+
+  const detail = appBar?.mode === "detail" ? appBar : null;
+
   return (
     <>
-      {appBar
+      {detail
         ? (
           <TopAppBar
-            title={appBar.title}
-            backUrl={appBar.backUrl}
+            title={detail.title}
+            backUrl={detail.backUrl}
             trailing={appBarAction.value
               ? (
                 <IconButton

--- a/routes/_app.tsx
+++ b/routes/_app.tsx
@@ -43,9 +43,7 @@ export default function App(
         {state?.userId && (
           <AppChrome
             activeId={activeTab?.id}
-            appBar={state.appBar
-              ? { title: state.appBar.title, backUrl: state.appBar.backUrl }
-              : undefined}
+            appBar={state.appBar}
             sectionTitle={activeTab?.label ?? "Happie"}
           />
         )}

--- a/routes/shopping/[id]/add.tsx
+++ b/routes/shopping/[id]/add.tsx
@@ -16,11 +16,9 @@ export const handler = define.handlers({
     if (!list) {
       return new Response("Not found", { status: 404 });
     }
-    ctx.state.appBar = {
-      mode: "detail",
-      title: "Add items",
-      backUrl: `/shopping/${listId}`,
-    };
+    // Full-screen search surface: the island owns the top bar and there is no
+    // bottom nav. The shell renders no chrome for mode:"none".
+    ctx.state.appBar = { mode: "none" };
     const [items, shoppingList, categories] = await Promise.all([
       ItemRepo.readAll(),
       ShoppingListItemRepo.getAll(listId),
@@ -33,7 +31,7 @@ export const handler = define.handlers({
 
 export default define.page<typeof handler>(function AddItemsPage({ data }) {
   return (
-    <main class="max-w-md mx-auto p-4">
+    <main class="max-w-md mx-auto">
       <AddItemsIsland
         listId={data.list.id}
         listName={data.list.name}

--- a/utils/define.ts
+++ b/utils/define.ts
@@ -7,13 +7,21 @@ export interface AppBarDetail {
   backUrl: string;
 }
 
+/** The route owns the whole viewport — the shell renders no top bar and no
+ *  bottom navigation (e.g. the full-screen add-items search). */
+export interface AppBarNone {
+  mode: "none";
+}
+
+export type AppBar = AppBarDetail | AppBarNone;
+
 export interface StateInterface {
   userId?: string;
   householdId?: string;
   items?: ItemInterface[];
   shoppingList?: ShoppingListItemInterface[];
   error?: string;
-  appBar?: AppBarDetail;
+  appBar?: AppBar;
 }
 
 // Setup, do this once in a file and import it everywhere else.


### PR DESCRIPTION
## Summary

Reworks the shopping-list **add-items** flow: the "dummy search bar that opened a bottom sheet" is replaced by an extended **"Add items" FAB** that opens a dedicated **full-screen MD3 search** page.

- **List page** (`islands/items.tsx`): retires the quick-add search bar + sheet; Plan mode now shows an extended **"Add items" FAB** (reusing `islands/shell/Fab.tsx`) → `/shopping/[id]/add`. The item-editor and list-options sheets are untouched.
- **Shell** (`utils/define.ts`, `routes/_app.tsx`, `islands/shell/AppChrome.tsx`): new app-bar mode **`{ mode: "none" }`** — a route owns the whole viewport (no top bar, no bottom nav).
- **Add page** (`routes/shopping/[id]/add.tsx`, `islands/add-items.tsx`): canonical full-screen search — island-owned **sticky search bar** (back + input + clear), a **search-first idle** hint (no category chips), live **results below the bar**, tap-to-add → **inline quantity stepper + tap-to-edit**, a compact **quantity + note editor sheet**, and a pinned **"Added (N)" building-cart** of items added this visit. The create-on-no-match card → category-picker sub-screen is kept.
- **`components/md3/CatalogueAddRow.tsx`**: gains an added-state (inline stepper, tap-to-edit, optional remove) with a backward-compatible static fallback.

No data-model or API changes for the feature itself — everything flows through the existing `useShoppingList` / `useSearchBox` hooks and repos.

## Two bugs caught in review/QA and fixed

- **Critical (final review):** result rows rendered via `<For each={results}>` over a static array froze at first render — a tapped row never flipped to the stepper, and because it still showed "+", a re-tap created a **duplicate list item**. Fixed by rendering results with `results.value.map(...)` so the row callback re-runs each render (matching the Added-section pattern) — commit `fdeda2a`.
- **Data loss (live QA):** a partial list-item PATCH omitting a field clobbered that field to `undefined` (`{ ...current, ...patch }` spreads `undefined` keys). Pre-existing repo bug that the new "bump quantity, then add a note" flow exposes (also affected the Shop-mode check toggle). Fixed at the single choke point with a `mergeDefinedPatch` helper that ignores `undefined` while keeping defined falsy values (`false`, `0`, `""`) — commit `7c39669`.

## Testing

- Gates green: `deno task check`, `deno test` **88/88**, `deno task build`.
- Live QA (mobile viewport, seeded KV): the full flow end-to-end (FAB → full-screen search → search-first idle → add → inline qty → note editor → Added cart expand/remove → back), zero console errors.
- The PATCH-clobber fix verified end-to-end: an item bumped to **qty 3** then noted **separately** persisted **both** the quantity *and* the note — whereas an item edited before the fix shows the note kept but the quantity clobbered back to 1.

## Notes

- Built with subagent-driven development (fresh implementer per task, per-task spec+quality reviews, a whole-branch review, then fixes).
- **Base is `feat/fullscreen-add-items` (PR #26)** — this stacks on it; retarget to `develop` after #26 merges.
- Follow-up worth a sweep: the same `{ ...current, ...patch }` clobber pattern may exist in the item / category / shopping-list repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
