### PR TITLE
feat(shopping): bulk-clear checked items in one request (#33)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,8 @@ shopping, or quickly adding something to a list from wherever you are.
 - `deno task preview` — Serve production build
 - `deno task db:seed` — Seed database with demo user (reads `.env`)
 - `deno task db:view` — Inspect KV database contents
-- `deno test` — Run tests
+- `deno task test` — Run tests (uses `--unstable-kv -A`; required for KV-backed
+  repo tests)
 
 ## Architecture
 

--- a/database/shopping-list-item.repo.test.ts
+++ b/database/shopping-list-item.repo.test.ts
@@ -1,0 +1,49 @@
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import { ShoppingListItemRepo } from "@/database/shopping-list-item.repo.ts";
+
+// Isolated in-memory KV for this test process. getKv() reads KV_PATH lazily on
+// first use (inside a repo method), and no repo method is called until a test
+// body runs — so setting it here at module load is early enough. Each test uses
+// a distinct listId because the process-wide KV singleton is shared.
+Deno.env.set("KV_PATH", ":memory:");
+
+// sanitizeResources is disabled because getKv() opens a module-level KV
+// singleton lazily on first use and never closes it (by design — it's meant
+// to live for the process's lifetime, same as in production). Deno's default
+// resource sanitizer would otherwise flag that singleton as "leaked" from
+// whichever test happens to open it first.
+
+Deno.test({
+  name: "clearChecked — removes only checked items and returns their count",
+  sanitizeResources: false,
+  async fn() {
+    const listId = "list-clear-1";
+    const a = await ShoppingListItemRepo.add(listId, "item-a");
+    const b = await ShoppingListItemRepo.add(listId, "item-b");
+    const c = await ShoppingListItemRepo.add(listId, "item-c");
+    await ShoppingListItemRepo.update(listId, a.id, { checked: true });
+    await ShoppingListItemRepo.update(listId, c.id, { checked: true });
+
+    const cleared = await ShoppingListItemRepo.clearChecked(listId);
+
+    assertEquals(cleared, 2);
+    const remaining = await ShoppingListItemRepo.getAll(listId);
+    assertEquals(remaining.map((i) => i.id), [b.id]);
+  },
+});
+
+Deno.test({
+  name: "clearChecked — returns 0 and deletes nothing when no item is checked",
+  sanitizeResources: false,
+  async fn() {
+    const listId = "list-clear-2";
+    await ShoppingListItemRepo.add(listId, "item-a");
+    await ShoppingListItemRepo.add(listId, "item-b");
+
+    const cleared = await ShoppingListItemRepo.clearChecked(listId);
+
+    assertEquals(cleared, 0);
+    const remaining = await ShoppingListItemRepo.getAll(listId);
+    assertEquals(remaining.length, 2);
+  },
+});

--- a/database/shopping-list-item.repo.ts
+++ b/database/shopping-list-item.repo.ts
@@ -57,4 +57,24 @@ export class ShoppingListItemRepo {
       await kv.delete(entry.key);
     }
   }
+
+  static async clearChecked(listId: string): Promise<number> {
+    const kv = await getKv();
+    let atomic = kv.atomic();
+    let count = 0;
+    for await (
+      const entry of kv.list<ShoppingListItemInterface>({
+        prefix: ["shopping_list_items", listId],
+      })
+    ) {
+      if (entry.value.checked) {
+        atomic = atomic.delete(entry.key);
+        count++;
+      }
+    }
+    if (count === 0) return 0;
+    const { ok } = await atomic.commit();
+    if (!ok) throw new Error("Failed to clear checked items.");
+    return count;
+  }
 }

--- a/deno.json
+++ b/deno.json
@@ -2,6 +2,7 @@
   "nodeModulesDir": "manual",
   "tasks": {
     "check": "deno fmt --check && deno lint && deno check",
+    "test": "deno test --unstable-kv -A",
     "dev": "deno run --env-file --unstable-kv -A vite",
     "build": "vite build",
     "preview": "deno serve --env-file --unstable-kv -A _fresh/server.js",

--- a/docs/superpowers/plans/2026-07-23-bulk-clear-checked-items.md
+++ b/docs/superpowers/plans/2026-07-23-bulk-clear-checked-items.md
@@ -1,0 +1,502 @@
+# Bulk-clear Checked Items Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Clear all checked-off items in a shopping list with a single API call, and wire the existing "Clear checked items" UI action to use it (replacing the current one-request-per-item loop).
+
+**Architecture:** A new `ShoppingListItemRepo.clearChecked(listId)` deletes only checked items in one Deno KV atomic transaction. A dedicated `DELETE /api/shopping/lists/:id/items/checked` route calls it. A shared `authorizeList` helper (extracted from the existing items route) guards both routes. Client-side, `api.shoppingList.clearChecked` and a `clearCheckedItems()` hook action perform an optimistic clear with rollback on failure.
+
+**Tech Stack:** Deno 2.7 + Fresh 2 (`define.handlers`) + Preact + `@preact/signals` + Deno KV. Tests use `jsr:@std/assert` and `jsr:@std/testing/mock` (`stub`).
+
+## Global Constraints
+
+- **Imports:** use the `@/` alias for project root (e.g. `@/database/index.ts`). Route/DB imports use `.ts` extensions.
+- **JSX/Styling:** Preact JSX with `class` (never `className`). Not relevant to most tasks here but applies to the island edit.
+- **Fresh handlers:** API routes export `export const handler = define.handlers({ ... })`; handler methods take a single `ctx` (request via `ctx.req`, params via `ctx.params`). API routes return JSON `Response` objects.
+- **KV access:** never call `Deno.openKv()` in routes — go through repository classes and the `getKv()` singleton in `database/db.ts`.
+- **Signals in islands:** local island state uses `useSignal()`, never `signal()`. (The `useShoppingList` hook deliberately uses module-`signal()` semantics via `useMemo([])` — do not change that.)
+- **Commits:** Conventional Commits (`feat:`, `refactor:`, `test:`, `docs:`, `chore:`). End commit messages with the `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>` trailer.
+- **Clearing = deletion:** "clear checked" permanently deletes the checked items (existing behaviour), it does not un-check them.
+
+---
+
+## File Structure
+
+- `deno.json` — add a `test` task (KV tests need `--unstable-kv -A`).
+- `CLAUDE.md` — update the test-command note.
+- `database/shopping-list-item.repo.ts` — add `clearChecked(listId)` (core logic).
+- `database/shopping-list-item.repo.test.ts` *(new)* — repo test on in-memory KV.
+- `utils/authorize-list.ts` *(new)* — shared list-ownership auth helper (server-only; imported directly, NOT via the `utils/index.ts` barrel, so it never leaks into client bundles).
+- `routes/api/shopping/lists/[id]/items.ts` — remove the local `authorizeList`, import the shared one.
+- `routes/api/shopping/lists/[id]/items/checked.ts` *(new)* — `DELETE` route for bulk-clear.
+- `services/api.ts` — add `shoppingList.clearChecked`.
+- `hooks/useShoppingList.ts` — add and export `clearCheckedItems`.
+- `hooks/useShoppingList.test.ts` — add success + rollback tests.
+- `islands/items.tsx` — wire the "Clear checked items" button to `clearCheckedItems`.
+
+**Note on routing:** `routes/api/shopping/lists/[id]/items.ts` (file) and `routes/api/shopping/lists/[id]/items/checked.ts` (dir) coexist — the codebase already does this with `routes/api/shopping/lists.ts` + `routes/api/shopping/lists/[id]/`.
+
+---
+
+## Task 1: Repo `clearChecked` + test tooling
+
+**Files:**
+- Modify: `deno.json` (tasks block)
+- Modify: `CLAUDE.md` (build commands note)
+- Modify: `database/shopping-list-item.repo.ts`
+- Test: `database/shopping-list-item.repo.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `getKv()` from `database/db.ts`; `ShoppingListItemInterface` from `@/models/index.ts`; existing `ShoppingListItemRepo.add`, `.update`, `.getAll`.
+- Produces: `ShoppingListItemRepo.clearChecked(listId: string): Promise<number>` — deletes only items whose `checked === true`, returns how many were deleted (0 if none).
+
+- [ ] **Step 1: Add the `test` task to `deno.json`**
+
+In the `"tasks"` block, add the `test` line immediately after `check`:
+
+```jsonc
+  "tasks": {
+    "check": "deno fmt --check && deno lint && deno check",
+    "test": "deno test --unstable-kv -A",
+    "dev": "deno run --env-file --unstable-kv -A vite",
+```
+
+(Deliberately no `--env-file` for `test`, so `.env` cannot point KV at the real dev database — the test sets an in-memory path itself.)
+
+- [ ] **Step 2: Write the failing repo test**
+
+Create `database/shopping-list-item.repo.test.ts`:
+
+```ts
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import { ShoppingListItemRepo } from "@/database/shopping-list-item.repo.ts";
+
+// Isolated in-memory KV for this test process. getKv() reads KV_PATH lazily on
+// first use (inside a repo method), and no repo method is called until a test
+// body runs — so setting it here at module load is early enough. Each test uses
+// a distinct listId because the process-wide KV singleton is shared.
+Deno.env.set("KV_PATH", ":memory:");
+
+Deno.test("clearChecked — removes only checked items and returns their count", async () => {
+  const listId = "list-clear-1";
+  const a = await ShoppingListItemRepo.add(listId, "item-a");
+  const b = await ShoppingListItemRepo.add(listId, "item-b");
+  const c = await ShoppingListItemRepo.add(listId, "item-c");
+  await ShoppingListItemRepo.update(listId, a.id, { checked: true });
+  await ShoppingListItemRepo.update(listId, c.id, { checked: true });
+
+  const cleared = await ShoppingListItemRepo.clearChecked(listId);
+
+  assertEquals(cleared, 2);
+  const remaining = await ShoppingListItemRepo.getAll(listId);
+  assertEquals(remaining.map((i) => i.id), [b.id]);
+});
+
+Deno.test("clearChecked — returns 0 and deletes nothing when no item is checked", async () => {
+  const listId = "list-clear-2";
+  await ShoppingListItemRepo.add(listId, "item-a");
+  await ShoppingListItemRepo.add(listId, "item-b");
+
+  const cleared = await ShoppingListItemRepo.clearChecked(listId);
+
+  assertEquals(cleared, 0);
+  const remaining = await ShoppingListItemRepo.getAll(listId);
+  assertEquals(remaining.length, 2);
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `deno test --unstable-kv -A database/shopping-list-item.repo.test.ts`
+Expected: FAIL — `ShoppingListItemRepo.clearChecked is not a function` (TypeError).
+
+- [ ] **Step 4: Implement `clearChecked`**
+
+In `database/shopping-list-item.repo.ts`, add this method to the `ShoppingListItemRepo` class (place it after `deleteAll`):
+
+```ts
+  static async clearChecked(listId: string): Promise<number> {
+    const kv = await getKv();
+    let atomic = kv.atomic();
+    let count = 0;
+    for await (
+      const entry of kv.list<ShoppingListItemInterface>({
+        prefix: ["shopping_list_items", listId],
+      })
+    ) {
+      if (entry.value.checked) {
+        atomic = atomic.delete(entry.key);
+        count++;
+      }
+    }
+    if (count === 0) return 0;
+    const { ok } = await atomic.commit();
+    if (!ok) throw new Error("Failed to clear checked items.");
+    return count;
+  }
+```
+
+(`getKv` and `ShoppingListItemInterface` are already imported at the top of the file. `const { ok } = await atomic.commit()` destructures the commit result correctly — the raw result object is always truthy, so check `.ok`, not the object.)
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `deno test --unstable-kv -A database/shopping-list-item.repo.test.ts`
+Expected: PASS — 2 tests ok.
+
+- [ ] **Step 6: Update the test-command note in `CLAUDE.md`**
+
+In the "Build & Development Commands" list, replace:
+
+```md
+- `deno test` — Run tests
+```
+
+with:
+
+```md
+- `deno task test` — Run tests (uses `--unstable-kv -A`; required for KV-backed repo tests)
+```
+
+- [ ] **Step 7: Verify the full suite + checks are green**
+
+Run: `deno task test`
+Expected: PASS — all existing tests plus the 2 new repo tests.
+
+Run: `deno task check`
+Expected: no fmt/lint/type errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add deno.json CLAUDE.md database/shopping-list-item.repo.ts database/shopping-list-item.repo.test.ts
+git commit -m "$(cat <<'EOF'
+feat(shopping): add ShoppingListItemRepo.clearChecked bulk delete
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Shared auth helper + bulk-clear endpoint
+
+**Files:**
+- Create: `utils/authorize-list.ts`
+- Modify: `routes/api/shopping/lists/[id]/items.ts` (top imports + remove local `authorizeList`)
+- Create: `routes/api/shopping/lists/[id]/items/checked.ts`
+
+**Interfaces:**
+- Consumes: `ShoppingListRepo.getById(householdId, listId)` from `@/database/index.ts`; `StateInterface` from `@/utils/define.ts`; `Context` from `fresh`; `ShoppingListItemRepo.clearChecked` (Task 1); `define` from `@/utils/index.ts`.
+- Produces: `authorizeList(ctx: Context<StateInterface>, listId: string): Promise<ShoppingListInterface | null>`; route `DELETE /api/shopping/lists/:id/items/checked` → `200 { cleared: number }` or `403`.
+
+> No automated route test is added: the repo has no route-test harness and the handler is thin glue (authorize → repo → JSON). Its correctness is covered by the repo test (Task 1), the hook test (Task 3), `deno task check`, and the manual end-to-end check (Task 4).
+
+- [ ] **Step 1: Create the shared auth helper**
+
+Create `utils/authorize-list.ts`:
+
+```ts
+import { type Context } from "fresh";
+import { ShoppingListRepo } from "@/database/index.ts";
+import { type StateInterface } from "@/utils/define.ts";
+
+/**
+ * Resolve a shopping list and authorize it for the current household.
+ * Returns the list when it belongs to the caller's household, otherwise null.
+ */
+export async function authorizeList(
+  ctx: Context<StateInterface>,
+  listId: string,
+) {
+  const householdId = ctx.state.householdId;
+  if (!householdId) return null;
+  const list = await ShoppingListRepo.getById(householdId, listId);
+  if (!list) return null;
+  return list;
+}
+```
+
+- [ ] **Step 2: Refactor `items.ts` to use the shared helper**
+
+In `routes/api/shopping/lists/[id]/items.ts`, replace the top of the file — the imports (lines 1-3) and the local `authorizeList` function (lines 5-14) — with:
+
+```ts
+import { ShoppingListItemRepo } from "@/database/index.ts";
+import { define } from "@/utils/index.ts";
+import { authorizeList } from "@/utils/authorize-list.ts";
+```
+
+Leave the entire `export const handler = define.handlers({ ... })` block unchanged. (This removes the now-unused `Context`, `StateInterface`, and `ShoppingListRepo` imports — `ShoppingListRepo` was only used by the local `authorizeList`.)
+
+- [ ] **Step 3: Create the bulk-clear route**
+
+Create `routes/api/shopping/lists/[id]/items/checked.ts`:
+
+```ts
+import { ShoppingListItemRepo } from "@/database/index.ts";
+import { define } from "@/utils/index.ts";
+import { authorizeList } from "@/utils/authorize-list.ts";
+
+export const handler = define.handlers({
+  async DELETE(ctx) {
+    const list = await authorizeList(ctx, ctx.params.id);
+    if (!list) return new Response("Forbidden", { status: 403 });
+    const cleared = await ShoppingListItemRepo.clearChecked(list.id);
+    return new Response(JSON.stringify({ cleared }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  },
+});
+```
+
+- [ ] **Step 4: Verify checks pass**
+
+Run: `deno task check`
+Expected: no fmt/lint/type errors (in particular, no "unused import" errors in `items.ts`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add utils/authorize-list.ts "routes/api/shopping/lists/[id]/items.ts" "routes/api/shopping/lists/[id]/items/checked.ts"
+git commit -m "$(cat <<'EOF'
+feat(shopping): add DELETE .../items/checked bulk-clear endpoint
+
+Extract authorizeList into a shared helper reused by both the items
+route and the new checked-items route.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Client service + hook action (with tests)
+
+**Files:**
+- Modify: `services/api.ts` (`shoppingList` object)
+- Modify: `hooks/useShoppingList.ts`
+- Test: `hooks/useShoppingList.test.ts`
+
+**Interfaces:**
+- Consumes: `api.shoppingList.clearChecked` (added here); `patchScheduler.cancel`, `checkedItems`, `pendingCount`, `listId` (existing in the hook).
+- Produces: `api.shoppingList.clearChecked(listId: string): Promise<number | null>` (`null` = request failed); `useShoppingList(...).clearCheckedItems(): Promise<void>` — optimistically empties `checkedItems`, rolls back on failure.
+
+- [ ] **Step 1: Add the service method**
+
+In `services/api.ts`, inside the `shoppingList` object, add `clearChecked` immediately after `removeItem`:
+
+```ts
+    clearChecked: async (listId: string): Promise<number | null> => {
+      const res = await fetch(`/api/shopping/lists/${listId}/items/checked`, {
+        method: "DELETE",
+      });
+      if (!res.ok) return null;
+      const data = await res.json();
+      return data.cleared as number;
+    },
+```
+
+- [ ] **Step 2: Write the failing hook tests**
+
+Append to `hooks/useShoppingList.test.ts` (the `stub`, `api`, `useShoppingList`, `assertEquals`, `makeItem`, `makeListItem`, and `TEST_LIST_ID` helpers already exist at the top of the file):
+
+```ts
+// ── clearCheckedItems ──────────────────────────────────────────────────────────
+
+Deno.test("clearCheckedItems — empties checkedItems with a single api call", async () => {
+  using clear = stub(
+    api.shoppingList,
+    "clearChecked",
+    () => Promise.resolve(2),
+  );
+
+  const hook = useShoppingList(
+    TEST_LIST_ID,
+    [makeItem("item-1", "Milk")],
+    [
+      makeListItem("sl-1", "item-1", true),
+      makeListItem("sl-2", "item-1", true),
+    ],
+  );
+
+  assertEquals(hook.checkedItems.value.length, 2);
+  await hook.clearCheckedItems();
+
+  assertEquals(hook.checkedItems.value.length, 0);
+  assertEquals(clear.calls.length, 1);
+});
+
+Deno.test("clearCheckedItems — rolls back checkedItems when the request fails", async () => {
+  using _clear = stub(
+    api.shoppingList,
+    "clearChecked",
+    () => Promise.resolve(null),
+  );
+
+  const hook = useShoppingList(
+    TEST_LIST_ID,
+    [makeItem("item-1", "Milk")],
+    [makeListItem("sl-1", "item-1", true)],
+  );
+
+  await hook.clearCheckedItems();
+
+  assertEquals(hook.checkedItems.value.length, 1);
+  assertEquals(hook.checkedItems.value[0].id, "sl-1");
+});
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `deno test --unstable-kv -A hooks/useShoppingList.test.ts`
+Expected: FAIL — `hook.clearCheckedItems is not a function`.
+
+- [ ] **Step 4: Implement `clearCheckedItems` in the hook**
+
+In `hooks/useShoppingList.ts`, add this function immediately after `uncheckItem` (before `refresh`):
+
+```ts
+  const clearCheckedItems = async () => {
+    const snapshot = checkedItems.value;
+    if (snapshot.length === 0) return;
+    // Cancel any in-flight debounced writes for items being cleared, so a
+    // late flush can't resurrect a deleted item.
+    for (const li of snapshot) {
+      if (li.id) patchScheduler.cancel(li.id);
+    }
+    checkedItems.value = [];
+    pendingCount.value++;
+    try {
+      const cleared = await api.shoppingList.clearChecked(listId);
+      if (cleared === null) checkedItems.value = snapshot; // rollback on failure
+    } finally {
+      pendingCount.value--;
+    }
+  };
+```
+
+Then add `clearCheckedItems,` to the object returned at the end of the hook (next to `flushListItem,`):
+
+```ts
+    lastSaved,
+    flushListItem,
+    clearCheckedItems,
+  };
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `deno test --unstable-kv -A hooks/useShoppingList.test.ts`
+Expected: PASS — both new tests ok.
+
+- [ ] **Step 6: Verify full checks**
+
+Run: `deno task check`
+Expected: no fmt/lint/type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add services/api.ts hooks/useShoppingList.ts hooks/useShoppingList.test.ts
+git commit -m "$(cat <<'EOF'
+feat(shopping): add clearCheckedItems client action with rollback
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Wire the UI + end-to-end verification
+
+**Files:**
+- Modify: `islands/items.tsx` (hook destructure ~line 60; "Clear checked items" `onClick` ~lines 500-508)
+
+**Interfaces:**
+- Consumes: `clearCheckedItems` from `useShoppingList` (Task 3).
+- Produces: the "Clear checked items" button issues a single `DELETE .../items/checked` instead of N per-item DELETEs.
+
+- [ ] **Step 1: Destructure `clearCheckedItems` from the hook**
+
+In `islands/items.tsx`, in the `useMemo(() => useShoppingList(...))` destructure, add `clearCheckedItems` after `flushListItem`:
+
+```tsx
+    lastSaved,
+    flushListItem,
+    clearCheckedItems,
+  } = useMemo(
+    () => useShoppingList(listId, catalog, shoppingList, initialCategories),
+    [], // intentionally empty — signals are initialized once from SSR data
+  );
+```
+
+- [ ] **Step 2: Replace the per-item clear loop with the bulk action**
+
+Find the "Clear checked" `ListItem`'s `onClick` (currently):
+
+```tsx
+            onClick={async () => {
+              const ids = checkedItems.value.map((li) => li.id!).filter(
+                Boolean,
+              );
+              mgmtOpen.value = false;
+              for (const id of ids) {
+                await removeListItem(id);
+              }
+            }}
+```
+
+Replace it with:
+
+```tsx
+            onClick={async () => {
+              mgmtOpen.value = false;
+              await clearCheckedItems();
+            }}
+```
+
+(Keep `removeListItem` in the destructure — it is still used elsewhere in the file, e.g. the item-editor delete.)
+
+- [ ] **Step 3: Verify checks pass**
+
+Run: `deno task check`
+Expected: no fmt/lint/type errors (no "unused var" for `removeListItem` — still used; `checkedItems` still used elsewhere).
+
+Run: `deno task test`
+Expected: PASS — whole suite green.
+
+- [ ] **Step 4: Manual end-to-end verification (browser preview)**
+
+Use the browser preview tooling (not manual hand-off):
+
+1. Start the dev server: `preview_start` with the dev launch config (Vite dev server). If `.claude/launch.json` has no entry, add one running `deno task dev` on its port.
+2. Log in (seed a demo user first if needed: `deno task db:seed`), open a shopping list, and add a few items.
+3. Check off 2-3 items (they move to the "In cart" section).
+4. Open the list management sheet and tap **Clear checked items**.
+5. In `read_network_requests`, confirm exactly **one** `DELETE` request to `/api/shopping/lists/<id>/items/checked` (not one per item), returning `200` with `{ "cleared": <n> }`.
+6. Confirm via `read_page` / screenshot that the checked section is now empty and no console errors appear (`read_console_messages`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add islands/items.tsx
+git commit -m "$(cat <<'EOF'
+feat(shopping): clear checked items in one request from the UI
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-Review (completed while writing)
+
+- **Spec coverage:** repo method (Task 1), dedicated endpoint + shared auth (Task 2), client service + hook with rollback (Task 3), UI wiring + e2e (Task 4), repo + hook tests + tooling (Tasks 1 & 3). All spec sections mapped.
+- **Placeholders:** none — every code step shows complete code and exact commands.
+- **Type consistency:** `clearChecked` returns `Promise<number>` (repo) / `Promise<number | null>` (service, `null` = failure); `clearCheckedItems(): Promise<void>`; endpoint returns `{ cleared: number }`. Names consistent across tasks.
+- **Known deviation from spec snippet:** the repo uses `const { ok } = await atomic.commit()` (correct `.ok` check) rather than the spec's `const ok = ...`; this is a correctness refinement, noted in Task 1 Step 4.

--- a/docs/superpowers/specs/2026-07-23-bulk-clear-checked-items-design.md
+++ b/docs/superpowers/specs/2026-07-23-bulk-clear-checked-items-design.md
@@ -1,0 +1,186 @@
+# Bulk-clear checked items — Design
+
+**Issue:** [#33 — Add API support for bulk clearing checked items in shopping
+list](https://github.com/FredericGryspeerdt/happie-fresh/issues/33)
+
+**Date:** 2026-07-23
+
+## Problem
+
+Clearing the checked-off items from a shopping list currently issues **one
+DELETE request per item**. The "Clear checked items" action in
+`islands/items.tsx` loops over every checked id and `await`s `removeListItem(id)`
+sequentially — each call is a separate network round-trip _and_ waits out a
+300ms exit animation. For a cart with N checked items this is N requests and at
+least N×300ms of latency.
+
+## Goal
+
+Clear all checked items in a single API call, and wire the existing UI action to
+use it — turning N sequential requests into 1.
+
+"Clearing" means **permanent deletion** of the checked items (the current
+behaviour), not merely un-checking them.
+
+## Non-goals
+
+- Undo / restore of cleared items.
+- Bulk operations other than clearing checked items (e.g. bulk check/uncheck).
+- Changing the single-item DELETE semantics.
+
+## Design
+
+### 1. Repository — `ShoppingListItemRepo.clearChecked`
+
+New method in `database/shopping-list-item.repo.ts`:
+
+```ts
+static async clearChecked(listId: string): Promise<number> {
+  const kv = await getKv();
+  let atomic = kv.atomic();
+  let count = 0;
+  for await (
+    const entry of kv.list<ShoppingListItemInterface>({
+      prefix: ["shopping_list_items", listId],
+    })
+  ) {
+    if (entry.value.checked) {
+      atomic = atomic.delete(entry.key);
+      count++;
+    }
+  }
+  if (count === 0) return 0;
+  const ok = await atomic.commit();
+  if (!ok) throw new Error("Failed to clear checked items.");
+  return count;
+}
+```
+
+- Deletes **only** items where `checked === true`; unchecked items are
+  untouched.
+- All deletes commit in a single atomic transaction, mirroring the established
+  batch pattern in `CategoryRepo.reorder`.
+- Returns the number of items cleared. Empty case commits nothing and returns
+  `0`.
+
+### 2. API endpoint — dedicated route
+
+New file `routes/api/shopping/lists/[id]/items/checked.ts` exposing a `DELETE`
+handler, i.e. `DELETE /api/shopping/lists/:id/items/checked`. The "checked
+items" sub-collection is treated as its own resource.
+
+- Authorization: household → list-ownership check, identical to the sibling
+  `items.ts` route. On failure return `403 Forbidden`.
+- Success: `200` with body `{ cleared: <number> }` (the count may be `0`).
+
+**Auth helper extraction.** `authorizeList(ctx, listId)` currently lives as a
+private function inside `routes/api/shopping/lists/[id]/items.ts`. To avoid
+duplicating it across the two sibling routes, extract it into a small
+co-located, non-routed module (underscore-prefixed so Fresh does not treat it as
+a route, e.g. `routes/api/shopping/lists/[id]/_list-auth.ts`). Both `items.ts`
+and `checked.ts` import it. Fresh 2's underscore-exclusion behaviour and the
+`define.handlers` signature will be confirmed against the live docs (Context7)
+before coding; if underscore-exclusion is not reliable, fall back to a helper
+under `utils/`.
+
+### 3. Client service
+
+Add to `services/api.ts` under `shoppingList`:
+
+```ts
+clearChecked: async (listId: string): Promise<number | null> => {
+  const res = await fetch(`/api/shopping/lists/${listId}/items/checked`, {
+    method: "DELETE",
+  });
+  if (!res.ok) return null; // null signals failure so the caller can roll back
+  return (await res.json()).cleared as number;
+},
+```
+
+Returning `number | null` lets the hook distinguish "nothing to clear" (`0`)
+from "request failed" (`null`).
+
+### 4. Hook — `useShoppingList.clearCheckedItems`
+
+Optimistic single-shot clear that replaces the per-item loop:
+
+```ts
+const clearCheckedItems = async () => {
+  const snapshot = checkedItems.value;
+  if (snapshot.length === 0) return;
+  // cancel any in-flight debounced writes for the items being cleared
+  for (const li of snapshot) if (li.id) patchScheduler.cancel(li.id);
+  checkedItems.value = [];
+  pendingCount.value++;
+  try {
+    const cleared = await api.shoppingList.clearChecked(listId);
+    if (cleared === null) checkedItems.value = snapshot; // rollback on failure
+  } finally {
+    pendingCount.value--;
+  }
+};
+```
+
+Exposed from the hook's return object.
+
+**Concurrency note:** if an item is checked while the clear request is in
+flight and the request then fails, the rollback restores the pre-clear snapshot
+and the concurrently-checked item is dropped from `checkedItems` in memory (it
+still exists server-side and reappears on next `refresh`). This is an accepted
+edge case for an optimistic single-user-per-moment flow.
+
+### 5. UI wiring
+
+In `islands/items.tsx`, the "Clear checked items" `ListItem` `onClick` currently
+does:
+
+```ts
+const ids = checkedItems.value.map((li) => li.id!).filter(Boolean);
+mgmtOpen.value = false;
+for (const id of ids) await removeListItem(id);
+```
+
+Replace with:
+
+```ts
+mgmtOpen.value = false;
+await clearCheckedItems();
+```
+
+`clearCheckedItems` is destructured from `useShoppingList`.
+
+## Error handling
+
+| Situation                | Result                                  |
+| ------------------------ | --------------------------------------- |
+| List not owned by caller | `403 Forbidden`                         |
+| Nothing checked          | `200 { cleared: 0 }` (no KV write)      |
+| Atomic commit fails      | throws → `500`                          |
+| Client request fails     | service returns `null` → hook rolls back|
+
+## Testing
+
+Built test-first (TDD).
+
+- **Repo test** — new `database/shopping-list-item.repo.test.ts` using an
+  in-memory KV (`KV_PATH=":memory:"`, unique `listId`s per case):
+  - clears only checked items and returns the correct count;
+  - leaves unchecked items intact;
+  - returns `0` for a list with nothing checked.
+
+  Because these tests exercise Deno KV, add a `"test": "deno test --unstable-kv
+  -A"` task to `deno.json` and update the test-command note in `CLAUDE.md`
+  (bare `deno test` cannot open KV without `--unstable-kv`).
+
+- **Hook test** — extend `hooks/useShoppingList.test.ts` using the existing
+  `stub` pattern on `api.shoppingList.clearChecked`:
+  - success empties `checkedItems` with exactly one api call;
+  - failure (stub returns `null`) rolls `checkedItems` back to its prior value.
+
+## Verification
+
+- `deno task check` (fmt + lint + type check) green.
+- `deno task test` green.
+- Manual: check off items, use "Clear checked items", confirm a single
+  `DELETE .../items/checked` request in the network panel and that the checked
+  section empties.

--- a/hooks/useShoppingList.test.ts
+++ b/hooks/useShoppingList.test.ts
@@ -397,3 +397,47 @@ Deno.test("addToCatalog — pendingCount returns to 0 after completion", async (
 
   assertEquals(hook.pendingCount.value, 0);
 });
+
+// ── clearCheckedItems ──────────────────────────────────────────────────────────
+
+Deno.test("clearCheckedItems — empties checkedItems with a single api call", async () => {
+  using clear = stub(
+    api.shoppingList,
+    "clearChecked",
+    () => Promise.resolve(2),
+  );
+
+  const hook = useShoppingList(
+    TEST_LIST_ID,
+    [makeItem("item-1", "Milk")],
+    [
+      makeListItem("sl-1", "item-1", true),
+      makeListItem("sl-2", "item-1", true),
+    ],
+  );
+
+  assertEquals(hook.checkedItems.value.length, 2);
+  await hook.clearCheckedItems();
+
+  assertEquals(hook.checkedItems.value.length, 0);
+  assertEquals(clear.calls.length, 1);
+});
+
+Deno.test("clearCheckedItems — rolls back checkedItems when the request fails", async () => {
+  using _clear = stub(
+    api.shoppingList,
+    "clearChecked",
+    () => Promise.resolve(null),
+  );
+
+  const hook = useShoppingList(
+    TEST_LIST_ID,
+    [makeItem("item-1", "Milk")],
+    [makeListItem("sl-1", "item-1", true)],
+  );
+
+  await hook.clearCheckedItems();
+
+  assertEquals(hook.checkedItems.value.length, 1);
+  assertEquals(hook.checkedItems.value[0].id, "sl-1");
+});

--- a/hooks/useShoppingList.ts
+++ b/hooks/useShoppingList.ts
@@ -148,6 +148,24 @@ export function useShoppingList(
     }
   };
 
+  const clearCheckedItems = async () => {
+    const snapshot = checkedItems.value;
+    if (snapshot.length === 0) return;
+    // Cancel any in-flight debounced writes for items being cleared, so a
+    // late flush can't resurrect a deleted item.
+    for (const li of snapshot) {
+      if (li.id) patchScheduler.cancel(li.id);
+    }
+    checkedItems.value = [];
+    pendingCount.value++;
+    try {
+      const cleared = await api.shoppingList.clearChecked(listId);
+      if (cleared === null) checkedItems.value = snapshot; // rollback on failure
+    } finally {
+      pendingCount.value--;
+    }
+  };
+
   const refresh = async () => {
     pendingCount.value++;
     try {
@@ -241,5 +259,6 @@ export function useShoppingList(
     listItemsMap,
     lastSaved,
     flushListItem,
+    clearCheckedItems,
   };
 }

--- a/islands/items.tsx
+++ b/islands/items.tsx
@@ -58,6 +58,7 @@ export default function Items(
     items,
     lastSaved,
     flushListItem,
+    clearCheckedItems,
   } = useMemo(
     () => useShoppingList(listId, catalog, shoppingList, initialCategories),
     [], // intentionally empty — signals are initialized once from SSR data
@@ -498,13 +499,8 @@ export default function Items(
               </span>
             }
             onClick={async () => {
-              const ids = checkedItems.value.map((li) => li.id!).filter(
-                Boolean,
-              );
               mgmtOpen.value = false;
-              for (const id of ids) {
-                await removeListItem(id);
-              }
+              await clearCheckedItems();
             }}
           />
 

--- a/routes/api/shopping/lists/[id]/items.ts
+++ b/routes/api/shopping/lists/[id]/items.ts
@@ -1,17 +1,6 @@
-import { type Context } from "fresh";
-import { ShoppingListItemRepo, ShoppingListRepo } from "@/database/index.ts";
-import { define, type StateInterface } from "@/utils/index.ts";
-
-async function authorizeList(
-  ctx: Context<StateInterface>,
-  listId: string,
-) {
-  const householdId = ctx.state.householdId;
-  if (!householdId) return null;
-  const list = await ShoppingListRepo.getById(householdId, listId);
-  if (!list) return null;
-  return list;
-}
+import { ShoppingListItemRepo } from "@/database/index.ts";
+import { define } from "@/utils/index.ts";
+import { authorizeList } from "@/utils/authorize-list.ts";
 
 export const handler = define.handlers({
   async GET(ctx) {

--- a/routes/api/shopping/lists/[id]/items/checked.ts
+++ b/routes/api/shopping/lists/[id]/items/checked.ts
@@ -1,0 +1,15 @@
+import { ShoppingListItemRepo } from "@/database/index.ts";
+import { define } from "@/utils/index.ts";
+import { authorizeList } from "@/utils/authorize-list.ts";
+
+export const handler = define.handlers({
+  async DELETE(ctx) {
+    const list = await authorizeList(ctx, ctx.params.id);
+    if (!list) return new Response("Forbidden", { status: 403 });
+    const cleared = await ShoppingListItemRepo.clearChecked(list.id);
+    return new Response(JSON.stringify({ cleared }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  },
+});

--- a/services/api.ts
+++ b/services/api.ts
@@ -156,5 +156,13 @@ export const api = {
         body: JSON.stringify({ id }),
       });
     },
+    clearChecked: async (listId: string): Promise<number | null> => {
+      const res = await fetch(`/api/shopping/lists/${listId}/items/checked`, {
+        method: "DELETE",
+      });
+      if (!res.ok) return null;
+      const data = await res.json();
+      return data.cleared as number;
+    },
   },
 };

--- a/utils/authorize-list.ts
+++ b/utils/authorize-list.ts
@@ -1,0 +1,18 @@
+import { type Context } from "fresh";
+import { ShoppingListRepo } from "@/database/index.ts";
+import { type StateInterface } from "@/utils/define.ts";
+
+/**
+ * Resolve a shopping list and authorize it for the current household.
+ * Returns the list when it belongs to the caller's household, otherwise null.
+ */
+export async function authorizeList(
+  ctx: Context<StateInterface>,
+  listId: string,
+) {
+  const householdId = ctx.state.householdId;
+  if (!householdId) return null;
+  const list = await ShoppingListRepo.getById(householdId, listId);
+  if (!list) return null;
+  return list;
+}


### PR DESCRIPTION
## Summary

Closes #33.

Clearing checked-off items previously issued **one DELETE per item** (N sequential requests, each with a 300 ms exit animation). This replaces that with a single bulk-clear API call, wired end-to-end.

## Changes

- **Repo** — `ShoppingListItemRepo.clearChecked(listId): Promise<number>` deletes only `checked` items in one Deno KV atomic transaction (mirrors the `CategoryRepo.reorder` batch pattern) and returns the count.
- **Endpoint** — new `DELETE /api/shopping/lists/:id/items/checked` → `200 { cleared: <n> }`, or `403` when the list isn't owned by the caller's household. The `authorizeList` guard is extracted into a shared, server-only `utils/authorize-list.ts` reused by both the items route and the new one.
- **Client** — `api.shoppingList.clearChecked` + a `useShoppingList().clearCheckedItems()` hook action: optimistic single-shot clear that cancels pending debounced writes and rolls back on failure.
- **UI** — the "Clear checked items" button now calls `clearCheckedItems()` instead of looping per-item: **N requests → 1**.
- **Tooling** — added a `deno task test` task (`deno test --unstable-kv -A`) so KV-backed repo tests can run; updated the `CLAUDE.md` note.

## Testing

- New repo tests (in-memory KV): clears only checked items + returns count; returns `0` when nothing is checked.
- New hook tests: optimistic empty with a single API call; rollback on failure.
- `deno task check` and `deno task test` green (**95 passed / 0 failed**).
- **Live end-to-end** against the dev server: the button fired exactly one `DELETE .../items/checked → 200 {"cleared":2}` (no per-item loop); only checked items were deleted (unchecked survived); edge cases returned `200 {cleared:0}` (nothing checked), `401` (unauthenticated), `403` (list not owned).

## Notes

Design spec and implementation plan are committed under `docs/superpowers/`. A few deferred, non-blocking edge cases (optimistic-concurrency, the 1000-op atomic cap) match existing repo-wide conventions and self-heal on refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)