### PR TITLE
fix(shopping): drop iOS keyboard field navigator during add-items search

### DIFF
--- a/islands/add-items.tsx
+++ b/islands/add-items.tsx
@@ -228,6 +228,9 @@ export default function AddItems(
             </span>
             <input
               ref={inputRef}
+              type="text"
+              autocomplete="off"
+              enterkeyhint="search"
               value={query.value}
               onInput={(e) => {
                 query.value = (e.target as HTMLInputElement).value;

--- a/islands/items.tsx
+++ b/islands/items.tsx
@@ -423,109 +423,118 @@ export default function Items(
       })()}
 
       {/* ══════════════════════ List-management sheet ══════════════════════ */}
-      <Sheet
-        open={mgmtOpen.value}
-        onClose={() => {
-          mgmtOpen.value = false;
-        }}
-        title="List options"
-      >
-        <div class="flex flex-col gap-1 pb-1">
-          {/* Rename */}
-          <div class="px-1 py-2">
-            <div class="md-body-large text-on-surface mb-2">Rename list</div>
-            <div class="flex gap-2">
-              <input
-                value={renameValue.value}
-                onInput={(e) => {
-                  renameValue.value = (e.target as HTMLInputElement).value;
-                }}
-                onKeyDown={async (e) => {
-                  if (e.key === "Enter" && renameValue.value.trim()) {
-                    await api.shoppingLists.rename(
-                      listId,
-                      renameValue.value.trim(),
-                    );
+      {
+        /* Gated on !addOpen: <Sheet> renders its children even when closed, so
+          this rename <input> would otherwise stay in the DOM while the add-items
+          overlay is open. That extra form field makes iOS add a prev/next field
+          navigator to the keyboard accessory bar; unmounting the sheet leaves the
+          overlay's search box as the only field. */
+      }
+      {!addOpen.value && (
+        <Sheet
+          open={mgmtOpen.value}
+          onClose={() => {
+            mgmtOpen.value = false;
+          }}
+          title="List options"
+        >
+          <div class="flex flex-col gap-1 pb-1">
+            {/* Rename */}
+            <div class="px-1 py-2">
+              <div class="md-body-large text-on-surface mb-2">Rename list</div>
+              <div class="flex gap-2">
+                <input
+                  value={renameValue.value}
+                  onInput={(e) => {
+                    renameValue.value = (e.target as HTMLInputElement).value;
+                  }}
+                  onKeyDown={async (e) => {
+                    if (e.key === "Enter" && renameValue.value.trim()) {
+                      await api.shoppingLists.rename(
+                        listId,
+                        renameValue.value.trim(),
+                      );
+                      mgmtOpen.value = false;
+                      // The route SSR renders the list name into the shell TopAppBar;
+                      // reload to reflect the new name there.
+                      globalThis.location.reload();
+                    }
+                  }}
+                  placeholder="List name"
+                  class="flex-1 md-body-large text-on-surface bg-surface-chigh border-0 rounded-[var(--md-shape-full)] py-3 px-4 outline-none"
+                />
+                <Button
+                  variant="filled"
+                  onClick={async () => {
+                    const name = renameValue.value.trim();
+                    if (!name) return;
+                    await api.shoppingLists.rename(listId, name);
                     mgmtOpen.value = false;
-                    // The route SSR renders the list name into the shell TopAppBar;
-                    // reload to reflect the new name there.
                     globalThis.location.reload();
-                  }
-                }}
-                placeholder="List name"
-                class="flex-1 md-body-large text-on-surface bg-surface-chigh border-0 rounded-[var(--md-shape-full)] py-3 px-4 outline-none"
-              />
-              <Button
-                variant="filled"
-                onClick={async () => {
-                  const name = renameValue.value.trim();
-                  if (!name) return;
-                  await api.shoppingLists.rename(listId, name);
-                  mgmtOpen.value = false;
-                  globalThis.location.reload();
-                }}
-              >
-                Save
-              </Button>
+                  }}
+                >
+                  Save
+                </Button>
+              </div>
             </div>
-          </div>
 
-          <div class="h-px bg-surface-chigh mx-1 my-1" />
+            <div class="h-px bg-surface-chigh mx-1 my-1" />
 
-          {/* Share — coming soon */}
-          <ListItem
-            headline="Share list"
-            supporting="Invite household members"
-            leading={
-              <span class="w-10 h-10 rounded-full bg-surface-chigh text-on-surface-variant grid place-items-center">
-                <Icon name="share" size={20} />
-              </span>
-            }
-            onClick={() => {
-              showSnack("Sharing is coming soon");
-            }}
-          />
-
-          {/* Clear checked */}
-          <ListItem
-            headline="Clear checked items"
-            supporting={checkedItems.value.length
-              ? `${checkedItems.value.length} checked off`
-              : "Nothing checked yet"}
-            leading={
-              <span class="w-10 h-10 rounded-full bg-surface-chigh text-on-surface-variant grid place-items-center">
-                <Icon name="check" size={20} />
-              </span>
-            }
-            onClick={async () => {
-              const ids = checkedItems.value.map((li) => li.id!).filter(
-                Boolean,
-              );
-              mgmtOpen.value = false;
-              for (const id of ids) {
-                await removeListItem(id);
+            {/* Share — coming soon */}
+            <ListItem
+              headline="Share list"
+              supporting="Invite household members"
+              leading={
+                <span class="w-10 h-10 rounded-full bg-surface-chigh text-on-surface-variant grid place-items-center">
+                  <Icon name="share" size={20} />
+                </span>
               }
-            }}
-          />
+              onClick={() => {
+                showSnack("Sharing is coming soon");
+              }}
+            />
 
-          <div class="h-px bg-surface-chigh mx-1 my-1" />
+            {/* Clear checked */}
+            <ListItem
+              headline="Clear checked items"
+              supporting={checkedItems.value.length
+                ? `${checkedItems.value.length} checked off`
+                : "Nothing checked yet"}
+              leading={
+                <span class="w-10 h-10 rounded-full bg-surface-chigh text-on-surface-variant grid place-items-center">
+                  <Icon name="check" size={20} />
+                </span>
+              }
+              onClick={async () => {
+                const ids = checkedItems.value.map((li) => li.id!).filter(
+                  Boolean,
+                );
+                mgmtOpen.value = false;
+                for (const id of ids) {
+                  await removeListItem(id);
+                }
+              }}
+            />
 
-          {/* Delete list */}
-          <ListItem
-            headline={<span class="text-error">Delete list</span>}
-            leading={
-              <span class="w-10 h-10 rounded-full bg-error-container text-error grid place-items-center">
-                <Icon name="trash" size={20} />
-              </span>
-            }
-            onClick={async () => {
-              mgmtOpen.value = false;
-              await api.shoppingLists.delete(listId);
-              globalThis.location.href = "/shopping";
-            }}
-          />
-        </div>
-      </Sheet>
+            <div class="h-px bg-surface-chigh mx-1 my-1" />
+
+            {/* Delete list */}
+            <ListItem
+              headline={<span class="text-error">Delete list</span>}
+              leading={
+                <span class="w-10 h-10 rounded-full bg-error-container text-error grid place-items-center">
+                  <Icon name="trash" size={20} />
+                </span>
+              }
+              onClick={async () => {
+                mgmtOpen.value = false;
+                await api.shoppingLists.delete(listId);
+                globalThis.location.href = "/shopping";
+              }}
+            />
+          </div>
+        </Sheet>
+      )}
 
       {/* ══════════════════════ Item-editor sheet ══════════════════════ */}
       <Sheet
@@ -678,16 +687,22 @@ export default function Items(
       {
         /* Keyboard primer — focused inside the FAB tap (see openAdd) so mobile
           browsers open the soft keyboard; focus then transfers to the overlay's
-          search field, which keeps it open. Kept always-mounted and offscreen. */
+          search field, which keeps it open. Mounted only while the overlay is
+          closed: once open it's dead weight, and leaving it in the DOM makes it a
+          second form field, so iOS adds a prev/next field navigator to the
+          keyboard accessory bar. Unmounting it leaves the search box as the sole
+          field, so the navigator disappears. */
       }
-      <input
-        ref={primerRef}
-        type="text"
-        aria-hidden="true"
-        tabIndex={-1}
-        class="fixed top-0 left-0 opacity-0 pointer-events-none"
-        style={{ width: 1, height: 1, fontSize: 16 }}
-      />
+      {!addOpen.value && (
+        <input
+          ref={primerRef}
+          type="text"
+          aria-hidden="true"
+          tabIndex={-1}
+          class="fixed top-0 left-0 opacity-0 pointer-events-none"
+          style={{ width: 1, height: 1, fontSize: 16 }}
+        />
+      )}
 
       {
         /* Add-items surface as a full-screen overlay. z-50 sits above the shell


### PR DESCRIPTION
## What

Removes the iOS **keyboard field navigator** (the `‹ ›` previous/next arrows on the soft-keyboard accessory bar) while searching in the add-items overlay, where there's only one input and the navigator was just clutter.

## Why

iOS/WebKit shows the prev/next field-navigation arrows whenever **2+ focusable form fields** exist in the DOM. The add-items search opens as an **in-page overlay** on top of the shopping list, so the underlying page's fields stayed mounted behind it:

- the **keyboard primer** `<input>` (used to open the soft keyboard within the FAB tap), and
- the **rename input** inside the list-management `<Sheet>` — which renders its children *even when closed* (`components/md3/Sheet.tsx`).

So a single-field search UI still got a pointless field navigator.

## Changes

- `islands/items.tsx` — gate the **primer** and the **management Sheet** on `!addOpen`, so neither is in the DOM while the overlay is open. The primer is still mounted at the FAB-tap moment, so keyboard priming/autofocus is preserved; it unmounts once the overlay's search field takes focus.
- `islands/add-items.tsx` — add `autocomplete="off"` + `enterkeyhint="search"` to the search input (declutters the keyboard; autocorrect/autocapitalize left as-is so created item names still capitalize normally).

> The `items.tsx` diff looks large but is mostly `deno fmt` re-indenting the block wrapped in the new conditional — the logic change is one `{!addOpen.value && (…)}` guard.

## Verification

Ran this worktree's branch against a copy of local KV data and inspected the DOM:

| State | Focusable form fields in DOM |
|---|---|
| Overlay closed | 2 (rename input + primer) |
| **Overlay open** | **1 (search box only)** |
| Typing a query | 1 — live results, focus retained on search |
| Closed again | 2 (both remount) |

`deno check` and `deno fmt` pass. Overlay opens/closes in place (no navigation) and focus transfers to the search field.

## Reviewer notes

- The accessory **bar itself** (with "Done") is a native WKWebView component — a PWA can't remove it; only the prev/next **navigator** is addressable, by ensuring a single field. This PR does the latter.
- The DOM condition and focus transfer were verified on desktop; the final on-device visual (grayed/absent arrows + keyboard staying up through the primer→search handoff) is worth a quick confirm on a real iPhone.
- Base is `develop` per the repo's feature-branch flow — retarget if that's not intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)