### PR TITLE
fix(database): prevent partial repo updates from clobbering omitted fields

### DIFF
--- a/database/category.repo.ts
+++ b/database/category.repo.ts
@@ -1,5 +1,6 @@
 import { CategoryInterface } from "../models/index.ts";
 import { getKv } from "./db.ts";
+import { mergeDefinedPatch } from "./merge-patch.ts";
 
 export class CategoryRepo {
   constructor() {}
@@ -56,7 +57,7 @@ export class CategoryRepo {
     const existing = await this.getById(id);
     if (!existing) return null;
 
-    const updated = { ...existing, ...patch };
+    const updated = mergeDefinedPatch(existing, patch);
     await kv.set(["categories", id], updated);
     return updated;
   }

--- a/database/merge-patch.test.ts
+++ b/database/merge-patch.test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "jsr:@std/assert@^1.0.19";
-import { mergeDefinedPatch } from "@/database/shopping-list-item.repo.ts";
+import { mergeDefinedPatch } from "@/database/merge-patch.ts";
 
 /** Minimal shape covering the fields exercised below. Typed explicitly (rather
  *  than inferred from each literal) so patches touching a key `current` didn't
@@ -33,4 +33,17 @@ Deno.test("mergeDefinedPatch — defined falsy values still apply", () => {
   const current: Partial<TestItem> = { checked: true };
   const result = mergeDefinedPatch(current, { checked: false });
   assertEquals(result, { checked: false });
+});
+
+Deno.test("mergeDefinedPatch — an empty patch returns an unchanged copy", () => {
+  const current: Partial<TestItem> = { quantity: 3, note: "keep" };
+  const result = mergeDefinedPatch(current, {});
+  assertEquals(result, { quantity: 3, note: "keep" });
+});
+
+Deno.test("mergeDefinedPatch — does not mutate the original current object", () => {
+  const current: Partial<TestItem> = { quantity: 1, note: "orig" };
+  const result = mergeDefinedPatch(current, { note: "changed" });
+  assertEquals(current, { quantity: 1, note: "orig" });
+  assertEquals(result, { quantity: 1, note: "changed" });
 });

--- a/database/merge-patch.ts
+++ b/database/merge-patch.ts
@@ -1,0 +1,19 @@
+/** Merge a partial patch onto `current`, ignoring keys whose value is undefined,
+ *  so a partial update never clobbers omitted fields. Defined falsy values
+ *  (false, 0, "") still apply.
+ *
+ *  Repositories persist whole records to KV, so a naive `{ ...current, ...patch }`
+ *  spread would write `undefined` over any field the caller left out of `patch`
+ *  (JS spread copies keys whose value is undefined). Routing every repo `update`
+ *  through this helper keeps partial updates non-destructive regardless of what
+ *  the caller forwards. */
+export function mergeDefinedPatch<T extends object>(
+  current: T,
+  patch: Partial<T>,
+): T {
+  const next = { ...current };
+  for (const [k, v] of Object.entries(patch)) {
+    if (v !== undefined) (next as Record<string, unknown>)[k] = v;
+  }
+  return next;
+}

--- a/database/shopping-list-item.repo.ts
+++ b/database/shopping-list-item.repo.ts
@@ -1,19 +1,6 @@
 import { ShoppingListItemInterface } from "@/models/index.ts";
 import { getKv } from "./db.ts";
-
-/** Merge a partial patch onto `current`, ignoring keys whose value is undefined,
- *  so a partial update never clobbers omitted fields. Defined falsy values
- *  (false, 0, "") still apply. */
-export function mergeDefinedPatch<T extends object>(
-  current: T,
-  patch: Partial<T>,
-): T {
-  const next = { ...current };
-  for (const [k, v] of Object.entries(patch)) {
-    if (v !== undefined) (next as Record<string, unknown>)[k] = v;
-  }
-  return next;
-}
+import { mergeDefinedPatch } from "./merge-patch.ts";
 
 export class ShoppingListItemRepo {
   static async add(

--- a/database/shopping-list.repo.ts
+++ b/database/shopping-list.repo.ts
@@ -3,6 +3,7 @@ import {
   ShoppingListInterface,
 } from "@/models/index.ts";
 import { getKv } from "./db.ts";
+import { mergeDefinedPatch } from "./merge-patch.ts";
 
 export class ShoppingListRepo {
   static async create(
@@ -46,7 +47,7 @@ export class ShoppingListRepo {
     const kv = await getKv();
     const existing = await this.getById(householdId, id);
     if (!existing) return null;
-    const updated = { ...existing, ...patch };
+    const updated = mergeDefinedPatch(existing, patch);
     await kv.set(["shopping_lists", householdId, id], updated);
     return updated;
   }


### PR DESCRIPTION
## What

Introduces a shared `mergeDefinedPatch` helper (`database/merge-patch.ts`) and routes every repository `update()` through it, so a partial update never writes `undefined` over fields the caller omitted.

- **New:** `database/merge-patch.ts` — `mergeDefinedPatch(current, patch)` copies `current` and applies only patch keys whose value is `!== undefined` (defined falsy values like `false` / `0` / `""` still apply).
- **Refactored** `ShoppingListItemRepo`, `CategoryRepo`, and `ShoppingListRepo` `update()` to use it.
- **Tests:** `database/merge-patch.test.ts` — 5 KV-free unit tests of the pure helper (plain `deno test` runs without `--unstable-kv`, so they never open Deno KV).

## Why

Repo `update()` methods merged patches with `{ ...current, ...patch }`. JS object spread copies keys whose value is `undefined`, so any caller that forwards an omitted field as `undefined` overwrites the stored value.

- **`ShoppingListItemRepo`** was actively affected — its PATCH route (`routes/api/shopping/lists/[id]/items.ts`) destructures `{ quantity, note, checked }` and forwards all three, so a note-only edit or a Shop-mode `{ checked: true }` toggle clobbered the others. This was already fixed in #27 via an inline helper; this PR promotes that helper to a shared module.
- **`CategoryRepo` / `ShoppingListRepo`** share the same fragile spread. Their routes happen to sanitize the patch today, so the clobber is **latent** — this hardens them against any future caller that forwards `undefined`.

## Relationship to #27

Builds on #27 (merged). #27 fixed `ShoppingListItemRepo` with an **inline** `mergeDefinedPatch`; this PR extracts it into `database/merge-patch.ts` as a single source of truth shared by all three repos. `shopping-list-item.repo.ts` now imports the helper instead of declaring it, and #27's `shopping-list-item.repo.test.ts` is consolidated into `merge-patch.test.ts` (git shows it as a rename; expanded from 3 → 5 cases, adding empty-patch and no-mutation).

## Out of scope (follow-up)

`database/item.repo.ts` was audited and deliberately left out: its `update()` is a **full replace** (`kv.set(id, item)`), not the `{ ...current, ...patch }` merge pattern. Separately, its catalogue route (`routes/api/shopping/catalogue.ts`) persists the raw request body while responding with a merged object — a different data-loss / response-vs-state divergence risk. Flagged for a follow-up, not addressed here.

## Verification

- `deno task check` ✅
- `deno test` ✅ (90 passed, 0 failed)
- `deno task build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
