### PR TITLE
feat: visual loading feedback for navigation and CRUD (#32)

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -267,6 +267,47 @@
   }
 }
 
+/* Global navigation/CRUD loading bar — wavy indeterminate (issue #32) */
+@keyframes md-loadbar-travel {
+  from {
+    -webkit-mask-position: 0 center;
+    mask-position: 0 center;
+  }
+  to {
+    -webkit-mask-position: 24px center;
+    mask-position: 24px center;
+  }
+}
+@keyframes md-loadbar-pulse {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+.md-loadbar-track {
+  height: 6px;
+  background: var(--md-primary-container);
+  overflow: hidden;
+}
+.md-loadbar-wave {
+  height: 100%;
+  background: var(--md-primary);
+  -webkit-mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='24' height='6'><path d='M0 3 Q 6 0 12 3 T 24 3' fill='none' stroke='black' stroke-width='3'/></svg>");
+  mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='24' height='6'><path d='M0 3 Q 6 0 12 3 T 24 3' fill='none' stroke='black' stroke-width='3'/></svg>");
+  -webkit-mask-repeat: repeat-x;
+  mask-repeat: repeat-x;
+  -webkit-mask-size: 24px 6px;
+  mask-size: 24px 6px;
+  animation: md-loadbar-travel 0.6s linear infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .md-loadbar-wave {
+    animation: md-loadbar-pulse 1.4s ease-in-out infinite;
+  }
+}
+
 body {
   background: var(--md-background);
   color: var(--md-on-surface);

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -260,6 +260,13 @@
   animation: md-saved-flash 1.6s var(--md-emphasized) forwards;
 }
 
+/* Circular indeterminate spinner (issue #32) */
+@keyframes md-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 body {
   background: var(--md-background);
   color: var(--md-on-surface);

--- a/components/md3/Button.test.tsx
+++ b/components/md3/Button.test.tsx
@@ -8,3 +8,10 @@ Deno.test("Button — filled variant uses primary background utility", () => {
   assertStringIncludes(html, "bg-primary");
   assertStringIncludes(html, "Save");
 });
+
+Deno.test("Button — loading renders a spinner and disabled styling", () => {
+  const html = render(h(Button, { loading: true }, "Save"));
+  assertStringIncludes(html, 'role="status"'); // the spinner
+  assertStringIncludes(html, "38%"); // disabled text mix (color-mix ... 38%)
+  assertStringIncludes(html, "Save");
+});

--- a/components/md3/Button.tsx
+++ b/components/md3/Button.tsx
@@ -3,6 +3,7 @@ import type { ComponentChildren, JSX } from "preact";
 import { Pressable } from "./Pressable.tsx";
 import { Icon, type IconName } from "./Icon.tsx";
 import { cn } from "./tokens.ts";
+import { Spinner } from "./Spinner.tsx";
 
 type Variant = "filled" | "tonal" | "elevated" | "outlined" | "text" | "error";
 const VARIANT: Record<Variant, string> = {
@@ -20,6 +21,7 @@ interface ButtonProps {
   full?: boolean;
   onClick?: (e: Event) => void;
   disabled?: boolean;
+  loading?: boolean;
   class?: string;
   style?: JSX.CSSProperties;
   children?: ComponentChildren;
@@ -32,27 +34,29 @@ export function Button(
     full,
     onClick,
     disabled,
+    loading,
     class: cls,
     style,
     children,
   }: ButtonProps,
 ) {
+  const isDisabled = disabled || loading;
   return (
     <Pressable
       onClick={onClick}
-      disabled={disabled}
+      disabled={isDisabled}
       class={cn(
         "md-label-large inline-flex items-center justify-center gap-2 h-10 rounded-[var(--md-shape-full)] whitespace-nowrap",
-        icon ? "pl-4 pr-[22px]" : "px-6",
+        icon || loading ? "pl-4 pr-[22px]" : "px-6",
         full ? "w-full" : "w-auto",
-        disabled
+        isDisabled
           ? "bg-[color-mix(in_srgb,var(--md-on-surface)_12%,transparent)] text-[color-mix(in_srgb,var(--md-on-surface)_38%,transparent)]"
           : VARIANT[variant],
         cls,
       )}
       style={style}
     >
-      {icon && <Icon name={icon} size={18} />}
+      {loading ? <Spinner size={18} /> : icon && <Icon name={icon} size={18} />}
       {children}
     </Pressable>
   );

--- a/components/md3/Spinner.test.tsx
+++ b/components/md3/Spinner.test.tsx
@@ -1,0 +1,15 @@
+import { assertStringIncludes } from "jsr:@std/assert@^1.0.19";
+import { render } from "npm:preact-render-to-string@^6.6.3";
+import { h } from "preact";
+import { Spinner } from "./Spinner.tsx";
+
+Deno.test("Spinner — renders status role and a default Loading label", () => {
+  const html = render(h(Spinner, {}));
+  assertStringIncludes(html, 'role="status"');
+  assertStringIncludes(html, "Loading");
+});
+
+Deno.test("Spinner — applies a custom size", () => {
+  const html = render(h(Spinner, { size: 40 }));
+  assertStringIncludes(html, "40px");
+});

--- a/components/md3/Spinner.tsx
+++ b/components/md3/Spinner.tsx
@@ -1,0 +1,38 @@
+// components/md3/Spinner.tsx
+import type { ComponentChildren } from "preact";
+import { cn } from "./tokens.ts";
+
+interface SpinnerProps {
+  /** Diameter in px. */
+  size?: number;
+  /** Any CSS color; defaults to currentColor so it inherits text color. */
+  color?: string;
+  class?: string;
+  "aria-label"?: string;
+  children?: ComponentChildren;
+}
+
+export function Spinner(
+  { size = 20, color = "currentColor", class: cls, "aria-label": ariaLabel }:
+    SpinnerProps,
+) {
+  const label = ariaLabel ?? "Loading";
+  const borderWidth = Math.max(2, Math.round(size / 10));
+  return (
+    <span role="status" class={cn("inline-block align-middle", cls)}>
+      <span
+        class="block rounded-[var(--md-shape-full)]"
+        style={{
+          width: size,
+          height: size,
+          borderWidth,
+          borderStyle: "solid",
+          borderColor: `color-mix(in srgb, ${color} 24%, transparent)`,
+          borderTopColor: color,
+          animation: "md-spin 0.7s linear infinite",
+        }}
+      />
+      <span class="sr-only">{label}</span>
+    </span>
+  );
+}

--- a/deno.lock
+++ b/deno.lock
@@ -1136,6 +1136,7 @@
     "https://esm.sh/v135/@types/babel__helper-validator-identifier@~7/index.d.ts": "https://esm.sh/v135/@types/babel__helper-validator-identifier@7.15.2/index.d.ts"
   },
   "remote": {
+    "https://cdn.jsdelivr.net/npm/@pwabuilder/pwaupdate": "7d60f6be3a54a3cf6b48e76e50f9b029391f4e21f5cf26523c40b7a4cf555602",
     "https://deno.land/std@0.208.0/assert/_constants.ts": "8a9da298c26750b28b326b297316cdde860bc237533b07e1337c021379e6b2a9",
     "https://deno.land/std@0.208.0/assert/_diff.ts": "58e1461cc61d8eb1eacbf2a010932bf6a05b79344b02ca38095f9b805795dc48",
     "https://deno.land/std@0.208.0/assert/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",

--- a/docs/superpowers/plans/2026-07-23-loading-feedback.md
+++ b/docs/superpowers/plans/2026-07-23-loading-feedback.md
@@ -317,11 +317,9 @@ git commit -m "feat(md3): add circular indeterminate Spinner primitive"
 
 - [ ] **Step 1: Add a failing test**
 
-Append to `components/md3/Button.test.tsx`:
+Append to `components/md3/Button.test.tsx` (the existing `render`, `h`, `assertStringIncludes`, and `Button` imports at the top of the file already cover this test — do NOT add new imports, or `deno lint` will flag them as unused):
 
 ```tsx
-import { Spinner } from "./Spinner.tsx"; // ensure module resolves
-
 Deno.test("Button — loading renders a spinner and disabled styling", () => {
   const html = render(h(Button, { loading: true }, "Save"));
   assertStringIncludes(html, 'role="status"'); // the spinner

--- a/docs/superpowers/plans/2026-07-23-loading-feedback.md
+++ b/docs/superpowers/plans/2026-07-23-loading-feedback.md
@@ -1,0 +1,973 @@
+# Visual Loading Feedback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give users MD3-styled, non-blocking loading feedback for page navigation and in-flight CRUD, delivered as reusable primitives.
+
+**Architecture:** A module-scope signal channel (`utils/loading.ts`) mirrors the existing `utils/app-bar.ts` cross-island pattern. A single `GlobalLoadingBar` island in the app shell renders a wavy indeterminate MD3 bar, driven by a `navPending` signal (set via centralized click interception + a `navigateTo()` helper) and a `busyCount` signal (fed by the existing optimistic-mutation hooks). Two small primitives — a circular `Spinner` and a `loading` state on `Button` — cover awaited actions. CRUD stays optimistic; nothing blocks.
+
+**Tech Stack:** Deno, Fresh 2 (SSR + Islands), Preact, `@preact/signals`, Tailwind CSS v4, Deno KV. Tests: `preact-render-to-string` + `jsr:@std/assert`.
+
+## Global Constraints
+
+- **Imports:** use the `@/` alias for project root (e.g. `import { navPending } from "@/utils/loading.ts"`).
+- **JSX:** Preact with `jsx: "precompile"` — always `class`, never `className`.
+- **Signals:** module-scope `signal()` ONLY in `utils/*` (never in a component body); inside islands/components use `useSignal()` / `useSignalEffect()`.
+- **Styling:** Tailwind semantic utilities backed by `--md-*` tokens (`bg-primary`, `text-on-surface-variant`, `bg-primary-container`, `rounded-[var(--md-shape-full)]`); motion easing `var(--md-emphasized)`.
+- **Islands rule:** only `islands/*` hydrate. Presentational primitives live in `components/md3/`. `GlobalLoadingBar` must be an island (installs listeners + reactive reads).
+- **Tests:** mirror `components/md3/*.test.tsx` — `render(h(Component, props, children))` + `assertStringIncludes`. There is NO DOM/jsdom test environment; SSR-render assertions + pure-function tests only. Interactive/timer behavior is verified in the browser preview.
+- **Verification gate:** `deno task check` (`deno fmt --check && deno lint && deno check`) must be green before every commit. Run `deno fmt` first to auto-format.
+- **Commits:** Conventional Commits. Scope `feat(loading)` / `feat(md3)` as appropriate.
+- **Discipline:** DRY, YAGNI, TDD, frequent commits.
+- **Out of scope (do NOT build):** skeleton loaders, the full MD3 morphing indicator, any client router/Partials, any API/repository/model change.
+
+## File Structure
+
+- `utils/loading.ts` — **new.** Module-scope `navPending` + `busyCount` signals; `navigateTo`/`reloadPage`/`beginBusy`/`endBusy` helpers; pure `shouldInterceptNav()`. Sole owner of loading state; the cross-island channel.
+- `utils/loading.test.ts` — **new.** Unit tests for the helpers + `shouldInterceptNav`.
+- `components/md3/Spinner.tsx` (+ `.test.tsx`) — **new.** Circular indeterminate spinner primitive.
+- `components/md3/Button.tsx` (+ `.test.tsx`) — **modify.** Add `loading` prop.
+- `islands/shell/GlobalLoadingBar.tsx` (+ `.test.tsx`) — **new.** The wavy bar island; installs nav interception; reads `utils/loading.ts`.
+- `assets/styles.css` — **modify.** New keyframes (`md-spin`, `md-loadbar-travel`, `md-loadbar-pulse`) + `.md-loadbar-track` / `.md-loadbar-wave` classes.
+- `islands/shell/AppChrome.tsx` — **modify.** Mount `GlobalLoadingBar` (including full-screen `mode:"none"` routes).
+- `islands/shell/NavigationBar.tsx`, `islands/shell/MoreSheet.tsx`, `islands/shopping-lists.tsx`, `islands/catalogue.tsx`, `islands/items.tsx` — **modify.** Route imperative navigations through `navigateTo`/`reloadPage`.
+- `hooks/useShoppingList.ts`, `hooks/useCatalogue.ts` — **modify.** Feed `busyCount`; `useShoppingList` also gains a `savingIds` signal for the "Saving…" phase.
+- `islands/shopping-lists.tsx` — **modify.** Create-list button `loading` state.
+- `islands/items.tsx` — **modify.** "Saving…" branch in the editor pill.
+
+---
+
+### Task 1: Shared loading state — `utils/loading.ts`
+
+**Files:**
+- Create: `utils/loading.ts`
+- Test: `utils/loading.test.ts`
+
+**Interfaces:**
+- Consumes: `signal` from `@preact/signals`.
+- Produces:
+  - `navPending: Signal<boolean>` — a navigation is in flight.
+  - `busyCount: Signal<number>` — count of in-flight background mutations.
+  - `navigateTo(url: string): void` — set `navPending`, then assign `location.href`.
+  - `reloadPage(): void` — set `navPending`, then `location.reload()`.
+  - `beginBusy(): void` / `endBusy(): void` — increment / decrement `busyCount` (floored at 0).
+  - `shouldInterceptNav(opts: { href: string | null; target?: string | null; download?: boolean; modified?: boolean; currentHref: string }): boolean` — pure decision for whether a link click is an internal navigation worth showing the bar for.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `utils/loading.test.ts`:
+
+```tsx
+import { assert, assertEquals } from "jsr:@std/assert@^1.0.19";
+import {
+  beginBusy,
+  busyCount,
+  endBusy,
+  navigateTo,
+  navPending,
+  shouldInterceptNav,
+} from "./loading.ts";
+
+Deno.test("beginBusy/endBusy balance busyCount and floor at zero", () => {
+  busyCount.value = 0;
+  beginBusy();
+  beginBusy();
+  assertEquals(busyCount.value, 2);
+  endBusy();
+  endBusy();
+  endBusy(); // extra end must not go negative
+  assertEquals(busyCount.value, 0);
+});
+
+Deno.test("navigateTo sets navPending (nav is a no-op without a DOM location)", () => {
+  navPending.value = false;
+  navigateTo("/shopping");
+  assert(navPending.value);
+});
+
+Deno.test("shouldInterceptNav — internal same-origin link is intercepted", () => {
+  assert(shouldInterceptNav({
+    href: "/shopping/123",
+    currentHref: "https://app.test/shopping",
+  }));
+});
+
+Deno.test("shouldInterceptNav — external, _blank, download, modified, hash are ignored", () => {
+  const cur = "https://app.test/shopping";
+  assert(!shouldInterceptNav({ href: "https://other.test/x", currentHref: cur }));
+  assert(!shouldInterceptNav({ href: "/x", target: "_blank", currentHref: cur }));
+  assert(!shouldInterceptNav({ href: "/x", download: true, currentHref: cur }));
+  assert(!shouldInterceptNav({ href: "/x", modified: true, currentHref: cur }));
+  assert(!shouldInterceptNav({ href: null, currentHref: cur }));
+  assert(!shouldInterceptNav({
+    href: "/shopping#top",
+    currentHref: cur,
+  }));
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `deno test -A utils/loading.test.ts`
+Expected: FAIL — `Module not found "./loading.ts"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `utils/loading.ts`:
+
+```ts
+import { signal } from "@preact/signals";
+
+/**
+ * Cross-island loading state. Module-scope signals are the sanctioned shared-state
+ * channel in this app (see utils/app-bar.ts). A full-page navigation resets them for free.
+ */
+
+/** True while a full-page navigation is in flight. */
+export const navPending = signal(false);
+
+/** Number of in-flight background mutations (optimistic CRUD). */
+export const busyCount = signal(0);
+
+/** Increment the in-flight mutation counter. */
+export function beginBusy(): void {
+  busyCount.value++;
+}
+
+/** Decrement the in-flight mutation counter (never below zero). */
+export function endBusy(): void {
+  busyCount.value = Math.max(0, busyCount.value - 1);
+}
+
+/** Show the nav indicator, then navigate. Nav is skipped when there is no DOM (tests). */
+export function navigateTo(url: string): void {
+  navPending.value = true;
+  if (typeof location !== "undefined" && location) location.href = url;
+}
+
+/** Show the nav indicator, then reload. */
+export function reloadPage(): void {
+  navPending.value = true;
+  if (typeof location !== "undefined" && location) location.reload();
+}
+
+/** Pure decision: should a link click show the navigation indicator? */
+export function shouldInterceptNav(opts: {
+  href: string | null;
+  target?: string | null;
+  download?: boolean;
+  modified?: boolean;
+  currentHref: string;
+}): boolean {
+  const { href, target, download, modified, currentHref } = opts;
+  if (!href) return false;
+  if (modified) return false;
+  if (download) return false;
+  if (target && target !== "_self") return false;
+  let url: URL;
+  let cur: URL;
+  try {
+    cur = new URL(currentHref);
+    url = new URL(href, currentHref);
+  } catch {
+    return false;
+  }
+  if (url.origin !== cur.origin) return false; // external
+  if (url.href === cur.href) return false; // no-op
+  // same page, only a hash change → let the browser handle it, no full load
+  if (url.pathname === cur.pathname && url.search === cur.search && url.hash) {
+    return false;
+  }
+  return true;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `deno test -A utils/loading.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+deno fmt && deno task check
+git add utils/loading.ts utils/loading.test.ts
+git commit -m "feat(loading): add cross-island loading state channel"
+```
+
+---
+
+### Task 2: `Spinner` primitive
+
+**Files:**
+- Create: `components/md3/Spinner.tsx`
+- Test: `components/md3/Spinner.test.tsx`
+- Modify: `assets/styles.css` (add `@keyframes md-spin`)
+
+**Interfaces:**
+- Consumes: `cn` from `@/components/md3/tokens.ts`.
+- Produces: `Spinner({ size?: number; color?: string; class?: string; "aria-label"?: string })` — a circular indeterminate MD3 spinner inheriting `currentColor` by default.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `components/md3/Spinner.test.tsx`:
+
+```tsx
+import { assertStringIncludes } from "jsr:@std/assert@^1.0.19";
+import { render } from "npm:preact-render-to-string@^6.6.3";
+import { h } from "preact";
+import { Spinner } from "./Spinner.tsx";
+
+Deno.test("Spinner — renders status role and a default Loading label", () => {
+  const html = render(h(Spinner, {}));
+  assertStringIncludes(html, 'role="status"');
+  assertStringIncludes(html, "Loading");
+});
+
+Deno.test("Spinner — applies a custom size", () => {
+  const html = render(h(Spinner, { size: 40 }));
+  assertStringIncludes(html, "40px");
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `deno test -A components/md3/Spinner.test.tsx`
+Expected: FAIL — `Module not found "./Spinner.tsx"`.
+
+- [ ] **Step 3: Add the spin keyframe**
+
+In `assets/styles.css`, after the existing `@keyframes md-saved-flash` block (near the end of the file), add:
+
+```css
+/* Circular indeterminate spinner (issue #32) */
+@keyframes md-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+```
+
+- [ ] **Step 4: Write the component**
+
+Create `components/md3/Spinner.tsx`:
+
+```tsx
+// components/md3/Spinner.tsx
+import { cn } from "./tokens.ts";
+
+interface SpinnerProps {
+  /** Diameter in px. */
+  size?: number;
+  /** Any CSS color; defaults to currentColor so it inherits text color. */
+  color?: string;
+  class?: string;
+  "aria-label"?: string;
+}
+
+export function Spinner(
+  { size = 20, color = "currentColor", class: cls, ...rest }: SpinnerProps,
+) {
+  const label = rest["aria-label"] ?? "Loading";
+  const borderWidth = Math.max(2, Math.round(size / 10));
+  return (
+    <span role="status" class={cn("inline-block align-middle", cls)}>
+      <span
+        class="block rounded-[var(--md-shape-full)]"
+        style={{
+          width: size,
+          height: size,
+          borderWidth,
+          borderStyle: "solid",
+          borderColor: `color-mix(in srgb, ${color} 24%, transparent)`,
+          borderTopColor: color,
+          animation: "md-spin 0.7s linear infinite",
+        }}
+      />
+      <span class="sr-only">{label}</span>
+    </span>
+  );
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `deno test -A components/md3/Spinner.test.tsx`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+deno fmt && deno task check
+git add components/md3/Spinner.tsx components/md3/Spinner.test.tsx assets/styles.css
+git commit -m "feat(md3): add circular indeterminate Spinner primitive"
+```
+
+---
+
+### Task 3: `Button` `loading` state
+
+**Files:**
+- Modify: `components/md3/Button.tsx`
+- Test: `components/md3/Button.test.tsx`
+
+**Interfaces:**
+- Consumes: `Spinner` from `@/components/md3/Spinner.tsx`.
+- Produces: `Button` gains `loading?: boolean`. When `loading`, the button renders a leading `Spinner` (in place of any `icon`), is force-disabled, and keeps its label.
+
+- [ ] **Step 1: Add a failing test**
+
+Append to `components/md3/Button.test.tsx`:
+
+```tsx
+import { Spinner } from "./Spinner.tsx"; // ensure module resolves
+
+Deno.test("Button — loading renders a spinner and disabled styling", () => {
+  const html = render(h(Button, { loading: true }, "Save"));
+  assertStringIncludes(html, 'role="status"'); // the spinner
+  assertStringIncludes(html, "38%"); // disabled text mix (color-mix ... 38%)
+  assertStringIncludes(html, "Save");
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `deno test -A components/md3/Button.test.tsx`
+Expected: FAIL — no `role="status"` in output (loading not yet implemented).
+
+- [ ] **Step 3: Implement the loading state**
+
+In `components/md3/Button.tsx`:
+
+1. Add the import after the existing imports:
+
+```tsx
+import { Spinner } from "./Spinner.tsx";
+```
+
+2. Add `loading` to `ButtonProps` (after `disabled?: boolean;`):
+
+```tsx
+  disabled?: boolean;
+  loading?: boolean;
+```
+
+3. Destructure it in the signature (after `disabled,`):
+
+```tsx
+    disabled,
+    loading,
+```
+
+4. Replace the `Pressable` body. Change the `onClick`/`disabled` and the disabled-class check to use a combined `isDisabled`, and swap the leading glyph. The full updated component body:
+
+```tsx
+  const isDisabled = disabled || loading;
+  return (
+    <Pressable
+      onClick={onClick}
+      disabled={isDisabled}
+      class={cn(
+        "md-label-large inline-flex items-center justify-center gap-2 h-10 rounded-[var(--md-shape-full)] whitespace-nowrap",
+        icon || loading ? "pl-4 pr-[22px]" : "px-6",
+        full ? "w-full" : "w-auto",
+        isDisabled
+          ? "bg-[color-mix(in_srgb,var(--md-on-surface)_12%,transparent)] text-[color-mix(in_srgb,var(--md-on-surface)_38%,transparent)]"
+          : VARIANT[variant],
+        cls,
+      )}
+      style={style}
+    >
+      {loading
+        ? <Spinner size={18} />
+        : icon && <Icon name={icon} size={18} />}
+      {children}
+    </Pressable>
+  );
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `deno test -A components/md3/Button.test.tsx`
+Expected: PASS (all Button tests, including the original filled-variant test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+deno fmt && deno task check
+git add components/md3/Button.tsx components/md3/Button.test.tsx
+git commit -m "feat(md3): add loading state to Button"
+```
+
+---
+
+### Task 4: `GlobalLoadingBar` island + wavy bar styles
+
+**Files:**
+- Create: `islands/shell/GlobalLoadingBar.tsx`
+- Test: `islands/shell/GlobalLoadingBar.test.tsx`
+- Modify: `assets/styles.css` (wavy bar keyframes + classes)
+
+**Interfaces:**
+- Consumes: `navPending`, `busyCount`, `shouldInterceptNav` from `@/utils/loading.ts`; `useSignal`/`useSignalEffect` from `@preact/signals`; `useEffect`/`useRef` from `preact/hooks`.
+- Produces: default-exported `GlobalLoadingBar()` island. Renders a fixed top wavy bar; visible when `navPending` OR a >200ms background write is in flight (with a 400ms minimum visible duration). Installs a document `click` listener (internal-link interception) and a `pageshow` handler (bfcache reset).
+
+- [ ] **Step 1: Add the wavy bar styles**
+
+In `assets/styles.css`, after the `@keyframes md-spin` block from Task 2, add:
+
+```css
+/* Global navigation/CRUD loading bar — wavy indeterminate (issue #32) */
+@keyframes md-loadbar-travel {
+  from {
+    -webkit-mask-position: 0 center;
+    mask-position: 0 center;
+  }
+  to {
+    -webkit-mask-position: 24px center;
+    mask-position: 24px center;
+  }
+}
+@keyframes md-loadbar-pulse {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+.md-loadbar-track {
+  height: 6px;
+  background: var(--md-primary-container);
+  overflow: hidden;
+}
+.md-loadbar-wave {
+  height: 100%;
+  background: var(--md-primary);
+  -webkit-mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='24' height='6'><path d='M0 3 Q 6 0 12 3 T 24 3' fill='none' stroke='black' stroke-width='3'/></svg>");
+  mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='24' height='6'><path d='M0 3 Q 6 0 12 3 T 24 3' fill='none' stroke='black' stroke-width='3'/></svg>");
+  -webkit-mask-repeat: repeat-x;
+  mask-repeat: repeat-x;
+  -webkit-mask-size: 24px 6px;
+  mask-size: 24px 6px;
+  animation: md-loadbar-travel 0.6s linear infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .md-loadbar-wave {
+    animation: md-loadbar-pulse 1.4s ease-in-out infinite;
+  }
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `islands/shell/GlobalLoadingBar.test.tsx` (SSR renders with effects NOT run, so the bar starts hidden but present):
+
+```tsx
+import { assertStringIncludes } from "jsr:@std/assert@^1.0.19";
+import { render } from "npm:preact-render-to-string@^6.6.3";
+import { h } from "preact";
+import GlobalLoadingBar from "./GlobalLoadingBar.tsx";
+
+Deno.test("GlobalLoadingBar — renders a progressbar region, hidden by default", () => {
+  const html = render(h(GlobalLoadingBar, {}));
+  assertStringIncludes(html, 'role="progressbar"');
+  assertStringIncludes(html, "md-loadbar-track");
+  assertStringIncludes(html, 'aria-hidden="true"'); // not visible until a load starts
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `deno test -A islands/shell/GlobalLoadingBar.test.tsx`
+Expected: FAIL — `Module not found "./GlobalLoadingBar.tsx"`.
+
+- [ ] **Step 4: Write the island**
+
+Create `islands/shell/GlobalLoadingBar.tsx`:
+
+```tsx
+import { useSignal, useSignalEffect } from "@preact/signals";
+import { useEffect, useRef } from "preact/hooks";
+import { busyCount, navPending, shouldInterceptNav } from "@/utils/loading.ts";
+
+const SHOW_DELAY_MS = 200; // don't flash the bar for fast optimistic writes
+const MIN_VISIBLE_MS = 400; // once shown, stay up long enough to be seen
+
+/**
+ * The app's single global loading indicator. Shows immediately for navigation
+ * (navPending) and, after a short delay, for background CRUD (busyCount) — with a
+ * minimum visible duration so quick writes don't flicker. Mounted once by AppChrome.
+ */
+export default function GlobalLoadingBar() {
+  const busyVisible = useSignal(false);
+  const showTimer = useRef<number | undefined>(undefined);
+  const hideTimer = useRef<number | undefined>(undefined);
+  const shownAt = useRef(0);
+
+  // Map busyCount → busyVisible with the show-delay / min-visible timing.
+  useSignalEffect(() => {
+    const active = busyCount.value > 0;
+    if (active) {
+      if (hideTimer.current !== undefined) {
+        clearTimeout(hideTimer.current);
+        hideTimer.current = undefined;
+      }
+      if (!busyVisible.peek() && showTimer.current === undefined) {
+        showTimer.current = setTimeout(() => {
+          busyVisible.value = true;
+          shownAt.current = Date.now();
+          showTimer.current = undefined;
+        }, SHOW_DELAY_MS);
+      }
+    } else {
+      if (showTimer.current !== undefined) {
+        clearTimeout(showTimer.current);
+        showTimer.current = undefined;
+      }
+      if (busyVisible.peek() && hideTimer.current === undefined) {
+        const wait = Math.max(0, MIN_VISIBLE_MS - (Date.now() - shownAt.current));
+        hideTimer.current = setTimeout(() => {
+          busyVisible.value = false;
+          hideTimer.current = undefined;
+        }, wait);
+      }
+    }
+  });
+
+  // Centralized navigation interception (internal links) + bfcache reset.
+  useEffect(() => {
+    const onClick = (e: MouseEvent) => {
+      if (e.defaultPrevented) return;
+      const anchor = (e.target as Element | null)?.closest?.("a");
+      if (!anchor) return;
+      const modified = e.metaKey || e.ctrlKey || e.shiftKey || e.altKey ||
+        e.button !== 0;
+      if (
+        shouldInterceptNav({
+          href: anchor.getAttribute("href"),
+          target: anchor.getAttribute("target"),
+          download: anchor.hasAttribute("download"),
+          modified,
+          currentHref: location.href,
+        })
+      ) {
+        navPending.value = true;
+      }
+    };
+    const onPageShow = (e: PageTransitionEvent) => {
+      if (e.persisted) navPending.value = false; // restored from bfcache
+    };
+    document.addEventListener("click", onClick);
+    globalThis.addEventListener("pageshow", onPageShow);
+    return () => {
+      document.removeEventListener("click", onClick);
+      globalThis.removeEventListener("pageshow", onPageShow);
+    };
+  }, []);
+
+  const visible = navPending.value || busyVisible.value;
+
+  return (
+    <div
+      role="progressbar"
+      aria-label="Loading"
+      aria-hidden={visible ? undefined : "true"}
+      class="fixed left-0 right-0 z-50 pointer-events-none"
+      style={{
+        top: 0,
+        paddingTop: "env(safe-area-inset-top)",
+        opacity: visible ? 1 : 0,
+        transition: "opacity .2s var(--md-emphasized)",
+      }}
+    >
+      <div class="md-loadbar-track">
+        <div class="md-loadbar-wave" />
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `deno test -A islands/shell/GlobalLoadingBar.test.tsx`
+Expected: PASS (1 test).
+
+- [ ] **Step 6: Commit**
+
+```bash
+deno fmt && deno task check
+git add islands/shell/GlobalLoadingBar.tsx islands/shell/GlobalLoadingBar.test.tsx assets/styles.css
+git commit -m "feat(loading): add GlobalLoadingBar island with wavy indeterminate bar"
+```
+
+---
+
+### Task 5: Mount the bar + route imperative navigations
+
+Wires the bar into the shell and makes every JS-driven navigation raise `navPending`. Declarative `<a href>` links are handled automatically by the click listener from Task 4, so they need no edits.
+
+**Files:**
+- Modify: `islands/shell/AppChrome.tsx`
+- Modify: `islands/shell/NavigationBar.tsx`
+- Modify: `islands/shell/MoreSheet.tsx`
+- Modify: `islands/shopping-lists.tsx`
+- Modify: `islands/catalogue.tsx`
+- Modify: `islands/items.tsx`
+
+**Interfaces:**
+- Consumes: `navigateTo`, `reloadPage` from `@/utils/loading.ts`; `GlobalLoadingBar` from `@/islands/shell/GlobalLoadingBar.tsx`.
+
+- [ ] **Step 1: Mount `GlobalLoadingBar` in `AppChrome`**
+
+In `islands/shell/AppChrome.tsx`:
+
+1. Add the import:
+
+```tsx
+import GlobalLoadingBar from "./GlobalLoadingBar.tsx";
+```
+
+2. Render the bar even on full-screen routes — change the early return:
+
+```tsx
+  if (appBar?.mode === "none") return <GlobalLoadingBar />;
+```
+
+3. Add the bar as the first child of the main fragment (immediately after the opening `<>`):
+
+```tsx
+  return (
+    <>
+      <GlobalLoadingBar />
+      {detail
+        ? (
+```
+
+- [ ] **Step 2: Route the bottom nav through `navigateTo`**
+
+In `islands/shell/NavigationBar.tsx`, add the import and replace the imperative nav:
+
+```tsx
+import { navigateTo } from "@/utils/loading.ts";
+```
+
+Change (line ~19):
+
+```tsx
+    if (it.id === "more") onMore();
+    else navigateTo(it.defaultRoute);
+```
+
+- [ ] **Step 3: Route MoreSheet's "Shopping" link**
+
+In `islands/shell/MoreSheet.tsx`, add `import { navigateTo } from "@/utils/loading.ts";` and replace `globalThis.location.href = "/shopping";` (line ~42) with `navigateTo("/shopping");`. (The `<a href>` logout/module links are covered by the click listener — leave them.)
+
+- [ ] **Step 4: Route the Lists index navigations**
+
+In `islands/shopping-lists.tsx`, add `import { navigateTo } from "@/utils/loading.ts";` and replace:
+
+- Segmented → Catalogue (line ~73):
+
+```tsx
+          onChange={(k) => {
+            if (k === "catalogue") navigateTo("/shopping/catalogue");
+          }}
+```
+
+- Open a list (line ~113):
+
+```tsx
+                onClick={() => {
+                  navigateTo(`/shopping/${list.id}`);
+                }}
+```
+
+- [ ] **Step 5: Route the Catalogue segmented nav**
+
+In `islands/catalogue.tsx`, add `import { navigateTo } from "@/utils/loading.ts";` and replace `if (k === "lists") globalThis.location.href = "/shopping";` (line ~124) with `if (k === "lists") navigateTo("/shopping");`.
+
+- [ ] **Step 6: Route the List-detail navigations**
+
+In `islands/items.tsx`, add `import { navigateTo, reloadPage } from "@/utils/loading.ts";` and replace:
+
+- Both rename reloads (lines ~452 and ~465): `globalThis.location.reload();` → `reloadPage();`
+- Delete redirect (line ~524): `globalThis.location.href = "/shopping";` → `navigateTo("/shopping");`
+
+- [ ] **Step 7: Verify with the browser preview**
+
+Run: `deno task check` (expected: green).
+
+Then start the dev server (via the preview tool, `deno task dev`), throttle the network to a slow profile, and confirm:
+- Tapping a bottom-nav tab, opening a list, and switching Lists↔Catalogue each show the wavy bar during the SSR round-trip; the bar is gone once the new page paints.
+- Browser back (bfcache) does not leave the bar stuck on.
+- A normal external/`target=_blank` link (if any) does not trigger the bar.
+
+- [ ] **Step 8: Commit**
+
+```bash
+deno fmt && deno task check
+git add islands/shell/AppChrome.tsx islands/shell/NavigationBar.tsx islands/shell/MoreSheet.tsx islands/shopping-lists.tsx islands/catalogue.tsx islands/items.tsx
+git commit -m "feat(loading): show navigation indicator on page transitions"
+```
+
+---
+
+### Task 6: Feed `busyCount` from the CRUD hooks
+
+Surfaces the already-maintained-but-unused in-flight counters into the global bar, so background writes show the bar (after the anti-flicker delay).
+
+**Files:**
+- Modify: `hooks/useShoppingList.ts`
+- Modify: `hooks/useCatalogue.ts`
+
+**Interfaces:**
+- Consumes: `beginBusy`, `endBusy` from `@/utils/loading.ts`.
+
+- [ ] **Step 1: Bridge `useShoppingList`'s counter**
+
+In `hooks/useShoppingList.ts`:
+
+1. Add the import near the top (with the other `@/` imports):
+
+```ts
+import { beginBusy, endBusy } from "@/utils/loading.ts";
+```
+
+2. Immediately after `const pendingCount = signal<number>(0);`, add two helpers:
+
+```ts
+  // Mirror each in-flight mutation into the global loading bar.
+  const startPending = () => {
+    pendingCount.value++;
+    beginBusy();
+  };
+  const endPending = () => {
+    pendingCount.value--;
+    endBusy();
+  };
+```
+
+3. Replace every `pendingCount.value++;` with `startPending();` and every `pendingCount.value--;` with `endPending();` in this file (they appear in `addToList`, `addToCatalog`, `removeListItem`, `checkItem`, `uncheckItem`, and `refresh` — all inside `try`/`finally` pairs, so the balance is preserved).
+
+- [ ] **Step 2: Bridge `useCatalogue`'s counter**
+
+In `hooks/useCatalogue.ts`, apply the identical change: add the `beginBusy`/`endBusy` import, define `startPending`/`endPending` right after its `const pendingCount = signal<number>(0);`, and replace every `pendingCount.value++;`/`pendingCount.value--;` accordingly.
+
+- [ ] **Step 3: Verify with the browser preview**
+
+Run: `deno task check` (expected: green).
+
+In the preview with a slow network profile:
+- Add an item / delete an item on the list detail: the wavy bar appears (after ~200ms) and clears when the write resolves.
+- A fast local check/uncheck does NOT flash the bar (sub-200ms writes stay invisible).
+
+- [ ] **Step 4: Commit**
+
+```bash
+deno fmt && deno task check
+git add hooks/useShoppingList.ts hooks/useCatalogue.ts
+git commit -m "feat(loading): reflect in-flight CRUD in the global bar"
+```
+
+---
+
+### Task 7: Create-list button busy state
+
+The create-list flow calls the API directly (not through the hooks), so it is NOT covered by `busyCount`. It already has a `loading` signal that only disables the button; now render it with the new `Button` `loading` prop.
+
+**Files:**
+- Modify: `islands/shopping-lists.tsx`
+
+**Interfaces:**
+- Consumes: `Button` `loading` prop (Task 3). The `loading` signal already exists in this island.
+
+- [ ] **Step 1: Render the busy state**
+
+In `islands/shopping-lists.tsx`, update the create-list `Button` (lines ~181–188) to pass `loading`:
+
+```tsx
+          <Button
+            variant="filled"
+            full
+            onClick={createList}
+            loading={loading.value}
+          >
+            Add
+          </Button>
+```
+
+(The `loading` prop force-disables the button, so the separate `disabled` prop is no longer needed.)
+
+- [ ] **Step 2: Verify with the browser preview**
+
+Run: `deno task check` (expected: green).
+
+In the preview: open the "New list" sheet, type a name, tap **Add** — the button shows the inline spinner and is disabled until the list is created and the sheet closes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+deno fmt && deno task check
+git add islands/shopping-lists.tsx
+git commit -m "feat(loading): show a busy spinner while creating a list"
+```
+
+---
+
+### Task 8: "Saving…" phase for debounced edits
+
+Completes the existing "Saved" affordance: while a debounced qty/note write is pending, the editor pill shows "Saving…", flipping to "Saved" on flush. Debounced writes are intentionally excluded from `busyCount` (per the spec), so this is driven by a dedicated signal.
+
+**Files:**
+- Modify: `hooks/useShoppingList.ts`
+- Modify: `islands/items.tsx`
+
+**Interfaces:**
+- Produces (from `useShoppingList`): `savingIds: Signal<Set<string>>` — ids of list items with a debounced write pending.
+- Consumes (in `items.tsx`): `savingIds` + the `Spinner` primitive.
+
+- [ ] **Step 1: Track pending debounced writes in the hook**
+
+In `hooks/useShoppingList.ts`:
+
+1. After `const lastSaved = signal<number>(0);`, add:
+
+```ts
+  // Ids of list items whose debounced write hasn't flushed yet (drives "Saving…").
+  const savingIds = signal<Set<string>>(new Set());
+  const markSaving = (id: string) => {
+    if (savingIds.value.has(id)) return;
+    const next = new Set(savingIds.value);
+    next.add(id);
+    savingIds.value = next;
+  };
+  const clearSaving = (id: string) => {
+    if (!savingIds.value.has(id)) return;
+    const next = new Set(savingIds.value);
+    next.delete(id);
+    savingIds.value = next;
+  };
+```
+
+2. In the `patchScheduler` `flush` callback, clear the id when the write lands:
+
+```ts
+    flush: async (id, patch) => {
+      await api.shoppingList.updateItem(listId, id, patch);
+      clearSaving(id);
+      lastSaved.value = lastSaved.value + 1;
+    },
+```
+
+3. In `updateListItem`, mark the id as saving when a debounced write is scheduled:
+
+```ts
+  const updateListItem = (
+    id: string,
+    patch: Partial<ShoppingListItemInterface>,
+  ) => {
+    list.value = list.value.map((li) =>
+      li.id === id ? { ...li, ...patch } : li
+    );
+    markSaving(id);
+    patchScheduler.schedule(id, patch);
+  };
+```
+
+4. In `removeListItem` and `checkItem`, alongside each `patchScheduler.cancel(id);`, also clear the saving flag:
+
+```ts
+    patchScheduler.cancel(id);
+    clearSaving(id);
+```
+
+5. Add `savingIds` to the returned object (next to `lastSaved`):
+
+```ts
+    lastSaved,
+    savingIds,
+    flushListItem,
+```
+
+- [ ] **Step 2: Show "Saving…" in the editor pill**
+
+In `islands/items.tsx`:
+
+1. Add `savingIds` to the hook destructure (next to `lastSaved`):
+
+```ts
+    lastSaved,
+    savingIds,
+    flushListItem,
+```
+
+2. Add the Spinner import (with the other `@/components/md3` imports):
+
+```tsx
+import { Spinner } from "@/components/md3/Spinner.tsx";
+```
+
+3. Replace the pill block (lines ~574–583) so "Saving…" takes precedence over "Saved":
+
+```tsx
+              <div class="h-6 flex justify-end items-center px-1">
+                {savingIds.value.has(li.id!)
+                  ? (
+                    <span class="inline-flex items-center gap-1.5 md-label-medium text-on-surface-variant">
+                      <Spinner size={12} /> Saving…
+                    </span>
+                  )
+                  : showSaved && (
+                    <span
+                      key={savedTick}
+                      class="md-saved-flash inline-flex items-center gap-1 md-label-medium text-on-tertiary-container bg-tertiary-container rounded-full px-2.5 py-0.5 pointer-events-none"
+                    >
+                      <Icon name="check" size={14} /> Saved
+                    </span>
+                  )}
+              </div>
+```
+
+- [ ] **Step 3: Verify with the browser preview**
+
+Run: `deno task check` (expected: green).
+
+In the preview: open an item editor, change the quantity or note — the pill shows a small spinner + "Saving…" during the ~500ms debounce, then flips to the "Saved" flash once the write lands.
+
+- [ ] **Step 4: Commit**
+
+```bash
+deno fmt && deno task check
+git add hooks/useShoppingList.ts islands/items.tsx
+git commit -m "feat(loading): show a Saving… phase before the Saved pill"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage** (against `docs/superpowers/specs/2026-07-23-loading-feedback-design.md`):
+
+- §2 global nav indicator → Tasks 4, 5. ✅
+- §2 reusable `Spinner` → Task 2. ✅
+- §2 `Button` busy state → Task 3 (+ wired in Task 7). ✅
+- §2 shared state module `utils/loading.ts` → Task 1. ✅
+- §2 surface unused `pendingCount` → Task 6. ✅
+- §2 / §6.4 "Saving…/Saved" consistency → Task 8. ✅
+- §5 wavy bar + circular spinner + reduced-motion + a11y roles → Tasks 2, 4. ✅
+- §6.1 centralized interception (click listener + `navigateTo` + `pageshow`) → Tasks 1, 4, 5. ✅
+- §6.2 non-blocking background CRUD w/ 200ms delay + 400ms min → Tasks 4, 6. ✅
+- §6.3 awaited-action button-busy (create list) → Task 7. ✅
+- §4 mount in `AppChrome`, including `mode:"none"` full-screen routes → Task 5 Step 1. ✅
+- D5 skeletons dropped → no task, by design. ✅
+- §8 error handling: `endBusy` in hook `finally`; `busyCount` floored at 0 (Task 1); bfcache reset (Task 4). ✅
+
+No spec requirement is left without a task.
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases"/"similar to". Every code step contains complete code. ✅
+
+**Type consistency:** `navPending`, `busyCount`, `navigateTo`, `reloadPage`, `beginBusy`, `endBusy`, `shouldInterceptNav` are defined in Task 1 and consumed with matching signatures in Tasks 4, 5, 6. `Spinner` (Task 2) props match its uses in Tasks 3 and 8. `Button.loading` (Task 3) matches its use in Task 7. `savingIds: Signal<Set<string>>` defined in Task 8 Step 1 and read as `savingIds.value.has(...)` in Step 2. ✅
+
+**Note on testing:** interception timing and DOM listeners are verified in the browser preview (Tasks 5–8), consistent with the repo's SSR-only test harness; pure logic (`shouldInterceptNav`, the signal helpers) and SSR output (Spinner, Button, GlobalLoadingBar) are unit-tested.

--- a/docs/superpowers/specs/2026-07-23-loading-feedback-design.md
+++ b/docs/superpowers/specs/2026-07-23-loading-feedback-design.md
@@ -1,0 +1,258 @@
+# Design: Visual Loading Feedback
+
+- **Date:** 2026-07-23
+- **Status:** Approved (design); pending implementation plan
+- **Issue:** [#32 — Add visual loading feedback for user interactions](https://github.com/FredericGryspeerdt/happie-fresh/issues/32)
+- **Author:** brainstormed with Claude
+
+## 1. Context & goal
+
+The app currently gives **no visual loading feedback**. There are no spinners,
+skeletons, or indeterminate indicators anywhere. The lone `Progress.tsx`
+primitive is a _determinate_ bar that visualizes shopping-list completion
+(`x / y` done), not loading.
+
+Two facts about the current architecture shape this entire design:
+
+1. **Navigation is 100% full-page SSR.** Every navigation is a real browser
+   document load (via `<a href>` or `globalThis.location.href`). There is no
+   client-side router and no Fresh Partials. The genuine, user-perceived wait in
+   this app is the navigation round-trip (route handlers do `Promise.all` DB
+   reads before the new page paints).
+2. **CRUD is fully optimistic.** Mutations in `useShoppingList` /
+   `useCatalogue` update the UI signals _instantly_ and fire the API call in the
+   background. Blocking the UI with a spinner until the server responds would
+   make the app feel **slower** than it is today.
+
+**Goal:** give users honest, MD3-styled confirmation that (a) the app is loading
+when navigating between pages, and (b) work is being processed for the few
+genuinely-awaited actions — **without** degrading the snappy optimistic feel.
+Deliver this as **reusable primitives** so future household modules (to-dos,
+meal planner, etc.) inherit loading feedback for free.
+
+## 2. Scope
+
+**In scope**
+
+- A global navigation loading indicator in the app shell.
+- A reusable MD3 `Spinner` primitive (circular, indeterminate).
+- A `loading` busy-state on the existing `Button`.
+- A shared cross-island state module (`utils/loading.ts`).
+- Wiring the above into the existing shopping surfaces + the shell.
+- Surfacing the already-maintained-but-unused `pendingCount` as an honest
+  "a write is in flight" signal.
+- Making the existing "Saved" flash consistent (add a "Saving…" phase).
+
+**Out of scope (deferred / YAGNI)**
+
+- **Skeleton loaders.** Because content is server-rendered and arrives fully
+  populated, there is no client-side "empty → fill" moment for a skeleton to
+  cover — the global nav bar covers the transition instead. No current wiring
+  target exists, so we do **not** build a `Skeleton` primitive now. Revisit when
+  a real client-fetched surface appears.
+- The full **MD3 Expressive morphing loading indicator** (7 morphing shapes,
+  spring transitions). We adopt the _wavy/amplitude_ expressive flavor instead
+  (see §5), for far less build/maintenance cost.
+- Any client-side router / Fresh Partials.
+- Any change to the optimistic data-flow, repositories, or API routes.
+
+## 3. Decisions of record
+
+| #  | Decision | Choice |
+|----|----------|--------|
+| D1 | Overall approach | **Full toolkit**: global nav indicator + reusable localized primitives. |
+| D2 | Visual style | **Wavy/amplitude MD3**: wavy indeterminate linear bar (nav) + simple circular `Spinner` (buttons/inline). Not the full morphing indicator. |
+| D3 | CRUD feedback | **Non-blocking.** Never block optimistic rows. Button-busy only for genuinely-awaited actions; global bar reflects background writes; keep the "Saved/Saving" pill for debounced edits. |
+| D4 | Nav trigger | **Centralized interception**: one delegated click listener for `<a>` links + a shared `navigateTo()` helper for the few imperative `location.href` sites. New links need zero per-site wiring. |
+| D5 | Skeletons | **Dropped** for now (YAGNI — no SSR wiring target). |
+| D6 | State plumbing | **Module-scope signals** in `utils/loading.ts`, mirroring the existing `utils/app-bar.ts` cross-island pattern. |
+
+## 4. Architecture & file layout
+
+```
+utils/loading.ts            NEW. Module-scope signals + helpers (cross-island glue).
+                              - navPending: Signal<boolean>   (navigation in flight)
+                              - busyCount:  Signal<number>    (background CRUD in flight)
+                              - navigateTo(url), reloadPage()  (set navPending, then navigate)
+                              - beginBusy() / endBusy()        (++/-- busyCount)
+                            (The bar's own show/hide with the ~200ms delay + ~400ms min
+                             visible duration is stateful/timer-based and lives in the
+                             GlobalLoadingBar island, not a pure computed — see §6.2.)
+
+components/md3/Spinner.tsx   NEW. MD3 circular indeterminate spinner. Props: size, color,
+                              aria-label. Pure CSS rotation keyframe. SSR-safe.
+
+islands/shell/GlobalLoadingBar.tsx
+                            NEW island. Renders the wavy indeterminate linear bar,
+                              fixed to the top of the viewport. Reads utils/loading.ts.
+                              Installs the centralized nav interception (click listener,
+                              pageshow/pagehide handlers) on mount.
+
+components/md3/Button.tsx    MODIFIED. Add `loading?: boolean`. When true → render a
+                              leading Spinner, force disabled, keep label width stable.
+
+assets/styles.css           MODIFIED. New @keyframes: md-wave (wavy bar traverse) +
+                              md-spin (circular rotation). prefers-reduced-motion fallbacks.
+
+islands/shell/AppChrome.tsx MODIFIED. Render <GlobalLoadingBar/> above TopAppBar
+                              (also in appBar.mode === "none" full-screen routes, so the
+                              add-items overlay still shows nav feedback).
+
+hooks/useShoppingList.ts    MODIFIED. Feed the shared busyCount (via beginBusy/endBusy)
+hooks/useCatalogue.ts         at the existing pendingCount ++/-- sites. (pendingCount stays
+                              for any local use; the shared signal is what the shell reads.)
+
+islands/shopping-lists.tsx  MODIFIED. Create-list button → Button loading prop (signal
+                              already exists). Replace raw location.href with navigateTo().
+islands/items.tsx           MODIFIED. Rename/delete reloads → navigateTo()/reloadPage().
+islands/catalogue.tsx       MODIFIED. Add-item action → Button loading; segmented nav →
+                              navigateTo(). Extend "Saved/Saving" consistency.
+islands/add-items.tsx       MODIFIED. Add action → Button loading (awaited add).
+islands/shell/NavigationBar.tsx, MoreSheet.tsx
+                            MODIFIED. Replace raw location.href with navigateTo().
+```
+
+**Fresh islands rule:** only islands hydrate. `Spinner` is a plain presentational
+component (CSS animation works in pure SSR). `GlobalLoadingBar` must be an island
+(it installs listeners + reads reactive signals). `utils/loading.ts` uses
+module-scope `signal()` (NOT `useSignal`), exactly like `utils/app-bar.ts` — this
+is the sanctioned cross-island channel; a full page load naturally resets it.
+
+## 5. Visual design (D2 — wavy/amplitude MD3)
+
+### 5.1 Global loading bar
+
+- A thin (**4px**) bar fixed to the very top of the viewport, `z` above
+  `TopAppBar`, spanning full width, honoring `env(safe-area-inset-top)`.
+- **Wavy indeterminate active track:** an amber (`--md-primary`) segment that
+  traverses left→right over a `--md-primary-container` track, with a subtle
+  vertical wave (the expressive "amplitude" flavor). Implemented as a CSS
+  `@keyframes md-wave` translating a gradient/segment; the wave is a repeating
+  SVG/CSS sine background on the active segment. Easing `--md-emphasized`.
+- Corners use `--md-shape-full`. Appears/disappears with a short opacity fade.
+
+### 5.2 Circular spinner
+
+- MD3 circular indeterminate: a `currentColor` arc on a faint track ring,
+  rotating via `@keyframes md-spin`. Props: `size` (default 20, button use ~18),
+  `color` (defaults to `currentColor` so it inherits button text color),
+  `aria-label` (default "Loading").
+
+### 5.3 Accessibility & motion
+
+- Bar: `role="progressbar"` + `aria-busy` on the region; a visually-hidden
+  "Loading" text node.
+- Spinner: `role="status"` with visually-hidden label.
+- `@media (prefers-reduced-motion: reduce)`: the wavy traverse and the spin are
+  replaced by a gentle opacity pulse (no translation/rotation).
+
+## 6. Behavior
+
+### 6.1 Navigation feedback (D4 — centralized interception)
+
+`GlobalLoadingBar` (mounted once in `AppChrome`) installs on hydrate:
+
+1. **Delegated `click` listener** on `document`. If the click target resolves to
+   an `<a>` whose href is same-origin, not `target="_blank"`, not `download`,
+   not a modifier/middle click, and not a pure `#hash` on the current page →
+   `navPending.value = true`. Default navigation proceeds; the old page stays
+   visible (with the bar animating) until the new document paints, at which point
+   the fresh module state resets `navPending` to `false` automatically.
+2. **`navigateTo(url)` / `reloadPage()` helpers** for the imperative sites that
+   don't emit an interceptable click (`NavigationBar` tab taps, `MoreSheet`
+   links, `shopping-lists` open-list + segmented, `catalogue` segmented,
+   `items` rename/delete reloads). Each sets `navPending` then assigns
+   `location.href` / calls `location.reload()`. This is the "interception" for
+   programmatic navigation — call sites swap `location.href = x` → `navigateTo(x)`.
+3. **`pageshow` handler:** if the page is restored from bfcache
+   (`event.persisted`), reset `navPending = false` (the restored DOM may have the
+   bar showing).
+
+Nav feedback appears **immediately** on trigger (perceived responsiveness) and is
+wiped by the destination's first paint.
+
+### 6.2 Background CRUD feedback (D3 — non-blocking)
+
+- `useShoppingList` / `useCatalogue` call `beginBusy()` / `endBusy()` at the
+  same points they currently bump `pendingCount` (add, remove, check, uncheck,
+  refresh, catalogue mutations). `GlobalLoadingBar` reflects `busyCount > 0`.
+- **Anti-flicker:** because optimistic writes are typically sub-second, the bar
+  only appears for background writes that exceed a **~200ms** threshold, and once
+  shown stays visible a **~400ms** minimum. Navigation (§6.1) is exempt — it
+  shows instantly. This keeps fast saves invisible and slow ones honest.
+- Optimistic rows are **never** blocked or spinner-covered.
+
+### 6.3 Awaited actions (button-busy)
+
+For the handful of actions where the user actually waits on a create before the
+UI can proceed:
+
+- **Create list** (`shopping-lists.tsx`) — the `loading` signal already exists
+  and disables the button; now it also renders `Button loading` (inline spinner).
+- **Add item / create catalogue item** (`add-items.tsx`, `catalogue.tsx`) — the
+  add action awaits `addToList` / `addToCatalog`; show `Button loading` for that
+  call.
+
+### 6.4 Debounced-edit "Saving / Saved"
+
+Keep the existing `.md-saved-flash` "Saved" pill (driven by `lastSaved`). Add a
+transient **"Saving…"** state while a debounced write is pending (scheduler has an
+in-flight/queued write), flipping to "Saved" on flush. This makes the one
+existing good affordance complete and consistent; it is **not** driven by
+`busyCount` (debounced writes are intentionally excluded from that counter).
+
+## 7. Data flow
+
+No API/repository/model changes. The additions are purely presentational state:
+
+- `utils/loading.ts` owns `navPending` + `busyCount` (module-scope signals).
+- Hooks feed `busyCount`; the shell island reads it. This mirrors the existing
+  `appBarAction` bridge in `utils/app-bar.ts`.
+- A full-page navigation resets all module signals for free (new document).
+
+## 8. Error handling & edge cases
+
+- **Failed background write:** `endBusy()` runs in a `finally`, so the bar always
+  clears even on error. (Surfacing errors themselves is out of scope — existing
+  behavior unchanged.)
+- **Navigation that never completes / is canceled:** the bar clears on the next
+  `pageshow` or on a subsequent successful navigation; a full load resets state.
+- **bfcache back/forward:** handled by the `pageshow` reset (§6.1.3).
+- **External / new-tab / download / modified-click links:** excluded by the
+  click-listener guard — no false nav indicator.
+- **Full-screen routes** (`appBar.mode === "none"`, e.g. add-items overlay):
+  `GlobalLoadingBar` still renders so those surfaces get nav + busy feedback.
+- **Reduced motion:** opacity-only fallbacks (§5.3).
+- **SSR:** `Spinner` renders its static ring server-side; `GlobalLoadingBar`
+  renders hidden until hydrated (no listeners server-side).
+
+## 9. Testing & verification
+
+- `deno task check` (fmt + lint + type) green throughout.
+- Unit tests (follow `components/md3/*.test.tsx` + `islands/**/*.test.tsx`):
+  - `Spinner` renders with role/label and respects `size`/`color`.
+  - `Button` `loading` renders a spinner, is disabled, preserves label.
+  - `utils/loading.ts`: `navigateTo` sets `navPending`; `beginBusy/endBusy`
+    balance `busyCount`; the ~200ms/~400ms show logic (with fake timers).
+  - `GlobalLoadingBar`: click-listener sets `navPending` for internal links and
+    ignores external/`_blank`/download/modified clicks; `pageshow(persisted)`
+    resets.
+- Manual/preview verification: throttle the network, navigate between Lists ↔
+  detail ↔ Catalogue and confirm the wavy bar; perform a slow add and confirm the
+  background bar; confirm fast optimistic checks show no flicker; confirm
+  reduced-motion fallback.
+
+## 10. References
+
+- Issue: https://github.com/FredericGryspeerdt/happie-fresh/issues/32
+- Cross-island signal pattern: `utils/app-bar.ts`, `islands/shell/AppChrome.tsx`
+- In-flight counters (currently unused): `hooks/useShoppingList.ts` `pendingCount`,
+  `hooks/useCatalogue.ts` `pendingCount`; "Saved" pill: `lastSaved` +
+  `assets/styles.css` `.md-saved-flash` / `@keyframes md-saved-flash`
+- MD3 tokens/motion: `assets/styles.css` (`--md-primary`, `--md-emphasized`,
+  `--md-shape-full`)
+- Navigation sites to route through `navigateTo()`: `islands/shell/NavigationBar.tsx`,
+  `islands/shell/MoreSheet.tsx`, `islands/shopping-lists.tsx`,
+  `islands/catalogue.tsx`, `islands/items.tsx`
+- MD3 Expressive Loading Indicator background:
+  https://github.com/material-components/material-components-android/blob/master/docs/components/LoadingIndicator.md

--- a/docs/superpowers/specs/2026-07-23-loading-feedback-design.md
+++ b/docs/superpowers/specs/2026-07-23-loading-feedback-design.md
@@ -193,6 +193,13 @@ UI can proceed:
   add action awaits `addToList` / `addToCatalog`; show `Button loading` for that
   call.
 
+> **Implementation note (2026-07-23):** the inline button-busy state shipped for
+> **create-list only**. The add-item and catalogue-create actions route through
+> `useShoppingList` / `useCatalogue`, which now feed the global `busyCount` bar —
+> so those actions already show loading feedback via the top bar. The extra
+> *local* inline spinner on those two buttons was deliberately deferred (accepted
+> narrowing, confirmed during final review). The global bar covers the gap.
+
 ### 6.4 Debounced-edit "Saving / Saved"
 
 Keep the existing `.md-saved-flash` "Saved" pill (driven by `lastSaved`). Add a

--- a/hooks/useCatalogue.ts
+++ b/hooks/useCatalogue.ts
@@ -1,6 +1,7 @@
 import { computed, signal } from "@preact/signals";
 import type { CategoryInterface, ItemInterface } from "@/models/index.ts";
 import { api } from "@/services/api.ts";
+import { beginBusy, endBusy } from "@/utils/loading.ts";
 
 export function useCatalogue(
   initialItems: ItemInterface[],
@@ -9,6 +10,15 @@ export function useCatalogue(
   const items = signal<ItemInterface[]>(initialItems ?? []);
   const categories = signal<CategoryInterface[]>(initialCategories ?? []);
   const pendingCount = signal<number>(0);
+  // Mirror each in-flight mutation into the global loading bar.
+  const startPending = () => {
+    pendingCount.value++;
+    beginBusy();
+  };
+  const endPending = () => {
+    pendingCount.value--;
+    endBusy();
+  };
 
   const sortedCategories = computed(() =>
     [...categories.value].sort((a, b) =>
@@ -43,7 +53,7 @@ export function useCatalogue(
   ): Promise<string | null> => {
     const trimmed = name.trim();
     if (!trimmed) return null;
-    pendingCount.value++;
+    startPending();
     try {
       const created = await api.items.create({ name: trimmed, categoryId });
       if (created) {
@@ -52,7 +62,7 @@ export function useCatalogue(
       }
       return null;
     } finally {
-      pendingCount.value--;
+      endPending();
     }
   };
 
@@ -63,11 +73,11 @@ export function useCatalogue(
     items.value = items.value.map((
       i,
     ) => (i.id === id ? { ...i, name: trimmed } : i));
-    pendingCount.value++;
+    startPending();
     try {
       await api.items.update(id, trimmed, existing.categoryId);
     } finally {
-      pendingCount.value--;
+      endPending();
     }
   };
 
@@ -77,21 +87,21 @@ export function useCatalogue(
     items.value = items.value.map((
       i,
     ) => (i.id === id ? { ...i, categoryId } : i));
-    pendingCount.value++;
+    startPending();
     try {
       await api.items.update(id, existing.name, categoryId);
     } finally {
-      pendingCount.value--;
+      endPending();
     }
   };
 
   const removeItem = async (id: string): Promise<void> => {
     items.value = items.value.filter((i) => i.id !== id);
-    pendingCount.value++;
+    startPending();
     try {
       await api.items.delete(id);
     } finally {
-      pendingCount.value--;
+      endPending();
     }
   };
 
@@ -100,7 +110,7 @@ export function useCatalogue(
   ): Promise<CategoryInterface | null> => {
     const trimmed = label.trim();
     if (!trimmed) return null;
-    pendingCount.value++;
+    startPending();
     try {
       const created = await api.categories.create(trimmed);
       if (created) {
@@ -109,7 +119,7 @@ export function useCatalogue(
       }
       return null;
     } finally {
-      pendingCount.value--;
+      endPending();
     }
   };
 
@@ -119,21 +129,21 @@ export function useCatalogue(
     categories.value = categories.value.map((c) =>
       c.id === id ? { ...c, label: trimmed } : c
     );
-    pendingCount.value++;
+    startPending();
     try {
       await api.categories.update(id, { label: trimmed });
     } finally {
-      pendingCount.value--;
+      endPending();
     }
   };
 
   const deleteCategory = async (id: string): Promise<void> => {
     categories.value = categories.value.filter((c) => c.id !== id);
-    pendingCount.value++;
+    startPending();
     try {
       await api.categories.delete(id);
     } finally {
-      pendingCount.value--;
+      endPending();
     }
   };
 

--- a/hooks/useShoppingList.ts
+++ b/hooks/useShoppingList.ts
@@ -6,6 +6,7 @@ import {
 } from "@/models/index.ts";
 import { createDebouncedMergeScheduler } from "@/utils/debounce-update.ts";
 import { api } from "@/services/api.ts";
+import { beginBusy, endBusy } from "@/utils/loading.ts";
 
 export function useShoppingList(
   listId: string,
@@ -31,6 +32,15 @@ export function useShoppingList(
   const categories = signal<CategoryInterface[]>(initialCategories);
   const selectedCategoryId = signal<string>("");
   const pendingCount = signal<number>(0);
+  // Mirror each in-flight mutation into the global loading bar.
+  const startPending = () => {
+    pendingCount.value++;
+    beginBusy();
+  };
+  const endPending = () => {
+    pendingCount.value--;
+    endBusy();
+  };
   // Bumped whenever a debounced list-item write actually flushes to the API,
   // so the UI can show a "Saved" indicator tied to the real write (not keystrokes).
   const lastSaved = signal<number>(0);
@@ -68,11 +78,11 @@ export function useShoppingList(
   };
 
   const addToList = async (itemId: string): Promise<string | null> => {
-    pendingCount.value++;
+    startPending();
     try {
       return await _addToList(itemId);
     } finally {
-      pendingCount.value--;
+      endPending();
     }
   };
 
@@ -81,7 +91,7 @@ export function useShoppingList(
     categoryId?: string,
   ): Promise<string | null> => {
     if (!name) return null;
-    pendingCount.value++;
+    startPending();
     try {
       const created = await api.items.create({ name, categoryId });
       if (created) {
@@ -92,7 +102,7 @@ export function useShoppingList(
       }
       return null;
     } finally {
-      pendingCount.value--;
+      endPending();
     }
   };
 
@@ -105,16 +115,16 @@ export function useShoppingList(
     checkedItems.value = checkedItems.value.filter((li) => li.id !== id);
     exitingItems.value = exitingItems.value.filter((itemId) => itemId !== id);
 
-    pendingCount.value++;
+    startPending();
     try {
       await api.shoppingList.removeItem(listId, id);
     } finally {
-      pendingCount.value--;
+      endPending();
     }
   };
 
   const checkItem = async (id: string) => {
-    pendingCount.value++;
+    startPending();
     exitingItems.value = [...exitingItems.value, id];
     try {
       await new Promise((resolve) => setTimeout(resolve, 300));
@@ -130,12 +140,12 @@ export function useShoppingList(
       checkedItems.value = [...checkedItems.value, checked];
       await api.shoppingList.updateItem(listId, id, { checked: true });
     } finally {
-      pendingCount.value--;
+      endPending();
     }
   };
 
   const uncheckItem = async (id: string) => {
-    pendingCount.value++;
+    startPending();
     try {
       const item = checkedItems.value.find((li) => li.id === id);
       if (!item) return;
@@ -144,12 +154,12 @@ export function useShoppingList(
       list.value = [...list.value, active];
       await api.shoppingList.updateItem(listId, id, { checked: false });
     } finally {
-      pendingCount.value--;
+      endPending();
     }
   };
 
   const refresh = async () => {
-    pendingCount.value++;
+    startPending();
     try {
       const [newList, newItems, newCategories] = await Promise.all([
         api.shoppingList.getItems(listId),
@@ -161,7 +171,7 @@ export function useShoppingList(
       items.value = newItems;
       categories.value = newCategories;
     } finally {
-      pendingCount.value--;
+      endPending();
     }
   };
 

--- a/hooks/useShoppingList.ts
+++ b/hooks/useShoppingList.ts
@@ -45,12 +45,28 @@ export function useShoppingList(
   // so the UI can show a "Saved" indicator tied to the real write (not keystrokes).
   const lastSaved = signal<number>(0);
 
+  // Ids of list items whose debounced write hasn't flushed yet (drives "Saving…").
+  const savingIds = signal<Set<string>>(new Set());
+  const markSaving = (id: string) => {
+    if (savingIds.value.has(id)) return;
+    const next = new Set(savingIds.value);
+    next.add(id);
+    savingIds.value = next;
+  };
+  const clearSaving = (id: string) => {
+    if (!savingIds.value.has(id)) return;
+    const next = new Set(savingIds.value);
+    next.delete(id);
+    savingIds.value = next;
+  };
+
   const patchScheduler = createDebouncedMergeScheduler<
     ShoppingListItemInterface
   >({
     delayMs: 500,
     flush: async (id, patch) => {
       await api.shoppingList.updateItem(listId, id, patch);
+      clearSaving(id);
       lastSaved.value = lastSaved.value + 1;
     },
   });
@@ -65,6 +81,7 @@ export function useShoppingList(
     list.value = list.value.map((li) =>
       li.id === id ? { ...li, ...patch } : li
     );
+    markSaving(id);
     patchScheduler.schedule(id, patch);
   };
 
@@ -111,6 +128,7 @@ export function useShoppingList(
     await new Promise((resolve) => setTimeout(resolve, 300));
 
     patchScheduler.cancel(id);
+    clearSaving(id);
     list.value = list.value.filter((li) => li.id !== id);
     checkedItems.value = checkedItems.value.filter((li) => li.id !== id);
     exitingItems.value = exitingItems.value.filter((itemId) => itemId !== id);
@@ -134,6 +152,7 @@ export function useShoppingList(
         return;
       }
       patchScheduler.cancel(id);
+      clearSaving(id);
       list.value = list.value.filter((li) => li.id !== id);
       exitingItems.value = exitingItems.value.filter((i) => i !== id);
       const checked = { ...item, checked: true };
@@ -250,6 +269,7 @@ export function useShoppingList(
     selectedCategoryId,
     listItemsMap,
     lastSaved,
+    savingIds,
     flushListItem,
   };
 }

--- a/hooks/useShoppingList.ts
+++ b/hooks/useShoppingList.ts
@@ -65,9 +65,12 @@ export function useShoppingList(
   >({
     delayMs: 500,
     flush: async (id, patch) => {
-      await api.shoppingList.updateItem(listId, id, patch);
-      clearSaving(id);
-      lastSaved.value = lastSaved.value + 1;
+      try {
+        await api.shoppingList.updateItem(listId, id, patch);
+        lastSaved.value = lastSaved.value + 1;
+      } finally {
+        clearSaving(id);
+      }
     },
   });
 
@@ -142,21 +145,23 @@ export function useShoppingList(
   };
 
   const checkItem = async (id: string) => {
-    startPending();
     exitingItems.value = [...exitingItems.value, id];
-    try {
-      await new Promise((resolve) => setTimeout(resolve, 300));
-      const item = list.value.find((li) => li.id === id);
-      if (!item) {
-        exitingItems.value = exitingItems.value.filter((i) => i !== id);
-        return;
-      }
-      patchScheduler.cancel(id);
-      clearSaving(id);
-      list.value = list.value.filter((li) => li.id !== id);
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    const item = list.value.find((li) => li.id === id);
+    if (!item) {
       exitingItems.value = exitingItems.value.filter((i) => i !== id);
-      const checked = { ...item, checked: true };
-      checkedItems.value = [...checkedItems.value, checked];
+      return;
+    }
+    patchScheduler.cancel(id);
+    clearSaving(id);
+    list.value = list.value.filter((li) => li.id !== id);
+    exitingItems.value = exitingItems.value.filter((i) => i !== id);
+    const checked = { ...item, checked: true };
+    checkedItems.value = [...checkedItems.value, checked];
+
+    startPending();
+    try {
       await api.shoppingList.updateItem(listId, id, { checked: true });
     } finally {
       endPending();

--- a/islands/catalogue.tsx
+++ b/islands/catalogue.tsx
@@ -11,6 +11,7 @@ import { IconButton } from "@/components/md3/IconButton.tsx";
 import { Icon } from "@/components/md3/Icon.tsx";
 import { Pressable } from "@/components/md3/Pressable.tsx";
 import { FabMenu } from "@/components/md3/FabMenu.tsx";
+import { navigateTo } from "@/utils/loading.ts";
 
 const SEGMENTED_OPTIONS: [string, "cart" | "tag", string][] = [
   ["lists", "cart", "Lists"],
@@ -121,7 +122,7 @@ export default function Catalogue(
           options={SEGMENTED_OPTIONS}
           value="catalogue"
           onChange={(k) => {
-            if (k === "lists") globalThis.location.href = "/shopping";
+            if (k === "lists") navigateTo("/shopping");
           }}
         />
       </div>

--- a/islands/items.tsx
+++ b/islands/items.tsx
@@ -10,6 +10,7 @@ import { useShoppingList } from "@/hooks/index.ts";
 import { api } from "@/services/api.ts";
 import { Segmented } from "@/components/md3/Segmented.tsx";
 import { Sheet } from "@/components/md3/Sheet.tsx";
+import { Spinner } from "@/components/md3/Spinner.tsx";
 import { CategoryPickerList } from "@/components/md3/CategoryPickerList.tsx";
 import { Card } from "@/components/md3/Card.tsx";
 import { Stepper } from "@/components/md3/Stepper.tsx";
@@ -58,6 +59,7 @@ export default function Items(
     categories,
     items,
     lastSaved,
+    savingIds,
     flushListItem,
   } = useMemo(
     () => useShoppingList(listId, catalog, shoppingList, initialCategories),
@@ -573,14 +575,20 @@ export default function Items(
                   savedTick so it replays on each flush */
               }
               <div class="h-6 flex justify-end items-center px-1">
-                {showSaved && (
-                  <span
-                    key={savedTick}
-                    class="md-saved-flash inline-flex items-center gap-1 md-label-medium text-on-tertiary-container bg-tertiary-container rounded-full px-2.5 py-0.5 pointer-events-none"
-                  >
-                    <Icon name="check" size={14} /> Saved
-                  </span>
-                )}
+                {savingIds.value.has(li.id!)
+                  ? (
+                    <span class="inline-flex items-center gap-1.5 md-label-medium text-on-surface-variant">
+                      <Spinner size={12} /> Saving…
+                    </span>
+                  )
+                  : showSaved && (
+                    <span
+                      key={savedTick}
+                      class="md-saved-flash inline-flex items-center gap-1 md-label-medium text-on-tertiary-container bg-tertiary-container rounded-full px-2.5 py-0.5 pointer-events-none"
+                    >
+                      <Icon name="check" size={14} /> Saved
+                    </span>
+                  )}
               </div>
 
               {/* Quantity */}

--- a/islands/items.tsx
+++ b/islands/items.tsx
@@ -23,6 +23,7 @@ import { RoundCheck } from "@/components/md3/RoundCheck.tsx";
 import { Snackbar } from "@/components/md3/Snackbar.tsx";
 import Fab from "@/islands/shell/Fab.tsx";
 import AddItems from "@/islands/add-items.tsx";
+import { navigateTo, reloadPage } from "@/utils/loading.ts";
 
 interface ItemsProps {
   listId: string;
@@ -449,7 +450,7 @@ export default function Items(
                     mgmtOpen.value = false;
                     // The route SSR renders the list name into the shell TopAppBar;
                     // reload to reflect the new name there.
-                    globalThis.location.reload();
+                    reloadPage();
                   }
                 }}
                 placeholder="List name"
@@ -462,7 +463,7 @@ export default function Items(
                   if (!name) return;
                   await api.shoppingLists.rename(listId, name);
                   mgmtOpen.value = false;
-                  globalThis.location.reload();
+                  reloadPage();
                 }}
               >
                 Save
@@ -521,7 +522,7 @@ export default function Items(
             onClick={async () => {
               mgmtOpen.value = false;
               await api.shoppingLists.delete(listId);
-              globalThis.location.href = "/shopping";
+              navigateTo("/shopping");
             }}
           />
         </div>

--- a/islands/shell/AppChrome.test.tsx
+++ b/islands/shell/AppChrome.test.tsx
@@ -1,13 +1,15 @@
-import { assertEquals, assertStringIncludes } from "jsr:@std/assert@^1.0.19";
+import { assertFalse, assertStringIncludes } from "jsr:@std/assert@^1.0.19";
 import { render } from "npm:preact-render-to-string@^6.6.3";
 import { h } from "preact";
 import AppChrome from "./AppChrome.tsx";
 
-Deno.test("AppChrome — mode:none renders no chrome (full-screen route)", () => {
+Deno.test("AppChrome — mode:none renders only the loading bar (full-screen route)", () => {
   const html = render(
     h(AppChrome, { appBar: { mode: "none" }, sectionTitle: "Shopping" }),
   );
-  assertEquals(html, "");
+  assertStringIncludes(html, 'role="progressbar"');
+  assertFalse(html.includes('aria-label="Main navigation"'));
+  assertFalse(html.includes("Shopping"));
 });
 
 Deno.test("AppChrome — mode:detail renders a back + title bar", () => {

--- a/islands/shell/AppChrome.tsx
+++ b/islands/shell/AppChrome.tsx
@@ -2,6 +2,7 @@ import { useSignal } from "@preact/signals";
 import TopAppBar from "./TopAppBar.tsx";
 import NavigationBar from "./NavigationBar.tsx";
 import MoreSheet from "./MoreSheet.tsx";
+import GlobalLoadingBar from "./GlobalLoadingBar.tsx";
 import { NAV_CONFIG } from "@/config/navigation.ts";
 import { appBarAction } from "@/utils/app-bar.ts";
 import { IconButton } from "@/components/md3/IconButton.tsx";
@@ -20,12 +21,13 @@ export default function AppChrome(
 
   // Full-screen routes (e.g. the add-items search) own the whole viewport:
   // no top bar and no bottom navigation.
-  if (appBar?.mode === "none") return null;
+  if (appBar?.mode === "none") return <GlobalLoadingBar />;
 
   const detail = appBar?.mode === "detail" ? appBar : null;
 
   return (
     <>
+      <GlobalLoadingBar />
       {detail
         ? (
           <TopAppBar

--- a/islands/shell/GlobalLoadingBar.test.tsx
+++ b/islands/shell/GlobalLoadingBar.test.tsx
@@ -1,0 +1,11 @@
+import { assertStringIncludes } from "jsr:@std/assert@^1.0.19";
+import { render } from "npm:preact-render-to-string@^6.6.3";
+import { h } from "preact";
+import GlobalLoadingBar from "./GlobalLoadingBar.tsx";
+
+Deno.test("GlobalLoadingBar — renders a progressbar region, hidden by default", () => {
+  const html = render(h(GlobalLoadingBar, {}));
+  assertStringIncludes(html, 'role="progressbar"');
+  assertStringIncludes(html, "md-loadbar-track");
+  assertStringIncludes(html, 'aria-hidden="true"'); // not visible until a load starts
+});

--- a/islands/shell/GlobalLoadingBar.tsx
+++ b/islands/shell/GlobalLoadingBar.tsx
@@ -1,0 +1,103 @@
+import { useSignal, useSignalEffect } from "@preact/signals";
+import { useEffect, useRef } from "preact/hooks";
+import { busyCount, navPending, shouldInterceptNav } from "@/utils/loading.ts";
+
+const SHOW_DELAY_MS = 200; // don't flash the bar for fast optimistic writes
+const MIN_VISIBLE_MS = 400; // once shown, stay up long enough to be seen
+
+/**
+ * The app's single global loading indicator. Shows immediately for navigation
+ * (navPending) and, after a short delay, for background CRUD (busyCount) — with a
+ * minimum visible duration so quick writes don't flicker. Mounted once by AppChrome.
+ */
+export default function GlobalLoadingBar() {
+  const busyVisible = useSignal(false);
+  const showTimer = useRef<number | undefined>(undefined);
+  const hideTimer = useRef<number | undefined>(undefined);
+  const shownAt = useRef(0);
+
+  // Map busyCount → busyVisible with the show-delay / min-visible timing.
+  useSignalEffect(() => {
+    const active = busyCount.value > 0;
+    if (active) {
+      if (hideTimer.current !== undefined) {
+        clearTimeout(hideTimer.current);
+        hideTimer.current = undefined;
+      }
+      if (!busyVisible.peek() && showTimer.current === undefined) {
+        showTimer.current = setTimeout(() => {
+          busyVisible.value = true;
+          shownAt.current = Date.now();
+          showTimer.current = undefined;
+        }, SHOW_DELAY_MS);
+      }
+    } else {
+      if (showTimer.current !== undefined) {
+        clearTimeout(showTimer.current);
+        showTimer.current = undefined;
+      }
+      if (busyVisible.peek() && hideTimer.current === undefined) {
+        const wait = Math.max(
+          0,
+          MIN_VISIBLE_MS - (Date.now() - shownAt.current),
+        );
+        hideTimer.current = setTimeout(() => {
+          busyVisible.value = false;
+          hideTimer.current = undefined;
+        }, wait);
+      }
+    }
+  });
+
+  // Centralized navigation interception (internal links) + bfcache reset.
+  useEffect(() => {
+    const onClick = (e: MouseEvent) => {
+      if (e.defaultPrevented) return;
+      const anchor = (e.target as Element | null)?.closest?.("a");
+      if (!anchor) return;
+      const modified = e.metaKey || e.ctrlKey || e.shiftKey || e.altKey ||
+        e.button !== 0;
+      if (
+        shouldInterceptNav({
+          href: anchor.getAttribute("href"),
+          target: anchor.getAttribute("target"),
+          download: anchor.hasAttribute("download"),
+          modified,
+          currentHref: location.href,
+        })
+      ) {
+        navPending.value = true;
+      }
+    };
+    const onPageShow = (e: PageTransitionEvent) => {
+      if (e.persisted) navPending.value = false; // restored from bfcache
+    };
+    document.addEventListener("click", onClick);
+    globalThis.addEventListener("pageshow", onPageShow);
+    return () => {
+      document.removeEventListener("click", onClick);
+      globalThis.removeEventListener("pageshow", onPageShow);
+    };
+  }, []);
+
+  const visible = navPending.value || busyVisible.value;
+
+  return (
+    <div
+      role="progressbar"
+      aria-label="Loading"
+      aria-hidden={visible ? undefined : "true"}
+      class="fixed left-0 right-0 z-50 pointer-events-none"
+      style={{
+        top: 0,
+        paddingTop: "env(safe-area-inset-top)",
+        opacity: visible ? 1 : 0,
+        transition: "opacity .2s var(--md-emphasized)",
+      }}
+    >
+      <div class="md-loadbar-track">
+        <div class="md-loadbar-wave" />
+      </div>
+    </div>
+  );
+}

--- a/islands/shell/MoreSheet.tsx
+++ b/islands/shell/MoreSheet.tsx
@@ -3,6 +3,7 @@ import { Sheet } from "@/components/md3/Sheet.tsx";
 import { ListItem } from "@/components/md3/ListItem.tsx";
 import { Icon, type IconName } from "@/components/md3/Icon.tsx";
 import { Snackbar } from "@/components/md3/Snackbar.tsx";
+import { navigateTo } from "@/utils/loading.ts";
 
 interface MoreSheetProps {
   open: boolean;
@@ -39,7 +40,7 @@ export default function MoreSheet({ open, onClose }: MoreSheetProps) {
           trailing={chevron()}
           onClick={() => {
             onClose();
-            globalThis.location.href = "/shopping";
+            navigateTo("/shopping");
           }}
         />
         <ListItem

--- a/islands/shell/NavigationBar.tsx
+++ b/islands/shell/NavigationBar.tsx
@@ -2,6 +2,7 @@ import { Pressable } from "@/components/md3/Pressable.tsx";
 import { Icon } from "@/components/md3/Icon.tsx";
 import { cn } from "@/components/md3/tokens.ts";
 import type { NavItem } from "@/config/navigation.ts";
+import { navigateTo } from "@/utils/loading.ts";
 
 interface NavigationBarProps {
   items: NavItem[];
@@ -16,7 +17,7 @@ export default function NavigationBar({
 }: NavigationBarProps) {
   const go = (it: NavItem) => {
     if (it.id === "more") onMore();
-    else globalThis.location.href = it.defaultRoute;
+    else navigateTo(it.defaultRoute);
   };
 
   return (

--- a/islands/shopping-lists.tsx
+++ b/islands/shopping-lists.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/md3/Button.tsx";
 import { Icon } from "@/components/md3/Icon.tsx";
 import { Segmented } from "@/components/md3/Segmented.tsx";
 import Fab from "@/islands/shell/Fab.tsx";
+import { navigateTo } from "@/utils/loading.ts";
 
 type ShoppingListWithCounts = ShoppingListInterface & {
   total: number;
@@ -70,8 +71,7 @@ export default function ShoppingLists({ initialLists }: ShoppingListsProps) {
           options={SEGMENTED_OPTIONS}
           value="lists"
           onChange={(k) => {
-            if (k === "catalogue") {globalThis.location.href =
-                "/shopping/catalogue";}
+            if (k === "catalogue") navigateTo("/shopping/catalogue");
           }}
         />
       </div>
@@ -110,7 +110,7 @@ export default function ShoppingLists({ initialLists }: ShoppingListsProps) {
                 variant="filled"
                 radius={20}
                 onClick={() => {
-                  globalThis.location.href = `/shopping/${list.id}`;
+                  navigateTo(`/shopping/${list.id}`);
                 }}
               >
                 <div class="flex flex-col gap-3">

--- a/islands/shopping-lists.tsx
+++ b/islands/shopping-lists.tsx
@@ -182,7 +182,7 @@ export default function ShoppingLists({ initialLists }: ShoppingListsProps) {
             variant="filled"
             full
             onClick={createList}
-            disabled={loading.value}
+            loading={loading.value}
           >
             Add
           </Button>

--- a/utils/loading.test.ts
+++ b/utils/loading.test.ts
@@ -1,0 +1,52 @@
+import { assert, assertEquals } from "jsr:@std/assert@^1.0.19";
+import {
+  beginBusy,
+  busyCount,
+  endBusy,
+  navigateTo,
+  navPending,
+  shouldInterceptNav,
+} from "./loading.ts";
+
+Deno.test("beginBusy/endBusy balance busyCount and floor at zero", () => {
+  busyCount.value = 0;
+  beginBusy();
+  beginBusy();
+  assertEquals(busyCount.value, 2);
+  endBusy();
+  endBusy();
+  endBusy(); // extra end must not go negative
+  assertEquals(busyCount.value, 0);
+});
+
+Deno.test("navigateTo sets navPending (nav is a no-op without a DOM location)", () => {
+  navPending.value = false;
+  navigateTo("/shopping");
+  assert(navPending.value);
+});
+
+Deno.test("shouldInterceptNav — internal same-origin link is intercepted", () => {
+  assert(shouldInterceptNav({
+    href: "/shopping/123",
+    currentHref: "https://app.test/shopping",
+  }));
+});
+
+Deno.test("shouldInterceptNav — external, _blank, download, modified, hash are ignored", () => {
+  const cur = "https://app.test/shopping";
+  assert(
+    !shouldInterceptNav({ href: "https://other.test/x", currentHref: cur }),
+  );
+  assert(
+    !shouldInterceptNav({ href: "/x", target: "_blank", currentHref: cur }),
+  );
+  assert(!shouldInterceptNav({ href: "/x", download: true, currentHref: cur }));
+  assert(!shouldInterceptNav({ href: "/x", modified: true, currentHref: cur }));
+  assert(!shouldInterceptNav({ href: null, currentHref: cur }));
+  assert(
+    !shouldInterceptNav({
+      href: "/shopping#top",
+      currentHref: cur,
+    }),
+  );
+});

--- a/utils/loading.ts
+++ b/utils/loading.ts
@@ -1,0 +1,64 @@
+import { signal } from "@preact/signals";
+
+/**
+ * Cross-island loading state. Module-scope signals are the sanctioned shared-state
+ * channel in this app (see utils/app-bar.ts). A full-page navigation resets them for free.
+ */
+
+/** True while a full-page navigation is in flight. */
+export const navPending = signal(false);
+
+/** Number of in-flight background mutations (optimistic CRUD). */
+export const busyCount = signal(0);
+
+/** Increment the in-flight mutation counter. */
+export function beginBusy(): void {
+  busyCount.value++;
+}
+
+/** Decrement the in-flight mutation counter (never below zero). */
+export function endBusy(): void {
+  busyCount.value = Math.max(0, busyCount.value - 1);
+}
+
+/** Show the nav indicator, then navigate. Nav is skipped when there is no DOM (tests). */
+export function navigateTo(url: string): void {
+  navPending.value = true;
+  if (typeof location !== "undefined" && location) location.href = url;
+}
+
+/** Show the nav indicator, then reload. */
+export function reloadPage(): void {
+  navPending.value = true;
+  if (typeof location !== "undefined" && location) location.reload();
+}
+
+/** Pure decision: should a link click show the navigation indicator? */
+export function shouldInterceptNav(opts: {
+  href: string | null;
+  target?: string | null;
+  download?: boolean;
+  modified?: boolean;
+  currentHref: string;
+}): boolean {
+  const { href, target, download, modified, currentHref } = opts;
+  if (!href) return false;
+  if (modified) return false;
+  if (download) return false;
+  if (target && target !== "_self") return false;
+  let url: URL;
+  let cur: URL;
+  try {
+    cur = new URL(currentHref);
+    url = new URL(href, currentHref);
+  } catch {
+    return false;
+  }
+  if (url.origin !== cur.origin) return false; // external
+  if (url.href === cur.href) return false; // no-op
+  // same page, only a hash change → let the browser handle it, no full load
+  if (url.pathname === cur.pathname && url.search === cur.search && url.hash) {
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
Closes #32.

## What & why

The app had **no visual loading feedback** — users couldn't tell whether a page was loading or a change was being processed. This adds MD3-styled, **non-blocking** feedback for page navigation and in-flight CRUD, delivered as reusable primitives so future household modules inherit it for free.

Two architectural facts shaped the design: navigation is 100% full-page SSR (the real user-perceived wait), and CRUD is already fully **optimistic** (instant UI). So the goal was honest feedback that never slows the snappy optimistic feel.

Design spec: `docs/superpowers/specs/2026-07-23-loading-feedback-design.md`
Implementation plan: `docs/superpowers/plans/2026-07-23-loading-feedback.md`

## What's included

- **`GlobalLoadingBar`** island — a wavy indeterminate MD3 bar in the app shell. Shows **immediately** on navigation and, for background CRUD, only after a 200 ms delay with a 400 ms minimum-visible window (so fast optimistic writes never flicker the bar).
- **Centralized nav interception** — a single delegated click listener + a `navigateTo()`/`reloadPage()` helper, so every current and future navigation raises the indicator with zero per-site wiring.
- **`Spinner`** primitive (circular indeterminate) + a **`loading`** state on `Button`.
- **`utils/loading.ts`** — a small module-scope signal channel (`navPending`, `busyCount`) mirroring the existing `utils/app-bar.ts` cross-island pattern.
- The two CRUD hooks now feed `busyCount`; the create-list button shows an inline spinner; the item editor shows a **"Saving…"** phase before the existing "Saved" pill.

Wavy/amplitude MD3 style (not the full morphing indicator); skeletons intentionally out of scope (SSR pages arrive fully rendered — nothing to skeleton).

## How it was built & verified

Executed as 8 TDD tasks, each with a two-stage (spec + quality) review. Then a whole-branch review traced the cross-task seams — signal contract, anti-flicker timing state machine, module-scope reset, bfcache path, and the non-blocking guarantee all verified sound.

- `deno task check` green; `deno test -A` → **99 passed**.
- Browser-verified in the running app: shell + bar hydrate; wavy-bar CSS wired (animation, SVG wave mask, `--md-primary` on `--md-primary-container`); cross-page navigation routes through `navigateTo`.
- **Fixed during final review:** `checkItem` was marking "busy" around its 300 ms exit animation (unlike `removeListItem`), which made the global bar flash on every check-off — now mirrors `removeListItem` so busy wraps only the API call. Also made the "Saving…" pill clear in a `finally` so a failed edit can't strand it.

## Scope note

The spec named three inline button-spinner sites; this PR ships **create-list only**. The add-item and catalogue-create actions already surface loading via the global `busyCount` bar, so only the *local* inline spinner on those two buttons was deferred (accepted narrowing, per the approved plan).

## Deferred follow-ups (non-blocking, from review)

Minor items triaged as follow-up: redundant `&& location` guard; extra `shouldInterceptNav`/`reloadPage` test coverage; remove the unused `children` prop on `Spinner`; `useSignalEffect` timer cleanup on unmount; a `savingIds` set→clear lifecycle unit test; bar is 6 px vs the spec's 4 px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
