### PR TITLE
feat(shopping): add reusable pull-to-refresh pattern

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -260,9 +260,20 @@
   animation: md-saved-flash 1.6s var(--md-emphasized) forwards;
 }
 
+/* Pull-to-refresh indicator spinner */
+@keyframes pull-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.pull-spin {
+  animation: pull-spin 0.8s linear infinite;
+}
+
 body {
   background: var(--md-background);
   color: var(--md-on-surface);
+  overscroll-behavior-y: contain;
 }
 * {
   box-sizing: border-box;

--- a/components/md3/PullToRefresh.test.tsx
+++ b/components/md3/PullToRefresh.test.tsx
@@ -1,0 +1,34 @@
+import { assert, assertStringIncludes } from "jsr:@std/assert@^1.0.19";
+import { render } from "npm:preact-render-to-string@^6.6.3";
+import { h } from "preact";
+import { PullToRefresh } from "./PullToRefresh.tsx";
+
+Deno.test("PullToRefresh — renders its children", () => {
+  const html = render(
+    h(
+      PullToRefresh,
+      { onRefresh: () => Promise.resolve() },
+      h("p", null, "Hello content"),
+    ),
+  );
+  assertStringIncludes(html, "Hello content");
+});
+
+Deno.test("PullToRefresh — forwards class to the content root", () => {
+  const html = render(
+    h(
+      PullToRefresh,
+      { onRefresh: () => Promise.resolve(), class: "flex flex-col gap-4" },
+      h("p", null, "x"),
+    ),
+  );
+  assertStringIncludes(html, "flex flex-col gap-4");
+});
+
+Deno.test("PullToRefresh — idle: sr-only status present, no error snackbar", () => {
+  const html = render(
+    h(PullToRefresh, { onRefresh: () => Promise.resolve() }, h("p", null, "x")),
+  );
+  assertStringIncludes(html, "aria-live");
+  assert(!html.includes("Couldn't refresh")); // error snackbar hidden at idle
+});

--- a/components/md3/PullToRefresh.tsx
+++ b/components/md3/PullToRefresh.tsx
@@ -1,0 +1,170 @@
+import type { ComponentChildren, VNode } from "preact";
+import { useEffect, useMemo, useRef } from "preact/hooks";
+import { useSignal } from "@preact/signals";
+import { usePullToRefresh } from "@/hooks/usePullToRefresh.ts";
+import { Icon } from "@/components/md3/Icon.tsx";
+import { Snackbar } from "@/components/md3/Snackbar.tsx";
+
+interface PullToRefreshProps {
+  /** The page's refresh action. Rejection surfaces the error Snackbar. */
+  onRefresh: () => Promise<unknown> | unknown;
+  /** When true, the gesture is inert (e.g. a sheet/overlay is open). */
+  disabled?: boolean;
+  /** Classes forwarded to the content root (so it can host the page's layout). */
+  class?: string;
+  children?: ComponentChildren;
+}
+
+const THRESHOLD = 72;
+
+/**
+ * Reusable pull-to-refresh wrapper. Overlay-style (content is NOT transformed),
+ * so it can safely enclose fixed FABs/sheets/overlays. Touch only.
+ *
+ * Usage:
+ *   <PullToRefresh onRefresh={refresh} disabled={sheetOpen} class="flex flex-col gap-4">
+ *     ...page content...
+ *   </PullToRefresh>
+ */
+export function PullToRefresh(
+  { onRefresh, disabled, class: className, children }: PullToRefreshProps,
+): VNode {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const snack = useSignal<{ msg: string } | null>(null);
+  const snackTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Latest props for the once-bound listeners / memoized controller to read.
+  const latest = useRef({ onRefresh, disabled });
+  latest.current = { onRefresh, disabled };
+
+  const showError = () => {
+    snack.value = { msg: "Couldn't refresh — try again" };
+    if (snackTimer.current) clearTimeout(snackTimer.current);
+    snackTimer.current = setTimeout(() => (snack.value = null), 3000);
+  };
+
+  // useMemo with [] ensures usePullToRefresh is called only once.
+  // usePullToRefresh uses plain signal() (not useSignal), so calling it on every
+  // re-render would recreate all signals from SSR props, discarding local state.
+  const ctrl = useMemo(
+    () =>
+      usePullToRefresh({
+        threshold: THRESHOLD,
+        onRefresh: () => latest.current.onRefresh(),
+        onError: () => showError(),
+      }),
+    [], // intentionally empty — signals are initialized once from SSR data
+  );
+
+  useEffect(() => {
+    const el = rootRef.current;
+    if (!el) return;
+    let startX = 0;
+
+    const onStart = (e: TouchEvent) => {
+      if (latest.current.disabled || e.touches.length !== 1) return;
+      const t = e.touches[0];
+      startX = t.clientX;
+      ctrl.begin(t.clientY);
+    };
+    const onMove = (e: TouchEvent) => {
+      if (latest.current.disabled || e.touches.length !== 1) return;
+      const t = e.touches[0];
+      // Bail on a predominantly-horizontal drag before we've engaged.
+      if (Math.abs(t.clientX - startX) > 40 && ctrl.pull.value === 0) {
+        ctrl.cancel();
+        return;
+      }
+      const atTop = (globalThis.scrollY ?? 0) <= 0;
+      const engaged = ctrl.move(t.clientY, atTop);
+      if (engaged && e.cancelable) e.preventDefault();
+    };
+    const onEnd = () => {
+      if (latest.current.disabled) return;
+      ctrl.end();
+    };
+    const onCancel = () => ctrl.cancel();
+
+    el.addEventListener("touchstart", onStart, { passive: true });
+    el.addEventListener("touchmove", onMove, { passive: false });
+    el.addEventListener("touchend", onEnd, { passive: true });
+    el.addEventListener("touchcancel", onCancel, { passive: true });
+    return () => {
+      el.removeEventListener("touchstart", onStart);
+      el.removeEventListener("touchmove", onMove);
+      el.removeEventListener("touchend", onEnd);
+      el.removeEventListener("touchcancel", onCancel);
+      if (snackTimer.current) clearTimeout(snackTimer.current);
+    };
+  }, []);
+
+  const status = ctrl.status.value;
+  const pull = ctrl.pull.value;
+  const dragging = status === "pulling" || status === "armed";
+  const active = status !== "idle" && status !== "error";
+  const progress = Math.min(pull / THRESHOLD, 1);
+
+  const offset = dragging ? pull * 0.6 : active ? 16 : -24;
+  const opacity = status === "idle" || status === "error"
+    ? 0
+    : dragging
+    ? progress
+    : 1;
+  const scale = 0.8 + 0.2 * (dragging ? progress : 1);
+  const spinDeg = dragging ? pull * 2.5 : 0;
+
+  return (
+    <>
+      <div ref={rootRef} class={className}>{children}</div>
+
+      {/* Decorative pull indicator */}
+      <div
+        aria-hidden="true"
+        class="fixed left-0 right-0 z-[250] flex justify-center pointer-events-none"
+        style={{ top: "calc(env(safe-area-inset-top) + 64px)" }}
+      >
+        <div
+          class="grid place-items-center bg-surface-c text-primary md-elevation-3 rounded-[var(--md-shape-full)]"
+          style={{
+            width: 40,
+            height: 40,
+            opacity,
+            transform: `translateY(${offset}px) scale(${scale})`,
+            transition: dragging ? "none" : "all .3s var(--md-emphasized)",
+          }}
+        >
+          {status === "success"
+            ? <Icon name="check" size={22} stroke={2.5} />
+            : (
+              <span
+                class={status === "refreshing" ? "pull-spin" : ""}
+                style={{
+                  width: 22,
+                  height: 22,
+                  borderRadius: "50%",
+                  border: "2.5px solid currentColor",
+                  borderTopColor: "transparent",
+                  transform: status === "refreshing"
+                    ? undefined
+                    : `rotate(${spinDeg}deg)`,
+                }}
+              />
+            )}
+        </div>
+      </div>
+
+      {/* Screen-reader status */}
+      <span class="sr-only" aria-live="polite">
+        {status === "refreshing"
+          ? "Refreshing"
+          : status === "success"
+          ? "Refreshed"
+          : status === "error"
+          ? "Couldn't refresh"
+          : ""}
+      </span>
+
+      <Snackbar data={snack.value} />
+    </>
+  );
+}

--- a/components/md3/PullToRefresh.tsx
+++ b/components/md3/PullToRefresh.tsx
@@ -46,15 +46,16 @@ export function PullToRefresh(
   // useMemo with [] ensures usePullToRefresh is called only once.
   // usePullToRefresh uses plain signal() (not useSignal), so calling it on every
   // re-render would recreate all signals from SSR props, discarding local state.
-  const ctrl = useMemo(
-    () =>
-      usePullToRefresh({
-        threshold: THRESHOLD,
-        onRefresh: () => latest.current.onRefresh(),
-        onError: () => showError(),
-      }),
-    [], // intentionally empty — signals are initialized once from SSR data
-  );
+  const { status: statusSignal, pull: pullSignal, begin, move, end, cancel } =
+    useMemo(
+      () =>
+        usePullToRefresh({
+          threshold: THRESHOLD,
+          onRefresh: () => latest.current.onRefresh(),
+          onError: () => showError(),
+        }),
+      [], // intentionally empty — signals are initialized once from SSR data
+    );
 
   useEffect(() => {
     const el = rootRef.current;
@@ -65,25 +66,25 @@ export function PullToRefresh(
       if (latest.current.disabled || e.touches.length !== 1) return;
       const t = e.touches[0];
       startX = t.clientX;
-      ctrl.begin(t.clientY);
+      begin(t.clientY);
     };
     const onMove = (e: TouchEvent) => {
       if (latest.current.disabled || e.touches.length !== 1) return;
       const t = e.touches[0];
       // Bail on a predominantly-horizontal drag before we've engaged.
-      if (Math.abs(t.clientX - startX) > 40 && ctrl.pull.value === 0) {
-        ctrl.cancel();
+      if (Math.abs(t.clientX - startX) > 40 && pullSignal.value === 0) {
+        cancel();
         return;
       }
       const atTop = (globalThis.scrollY ?? 0) <= 0;
-      const engaged = ctrl.move(t.clientY, atTop);
+      const engaged = move(t.clientY, atTop);
       if (engaged && e.cancelable) e.preventDefault();
     };
     const onEnd = () => {
       if (latest.current.disabled) return;
-      ctrl.end();
+      end();
     };
-    const onCancel = () => ctrl.cancel();
+    const onCancel = () => cancel();
 
     el.addEventListener("touchstart", onStart, { passive: true });
     el.addEventListener("touchmove", onMove, { passive: false });
@@ -98,8 +99,8 @@ export function PullToRefresh(
     };
   }, []);
 
-  const status = ctrl.status.value;
-  const pull = ctrl.pull.value;
+  const status = statusSignal.value;
+  const pull = pullSignal.value;
   const dragging = status === "pulling" || status === "armed";
   const active = status !== "idle" && status !== "error";
   const progress = Math.min(pull / THRESHOLD, 1);

--- a/components/md3/PullToRefresh.tsx
+++ b/components/md3/PullToRefresh.tsx
@@ -81,7 +81,8 @@ export function PullToRefresh(
       if (engaged && e.cancelable) e.preventDefault();
     };
     const onEnd = () => {
-      if (latest.current.disabled) return;
+      // end() is a no-op when no gesture is engaged; always call it so a
+      // gesture in progress when `disabled` flips still resolves (never strands).
       end();
     };
     const onCancel = () => cancel();

--- a/deno.lock
+++ b/deno.lock
@@ -1136,6 +1136,7 @@
     "https://esm.sh/v135/@types/babel__helper-validator-identifier@~7/index.d.ts": "https://esm.sh/v135/@types/babel__helper-validator-identifier@7.15.2/index.d.ts"
   },
   "remote": {
+    "https://cdn.jsdelivr.net/npm/@pwabuilder/pwaupdate": "7d60f6be3a54a3cf6b48e76e50f9b029391f4e21f5cf26523c40b7a4cf555602",
     "https://deno.land/std@0.208.0/assert/_constants.ts": "8a9da298c26750b28b326b297316cdde860bc237533b07e1337c021379e6b2a9",
     "https://deno.land/std@0.208.0/assert/_diff.ts": "58e1461cc61d8eb1eacbf2a010932bf6a05b79344b02ca38095f9b805795dc48",
     "https://deno.land/std@0.208.0/assert/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",

--- a/docs/superpowers/plans/2026-07-23-pull-to-refresh.md
+++ b/docs/superpowers/plans/2026-07-23-pull-to-refresh.md
@@ -1,0 +1,999 @@
+# Pull-to-Refresh Pattern Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a reusable, MD3-consistent pull-to-refresh primitive and wire it into the three shopping data pages, each with its own refresh behaviour.
+
+**Architecture:** A DOM-free gesture state machine (`hooks/usePullToRefresh.ts`, `signal()`-based factory like `useShoppingList`) drives a presentational wrapper (`components/md3/PullToRefresh.tsx`) that owns touch listeners, a Material-style overlay indicator puck, and an internal error Snackbar. The indicator overlays static content (it does **not** transform the page), so the wrapper can safely enclose fixed overlays/FABs/sheets. Pages pass an `onRefresh` callback and a `disabled` flag.
+
+**Tech Stack:** Deno + Fresh 2 (Islands) + Preact + `@preact/signals` + Tailwind CSS v4. Tests via `deno test` (`@std/assert`, `@std/testing` `stub`/`FakeTime`, `preact-render-to-string`).
+
+## Global Constraints
+
+- **Imports:** use the `@/` alias (e.g. `import { Icon } from "@/components/md3/Icon.tsx"`).
+- **JSX:** Preact with `jsx: "precompile"` — use `class`, never `className`.
+- **Signals in islands:** local island state uses `useSignal()`; the logic hook `usePullToRefresh` deliberately uses module `signal()` and is created once via `useMemo(() => usePullToRefresh(...), [])` (same pattern as `useShoppingList`).
+- **Gesture:** touch only (no mouse/desktop). Default `threshold = 72` px damped travel, `resistance = 0.5`.
+- **Error copy (verbatim):** `Couldn't refresh — try again`.
+- **CSS:** add `overscroll-behavior-y: contain` to `body` as defense-in-depth against native browser pull-to-refresh.
+- **Out of scope:** category-reorder page, Home/Menu/Todos placeholders, keyboard/programmatic trigger, any API/route/data-model change.
+- **Commits:** Conventional Commits (`feat:`, `test:`, `docs:` …).
+- **Every task ends green:** `deno task check` and `deno test -A` must pass before committing.
+
+---
+
+### Task 1: `usePullToRefresh` gesture state machine
+
+**Files:**
+- Create: `hooks/usePullToRefresh.ts`
+- Test: `hooks/usePullToRefresh.test.ts`
+- Modify: `hooks/index.ts` (add export)
+
+**Interfaces:**
+- Consumes: `signal`, `Signal` from `@preact/signals`.
+- Produces:
+  - `type PullStatus = "idle" | "pulling" | "armed" | "refreshing" | "success" | "error"`
+  - `interface UsePullToRefreshOptions { onRefresh: () => Promise<unknown> | unknown; threshold?: number; resistance?: number; onError?: (error: unknown) => void; onSuccess?: () => void; }`
+  - `interface PullToRefreshController { status: Signal<PullStatus>; pull: Signal<number>; begin(startY: number): void; move(currentY: number, atTop: boolean): boolean; end(): void; cancel(): void; }`
+  - `function usePullToRefresh(opts: UsePullToRefreshOptions): PullToRefreshController`
+  - `move` returns `true` when the gesture is engaged (caller should `preventDefault`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `hooks/usePullToRefresh.test.ts`:
+
+```ts
+import { assert, assertEquals } from "jsr:@std/assert@^1.0.19";
+import { FakeTime } from "jsr:@std/testing@^1.0.18/time";
+import { usePullToRefresh } from "@/hooks/usePullToRefresh.ts";
+
+Deno.test("usePullToRefresh — pull below threshold springs back, no refresh", () => {
+  let calls = 0;
+  const c = usePullToRefresh({
+    threshold: 72,
+    resistance: 0.5,
+    onRefresh: () => {
+      calls++;
+      return Promise.resolve();
+    },
+  });
+  c.begin(100);
+  const engaged = c.move(220, true); // raw 120 * 0.5 = 60 < 72
+  assert(engaged);
+  assertEquals(c.status.value, "pulling");
+  assertEquals(c.pull.value, 60);
+  c.end();
+  assertEquals(c.status.value, "idle");
+  assertEquals(c.pull.value, 0);
+  assertEquals(calls, 0);
+});
+
+Deno.test("usePullToRefresh — past threshold arms, then refreshes and succeeds", async () => {
+  const time = new FakeTime();
+  try {
+    let calls = 0;
+    const c = usePullToRefresh({
+      threshold: 72,
+      resistance: 0.5,
+      onRefresh: () => {
+        calls++;
+        return Promise.resolve();
+      },
+    });
+    c.begin(0);
+    c.move(200, true); // raw 200 * 0.5 = 100 >= 72 → armed
+    assertEquals(c.status.value, "armed");
+    c.end();
+    assertEquals(c.status.value, "refreshing");
+    assertEquals(calls, 1);
+    await time.tickAsync(0); // flush onRefresh microtasks
+    assertEquals(c.status.value, "success");
+    await time.tickAsync(600);
+    assertEquals(c.status.value, "idle");
+    assertEquals(c.pull.value, 0);
+  } finally {
+    time.restore();
+  }
+});
+
+Deno.test("usePullToRefresh — rejection goes to error then idle and calls onError", async () => {
+  const time = new FakeTime();
+  try {
+    let errored: unknown = null;
+    const c = usePullToRefresh({
+      threshold: 72,
+      onRefresh: () => Promise.reject(new Error("boom")),
+      onError: (e) => (errored = e),
+    });
+    c.begin(0);
+    c.move(300, true);
+    c.end();
+    await time.tickAsync(0);
+    assertEquals(c.status.value, "error");
+    assert(errored instanceof Error);
+    await time.tickAsync(400);
+    assertEquals(c.status.value, "idle");
+  } finally {
+    time.restore();
+  }
+});
+
+Deno.test("usePullToRefresh — does not engage when not scrolled to top", () => {
+  let calls = 0;
+  const c = usePullToRefresh({
+    onRefresh: () => {
+      calls++;
+      return Promise.resolve();
+    },
+  });
+  c.begin(0);
+  const engaged = c.move(200, false); // atTop = false
+  assertEquals(engaged, false);
+  assertEquals(c.status.value, "idle");
+  c.end();
+  assertEquals(calls, 0);
+});
+
+Deno.test("usePullToRefresh — ignores new gestures while refreshing", async () => {
+  const time = new FakeTime();
+  try {
+    let calls = 0;
+    const c = usePullToRefresh({
+      threshold: 72,
+      onRefresh: () => {
+        calls++;
+        return Promise.resolve();
+      },
+    });
+    c.begin(0);
+    c.move(300, true);
+    c.end();
+    assertEquals(c.status.value, "refreshing");
+    c.begin(0);
+    assertEquals(c.move(300, true), false); // no-op mid-refresh
+    c.end();
+    await time.tickAsync(0);
+    assertEquals(calls, 1);
+    await time.tickAsync(600);
+  } finally {
+    time.restore();
+  }
+});
+
+Deno.test("usePullToRefresh — resistance damps pull distance", () => {
+  const c = usePullToRefresh({
+    threshold: 72,
+    resistance: 0.4,
+    onRefresh: () => Promise.resolve(),
+  });
+  c.begin(0);
+  c.move(100, true); // 100 * 0.4 = 40
+  assertEquals(c.pull.value, 40);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `deno test -A hooks/usePullToRefresh.test.ts`
+Expected: FAIL — module `hooks/usePullToRefresh.ts` not found / `usePullToRefresh` is not a function.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `hooks/usePullToRefresh.ts`:
+
+```ts
+import { signal, type Signal } from "@preact/signals";
+
+export type PullStatus =
+  | "idle"
+  | "pulling"
+  | "armed"
+  | "refreshing"
+  | "success"
+  | "error";
+
+export interface UsePullToRefreshOptions {
+  /** The page's refresh action. May return a promise; rejection → error state. */
+  onRefresh: () => Promise<unknown> | unknown;
+  /** Damped pull distance (px) required to arm a refresh. Default 72. */
+  threshold?: number;
+  /** Fraction of raw finger travel applied to the pull. Default 0.5. */
+  resistance?: number;
+  onError?: (error: unknown) => void;
+  onSuccess?: () => void;
+}
+
+export interface PullToRefreshController {
+  status: Signal<PullStatus>;
+  pull: Signal<number>;
+  /** Record the touch origin. */
+  begin(startY: number): void;
+  /** Update from a move; returns true when engaged (caller should preventDefault). */
+  move(currentY: number, atTop: boolean): boolean;
+  /** Release: refresh if armed, else spring back. */
+  end(): void;
+  /** Abort an in-progress (non-refreshing) pull. */
+  cancel(): void;
+}
+
+const ENGAGE_SLOP = 6; // px of downward travel before we hijack the gesture
+const SUCCESS_MS = 600; // how long the success check lingers
+const ERROR_MS = 400; // how long the error state lingers before reset
+
+/**
+ * Gesture state machine for pull-to-refresh. DOM-free and signal-based so it can
+ * be unit-tested by calling its methods directly (see usePullToRefresh.test.ts).
+ * Created once per consumer via `useMemo(() => usePullToRefresh(...), [])`.
+ */
+export function usePullToRefresh(
+  opts: UsePullToRefreshOptions,
+): PullToRefreshController {
+  const { onRefresh, threshold = 72, resistance = 0.5, onError, onSuccess } =
+    opts;
+
+  const status = signal<PullStatus>("idle");
+  const pull = signal(0);
+  const maxPull = threshold + 48;
+
+  let startY = 0;
+  let engaged = false;
+  let resetTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const busy = () =>
+    status.value === "refreshing" || status.value === "success";
+
+  const scheduleIdle = (ms: number) => {
+    if (resetTimer) clearTimeout(resetTimer);
+    resetTimer = setTimeout(() => {
+      status.value = "idle";
+      pull.value = 0;
+    }, ms);
+  };
+
+  const begin = (y: number) => {
+    if (busy()) return;
+    startY = y;
+    engaged = false;
+  };
+
+  const move = (currentY: number, atTop: boolean): boolean => {
+    if (busy()) return false;
+    if (!engaged) {
+      if (atTop && currentY - startY > ENGAGE_SLOP) engaged = true;
+      else return false;
+    }
+    const raw = currentY - startY;
+    if (raw <= 0) {
+      pull.value = 0;
+      status.value = "idle";
+      engaged = false;
+      return false;
+    }
+    const damped = Math.min(raw * resistance, maxPull);
+    pull.value = damped;
+    status.value = damped >= threshold ? "armed" : "pulling";
+    return true;
+  };
+
+  const end = () => {
+    if (!engaged) return;
+    engaged = false;
+    if (status.value !== "armed") {
+      pull.value = 0;
+      status.value = "idle";
+      return;
+    }
+    status.value = "refreshing";
+    pull.value = threshold;
+    Promise.resolve()
+      .then(() => onRefresh())
+      .then(
+        () => {
+          status.value = "success";
+          onSuccess?.();
+          scheduleIdle(SUCCESS_MS);
+        },
+        (error) => {
+          status.value = "error";
+          pull.value = 0;
+          onError?.(error);
+          scheduleIdle(ERROR_MS);
+        },
+      );
+  };
+
+  const cancel = () => {
+    if (busy()) return;
+    pull.value = 0;
+    status.value = "idle";
+    engaged = false;
+  };
+
+  return { status, pull, begin, move, end, cancel };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `deno test -A hooks/usePullToRefresh.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Export from the hooks barrel**
+
+Add to `hooks/index.ts` (after the existing exports):
+
+```ts
+export * from "./usePullToRefresh.ts";
+```
+
+- [ ] **Step 6: Verify the gate is green**
+
+Run: `deno task check && deno test -A hooks/usePullToRefresh.test.ts`
+Expected: fmt/lint/type-check clean; tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add hooks/usePullToRefresh.ts hooks/usePullToRefresh.test.ts hooks/index.ts
+git commit -m "feat(shopping): add usePullToRefresh gesture state machine"
+```
+
+---
+
+### Task 2: `PullToRefresh` wrapper component + indicator CSS
+
+**Files:**
+- Create: `components/md3/PullToRefresh.tsx`
+- Test: `components/md3/PullToRefresh.test.tsx`
+- Modify: `assets/styles.css` (spinner keyframe + `overscroll-behavior-y`)
+
+**Interfaces:**
+- Consumes: `usePullToRefresh` + `PullToRefreshController` (Task 1); `Icon` from `@/components/md3/Icon.tsx`; `Snackbar` from `@/components/md3/Snackbar.tsx`.
+- Produces:
+  - `interface PullToRefreshProps { onRefresh: () => Promise<unknown> | unknown; disabled?: boolean; class?: string; children: ComponentChildren; }`
+  - `function PullToRefresh(props: PullToRefreshProps): VNode` (named export).
+  - Renders `children` inside a `class`-forwarded root div; a fixed decorative indicator; an `aria-live` status; an internal error Snackbar.
+
+- [ ] **Step 1: Add the spinner keyframe and overscroll guard to CSS**
+
+In `assets/styles.css`, append after the `.md-saved-flash` block (near line 261):
+
+```css
+/* Pull-to-refresh indicator spinner */
+@keyframes pull-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.pull-spin {
+  animation: pull-spin 0.8s linear infinite;
+}
+```
+
+Then change the existing `body` rule (near line 263) from:
+
+```css
+body {
+  background: var(--md-background);
+  color: var(--md-on-surface);
+}
+```
+
+to:
+
+```css
+body {
+  background: var(--md-background);
+  color: var(--md-on-surface);
+  overscroll-behavior-y: contain;
+}
+```
+
+- [ ] **Step 2: Write the failing SSR test**
+
+Create `components/md3/PullToRefresh.test.tsx`:
+
+```tsx
+import { assert, assertStringIncludes } from "jsr:@std/assert@^1.0.19";
+import { render } from "npm:preact-render-to-string@^6.6.3";
+import { h } from "preact";
+import { PullToRefresh } from "./PullToRefresh.tsx";
+
+Deno.test("PullToRefresh — renders its children", () => {
+  const html = render(
+    h(
+      PullToRefresh,
+      { onRefresh: () => Promise.resolve() },
+      h("p", null, "Hello content"),
+    ),
+  );
+  assertStringIncludes(html, "Hello content");
+});
+
+Deno.test("PullToRefresh — forwards class to the content root", () => {
+  const html = render(
+    h(
+      PullToRefresh,
+      { onRefresh: () => Promise.resolve(), class: "flex flex-col gap-4" },
+      h("p", null, "x"),
+    ),
+  );
+  assertStringIncludes(html, "flex flex-col gap-4");
+});
+
+Deno.test("PullToRefresh — idle: sr-only status present, no error snackbar", () => {
+  const html = render(
+    h(PullToRefresh, { onRefresh: () => Promise.resolve() }, h("p", null, "x")),
+  );
+  assertStringIncludes(html, "aria-live");
+  assert(!html.includes("Couldn't refresh")); // error snackbar hidden at idle
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `deno test -A components/md3/PullToRefresh.test.tsx`
+Expected: FAIL — `./PullToRefresh.tsx` not found.
+
+- [ ] **Step 4: Write the component**
+
+Create `components/md3/PullToRefresh.tsx`:
+
+```tsx
+import type { ComponentChildren } from "preact";
+import { useEffect, useMemo, useRef } from "preact/hooks";
+import { useSignal } from "@preact/signals";
+import { usePullToRefresh } from "@/hooks/usePullToRefresh.ts";
+import { Icon } from "@/components/md3/Icon.tsx";
+import { Snackbar } from "@/components/md3/Snackbar.tsx";
+
+interface PullToRefreshProps {
+  /** The page's refresh action. Rejection surfaces the error Snackbar. */
+  onRefresh: () => Promise<unknown> | unknown;
+  /** When true, the gesture is inert (e.g. a sheet/overlay is open). */
+  disabled?: boolean;
+  /** Classes forwarded to the content root (so it can host the page's layout). */
+  class?: string;
+  children: ComponentChildren;
+}
+
+const THRESHOLD = 72;
+
+/**
+ * Reusable pull-to-refresh wrapper. Overlay-style (content is NOT transformed),
+ * so it can safely enclose fixed FABs/sheets/overlays. Touch only.
+ *
+ * Usage:
+ *   <PullToRefresh onRefresh={refresh} disabled={sheetOpen} class="flex flex-col gap-4">
+ *     ...page content...
+ *   </PullToRefresh>
+ */
+export function PullToRefresh(
+  { onRefresh, disabled, class: className, children }: PullToRefreshProps,
+) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const snack = useSignal<{ msg: string } | null>(null);
+  const snackTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Latest props for the once-bound listeners / memoized controller to read.
+  const latest = useRef({ onRefresh, disabled });
+  latest.current = { onRefresh, disabled };
+
+  const showError = () => {
+    snack.value = { msg: "Couldn't refresh — try again" };
+    if (snackTimer.current) clearTimeout(snackTimer.current);
+    snackTimer.current = setTimeout(() => (snack.value = null), 3000);
+  };
+
+  // signal()-based factory, created once (mirrors useShoppingList usage).
+  const ctrl = useMemo(
+    () =>
+      usePullToRefresh({
+        threshold: THRESHOLD,
+        onRefresh: () => latest.current.onRefresh(),
+        onError: () => showError(),
+      }),
+    [],
+  );
+
+  useEffect(() => {
+    const el = rootRef.current;
+    if (!el) return;
+    let startX = 0;
+
+    const onStart = (e: TouchEvent) => {
+      if (latest.current.disabled || e.touches.length !== 1) return;
+      const t = e.touches[0];
+      startX = t.clientX;
+      ctrl.begin(t.clientY);
+    };
+    const onMove = (e: TouchEvent) => {
+      if (latest.current.disabled || e.touches.length !== 1) return;
+      const t = e.touches[0];
+      // Bail on a predominantly-horizontal drag before we've engaged.
+      if (Math.abs(t.clientX - startX) > 40 && ctrl.pull.value === 0) {
+        ctrl.cancel();
+        return;
+      }
+      const atTop = (globalThis.scrollY ?? 0) <= 0;
+      const engaged = ctrl.move(t.clientY, atTop);
+      if (engaged && e.cancelable) e.preventDefault();
+    };
+    const onEnd = () => {
+      if (latest.current.disabled) return;
+      ctrl.end();
+    };
+    const onCancel = () => ctrl.cancel();
+
+    el.addEventListener("touchstart", onStart, { passive: true });
+    el.addEventListener("touchmove", onMove, { passive: false });
+    el.addEventListener("touchend", onEnd, { passive: true });
+    el.addEventListener("touchcancel", onCancel, { passive: true });
+    return () => {
+      el.removeEventListener("touchstart", onStart);
+      el.removeEventListener("touchmove", onMove);
+      el.removeEventListener("touchend", onEnd);
+      el.removeEventListener("touchcancel", onCancel);
+      if (snackTimer.current) clearTimeout(snackTimer.current);
+    };
+  }, []);
+
+  const status = ctrl.status.value;
+  const pull = ctrl.pull.value;
+  const dragging = status === "pulling" || status === "armed";
+  const active = status !== "idle" && status !== "error";
+  const progress = Math.min(pull / THRESHOLD, 1);
+
+  const offset = dragging ? pull * 0.6 : active ? 16 : -24;
+  const opacity = status === "idle" || status === "error"
+    ? 0
+    : dragging
+    ? progress
+    : 1;
+  const scale = 0.8 + 0.2 * (dragging ? progress : 1);
+  const spinDeg = dragging ? pull * 2.5 : 0;
+
+  return (
+    <>
+      <div ref={rootRef} class={className}>{children}</div>
+
+      {/* Decorative pull indicator */}
+      <div
+        aria-hidden="true"
+        class="fixed left-0 right-0 z-[250] flex justify-center pointer-events-none"
+        style={{ top: "calc(env(safe-area-inset-top) + 64px)" }}
+      >
+        <div
+          class="grid place-items-center bg-surface-c text-primary md-elevation-3 rounded-[var(--md-shape-full)]"
+          style={{
+            width: 40,
+            height: 40,
+            opacity,
+            transform: `translateY(${offset}px) scale(${scale})`,
+            transition: dragging ? "none" : "all .3s var(--md-emphasized)",
+          }}
+        >
+          {status === "success"
+            ? <Icon name="check" size={22} stroke={2.5} />
+            : (
+              <span
+                class={status === "refreshing" ? "pull-spin" : ""}
+                style={{
+                  width: 22,
+                  height: 22,
+                  borderRadius: "50%",
+                  border: "2.5px solid currentColor",
+                  borderTopColor: "transparent",
+                  transform: status === "refreshing"
+                    ? undefined
+                    : `rotate(${spinDeg}deg)`,
+                }}
+              />
+            )}
+        </div>
+      </div>
+
+      {/* Screen-reader status */}
+      <span class="sr-only" aria-live="polite">
+        {status === "refreshing"
+          ? "Refreshing"
+          : status === "success"
+          ? "Refreshed"
+          : status === "error"
+          ? "Couldn't refresh"
+          : ""}
+      </span>
+
+      <Snackbar data={snack.value} />
+    </>
+  );
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `deno test -A components/md3/PullToRefresh.test.tsx`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Verify the gate is green**
+
+Run: `deno task check && deno test -A`
+Expected: fmt/lint/type-check clean; full suite PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add components/md3/PullToRefresh.tsx components/md3/PullToRefresh.test.tsx assets/styles.css
+git commit -m "feat(shopping): add PullToRefresh wrapper component and indicator styles"
+```
+
+---
+
+### Task 3: Integrate on the list-detail page (`items.tsx`)
+
+**Files:**
+- Modify: `islands/items.tsx`
+
+**Interfaces:**
+- Consumes: `PullToRefresh` (Task 2); the island's existing `refresh` (from `useShoppingList`) and signals `addOpen`, `mgmtOpen`, `editingId`.
+- Produces: no new exports.
+
+- [ ] **Step 1: Import the component**
+
+In `islands/items.tsx`, add to the imports (after the `AddItems` import near line 25):
+
+```tsx
+import { PullToRefresh } from "@/components/md3/PullToRefresh.tsx";
+```
+
+- [ ] **Step 2: Wrap the island content — opening tag**
+
+Replace the render's opening wrapper (currently line 186-187):
+
+```tsx
+  return (
+    <div class="flex flex-col gap-4 pb-24">
+```
+
+with:
+
+```tsx
+  return (
+    <PullToRefresh
+      onRefresh={refresh}
+      disabled={addOpen.value || mgmtOpen.value || editingId.value !== null}
+      class="flex flex-col gap-4 pb-24"
+    >
+```
+
+- [ ] **Step 3: Wrap the island content — closing tag**
+
+Replace the render's closing block (currently the tail of the component):
+
+```tsx
+      {/* ══════════════════════ Snackbar ══════════════════════ */}
+      <Snackbar data={snackData.value} />
+    </div>
+  );
+}
+```
+
+with:
+
+```tsx
+      {/* ══════════════════════ Snackbar ══════════════════════ */}
+      <Snackbar data={snackData.value} />
+    </PullToRefresh>
+  );
+}
+```
+
+- [ ] **Step 4: Verify type-check, lint, existing tests**
+
+Run: `deno task check && deno test -A islands/items.test.tsx`
+Expected: clean; `items.test.tsx` still PASS (SSR renders children unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add islands/items.tsx
+git commit -m "feat(shopping): wire pull-to-refresh into the list-detail page"
+```
+
+---
+
+### Task 4: Add `refresh` to `useCatalogue` and integrate on the catalogue page
+
+**Files:**
+- Modify: `hooks/useCatalogue.ts`
+- Test: `hooks/useCatalogue.test.ts` (add one test)
+- Modify: `islands/catalogue.tsx`
+
+**Interfaces:**
+- Consumes: `api.items.getAll`, `api.categories.getAll` (existing); `PullToRefresh` (Task 2); the island's existing `anySheetOpen`.
+- Produces: `useCatalogue(...).refresh: () => Promise<void>` (added to the returned object).
+
+- [ ] **Step 1: Write the failing hook test**
+
+Add to `hooks/useCatalogue.test.ts` (append at the end of the file):
+
+```ts
+Deno.test("refresh — re-pulls items and categories from the API", async () => {
+  const hook = useCatalogue([item("i1", "Butter", "d")], [cat("d", "Dairy")]);
+
+  const itemsStub = stub(
+    api.items,
+    "getAll",
+    () => Promise.resolve([item("i2", "Milk", "d"), item("i3", "Bread", "b")]),
+  );
+  const catsStub = stub(
+    api.categories,
+    "getAll",
+    () => Promise.resolve([cat("d", "Dairy"), cat("b", "Bakery")]),
+  );
+  try {
+    await hook.refresh();
+  } finally {
+    itemsStub.restore();
+    catsStub.restore();
+  }
+
+  assertEquals(hook.items.value.map((i) => i.name), ["Milk", "Bread"]);
+  assertEquals(hook.categories.value.map((c) => c.label), ["Dairy", "Bakery"]);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `deno test -A hooks/useCatalogue.test.ts`
+Expected: FAIL — `hook.refresh is not a function`.
+
+- [ ] **Step 3: Implement `refresh`**
+
+In `hooks/useCatalogue.ts`, add this function just before the `return {` block (after `deleteCategory`, near line 138):
+
+```ts
+  const refresh = async (): Promise<void> => {
+    pendingCount.value++;
+    try {
+      const [newItems, newCategories] = await Promise.all([
+        api.items.getAll(),
+        api.categories.getAll(),
+      ]);
+      items.value = newItems;
+      categories.value = newCategories;
+    } finally {
+      pendingCount.value--;
+    }
+  };
+```
+
+Then add `refresh,` to the returned object (inside `return { ... }`, e.g. right after `pendingCount,`):
+
+```ts
+    pendingCount,
+    refresh,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `deno test -A hooks/useCatalogue.test.ts`
+Expected: PASS (including the new test).
+
+- [ ] **Step 5: Import + destructure `refresh` in the catalogue island**
+
+In `islands/catalogue.tsx`, add to the imports (after the `useCatalogue` import near line 4):
+
+```tsx
+import { PullToRefresh } from "@/components/md3/PullToRefresh.tsx";
+```
+
+Then add `refresh` to the destructured hook result (the `const { ... } = useMemo(...)` block near line 35-51) — add it alongside the others, e.g. after `items,`:
+
+```tsx
+    items,
+    refresh,
+```
+
+- [ ] **Step 6: Wrap the island content — opening tag**
+
+Replace the render's opening fragment (currently line 116-119):
+
+```tsx
+  return (
+    <>
+      {/* Lists / Catalogue selector */}
+      <div class="px-4 pt-4 pb-2">
+```
+
+with:
+
+```tsx
+  return (
+    <PullToRefresh onRefresh={refresh} disabled={anySheetOpen}>
+      {/* Lists / Catalogue selector */}
+      <div class="px-4 pt-4 pb-2">
+```
+
+- [ ] **Step 7: Wrap the island content — closing tag**
+
+Replace the render's closing block (the tail of the component, currently lines 353-357):
+
+```tsx
+          ]}
+        />
+      )}
+    </>
+  );
+}
+```
+
+with:
+
+```tsx
+          ]}
+        />
+      )}
+    </PullToRefresh>
+  );
+}
+```
+
+- [ ] **Step 8: Verify the gate is green**
+
+Run: `deno task check && deno test -A hooks/useCatalogue.test.ts islands/catalogue.test.tsx`
+Expected: clean; both test files PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add hooks/useCatalogue.ts hooks/useCatalogue.test.ts islands/catalogue.tsx
+git commit -m "feat(shopping): add catalogue refresh and wire pull-to-refresh"
+```
+
+---
+
+### Task 5: Add a local `refresh` and integrate on the lists overview page (`shopping-lists.tsx`)
+
+**Files:**
+- Modify: `islands/shopping-lists.tsx`
+
+**Interfaces:**
+- Consumes: `api.shoppingLists.getAll`, `api.shoppingList.getItems` (existing); `PullToRefresh` (Task 2); the island's `lists` signal and `ShoppingListWithCounts` type.
+- Produces: a local `refresh` (not exported).
+
+**Note on counts:** the page renders lists with `total`/`done`, but `api.shoppingLists.getAll()` returns bare lists — so `refresh` re-fetches lists and recomputes counts per list via `api.shoppingList.getItems`, mirroring the server handler in `routes/shopping/index.tsx`.
+
+- [ ] **Step 1: Import the component**
+
+In `islands/shopping-lists.tsx`, add to the imports (after the `Fab` import near line 10):
+
+```tsx
+import { PullToRefresh } from "@/components/md3/PullToRefresh.tsx";
+```
+
+- [ ] **Step 2: Add the `refresh` function**
+
+In `islands/shopping-lists.tsx`, inside the `ShoppingLists` component, add this after the `createList` function (near line 63, before `return (`):
+
+```tsx
+  const refresh = async () => {
+    const fresh = await api.shoppingLists.getAll();
+    const withCounts = await Promise.all(
+      fresh.map(async (l) => {
+        const items = await api.shoppingList.getItems(l.id);
+        return {
+          ...l,
+          total: items.length,
+          done: items.filter((i) => i.checked).length,
+        };
+      }),
+    );
+    lists.value = withCounts;
+  };
+```
+
+- [ ] **Step 3: Wrap the island content — opening tag**
+
+Replace the render's opening fragment (currently line 65-68):
+
+```tsx
+  return (
+    <>
+      {/* Lists / Catalogue selector */}
+      <div class="px-4 pt-4 pb-2">
+```
+
+with:
+
+```tsx
+  return (
+    <PullToRefresh onRefresh={refresh} disabled={newOpen.value}>
+      {/* Lists / Catalogue selector */}
+      <div class="px-4 pt-4 pb-2">
+```
+
+- [ ] **Step 4: Wrap the island content — closing tag**
+
+Replace the render's closing block (the tail of the component, currently lines 190-193):
+
+```tsx
+        </div>
+      </Sheet>
+    </>
+  );
+}
+```
+
+with:
+
+```tsx
+        </div>
+      </Sheet>
+    </PullToRefresh>
+  );
+}
+```
+
+- [ ] **Step 5: Verify the gate is green**
+
+Run: `deno task check && deno test -A islands/shopping-lists.test.tsx`
+Expected: clean; `shopping-lists.test.tsx` still PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add islands/shopping-lists.tsx
+git commit -m "feat(shopping): add lists refresh and wire pull-to-refresh"
+```
+
+---
+
+### Task 6: Full-suite gate + live verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the whole gate**
+
+Run: `deno task check && deno test -A && deno task build`
+Expected: all green.
+
+- [ ] **Step 2: Live-verify in the browser preview (mobile viewport)**
+
+Start the dev server (`deno task dev`) and open the preview at a mobile size (e.g. 375×812). On **each** of `/shopping`, `/shopping/<id>`, and `/shopping/catalogue`:
+
+- Scroll to the top, drag down a little (below threshold) and release → puck peeks in, then springs back; content unchanged; no refresh.
+- Drag down past ~72px damped and release → puck settles and spins, content re-pulls, puck shows a check, then retracts.
+- With a sheet/overlay open (new-list sheet, add-items overlay, catalogue edit/add sheet) → pulling does nothing.
+- Mid-scroll (not at the top) → pulling does not trigger; the page scrolls normally.
+- Force an error (temporarily make the page's refresh reject, or go offline) → puck retracts and the Snackbar shows "Couldn't refresh — try again". Revert any temporary change.
+- Confirm on Android Chrome that the browser's own pull-to-refresh does not also fire.
+
+- [ ] **Step 3: Capture proof**
+
+Take a screenshot of the spinning indicator (or the success check) on the list-detail page to attach to the PR.
+
+- [ ] **Step 4: Finish the branch**
+
+Use the `superpowers:finishing-a-development-branch` skill to open the PR against `main`, referencing issue #34.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Reusable component → Tasks 1 (hook) + 2 (component). ✓
+- Flexible per-page refresh via `onRefresh` → Tasks 3/4/5. ✓
+- Loading/success/error feedback → Task 2 indicator states + internal Snackbar; Task 1 state machine. ✓
+- Works with existing scroll model / layouts → overlay (no content transform) so fixed FABs/sheets are safe; verified live in Task 6. ✓
+- Unit-testable gesture → Task 1 tests. ✓
+- Integrate on all shopping data pages, skip category-reorder → Tasks 3/4/5; category-reorder untouched. ✓
+- `overscroll-behavior-y: contain`, spinner CSS → Task 2 Step 1. ✓
+- Lists-page count recomputation → Task 5 note + code. ✓
+- Non-passive `touchmove` for `preventDefault` → Task 2 component (`{ passive: false }`). ✓
+- Accessibility `aria-live` status → Task 2 component + test. ✓
+- Docs (usage) → JSDoc on the component (Task 2). ✓
+
+**2. Placeholder scan:** No TBD/TODO; every code step contains complete code; commands have expected output. ✓
+
+**3. Type consistency:** `PullStatus`, `PullToRefreshController`, and method names (`begin`/`move`/`end`/`cancel`, `status`/`pull`) are identical across Task 1 (definition), its tests, and Task 2 (consumption). `PullToRefreshProps` (`onRefresh`/`disabled`/`class`/`children`) matches usage in Tasks 3/4/5. `useCatalogue().refresh` signature matches its test and island usage. ✓

--- a/docs/superpowers/specs/2026-07-23-pull-to-refresh-design.md
+++ b/docs/superpowers/specs/2026-07-23-pull-to-refresh-design.md
@@ -1,0 +1,269 @@
+# Pull-to-Refresh Pattern — Design
+
+**Date:** 2026-07-23
+**Status:** Draft (awaiting review)
+**Issue:** [#34](https://github.com/FredericGryspeerdt/happie-fresh/issues/34) — Add pull-to-refresh pattern
+**Module:** Platform primitive (MD3) → first consumed by the Shopping module
+
+---
+
+## 1. Problem & context
+
+Happie is a mobile-first PWA where data is shared across a household. A user
+looking at a shopping list on their phone has no obvious way to pull in changes a
+partner just made from another device short of navigating away and back. The
+platform-standard gesture for "give me the latest" on mobile is **pull-to-
+refresh** — drag down from the top of the content, release, watch it reload.
+
+We want this as a **reusable platform primitive**, not a shopping-specific hack.
+Per the product vision, the shopping list is only the first module; anything
+built here should be a cohesive building block future modules (meal planning,
+todos, dashboards) can drop in without re-inventing the gesture, the motion, or
+the feedback states.
+
+## 2. Goals / non-goals
+
+**Goals**
+- A reusable, MD3-consistent pull-to-refresh primitive integrable on any page.
+- Each page defines **its own** refresh behaviour via an `onRefresh` callback.
+- Clear visual feedback across the full lifecycle: pulling → armed → refreshing →
+  success / error.
+- Works with the existing scroll model (the `<body>` scrolls) and page layouts.
+- Unit-testable gesture logic, following the repo's hook-test conventions.
+
+**Non-goals (v1)**
+- Keyboard or programmatic refresh trigger (the gesture is touch-only; it
+  *augments* the existing navigate-to-reload behaviour, it does not replace it).
+- Mouse-drag / desktop support (desktop users reload via the browser; PTR is a
+  mobile idiom).
+- Integration on the **category-reorder** page (drag-to-reorder would fight the
+  pull gesture) or the **Home / Menu / Todos** placeholders (`ComingSoon`, no
+  data to refresh).
+- Any data-model, API, or route change. No new endpoints.
+- Infinite scroll / pull-up-to-load-more (a different pattern).
+
+## 3. Product alignment
+
+Refreshing shared data mid-task is a core "on the go" moment: check off items
+while shopping, then pull to see what someone added at home. Building it as a
+platform primitive (`components/md3/`) rather than inside the shopping islands
+keeps the codebase aligned with "new features should feel like cohesive modules
+within a broader household platform." The warm, approachable tone is preserved by
+friendly copy ("Couldn't refresh — try again") and playful-but-calm MD3 motion.
+
+## 4. UX design
+
+### 4.1 The gesture
+
+Touch only. Starting from the **top** of the page (`window.scrollY <= 0`), a
+**downward** drag reveals a circular indicator that follows the finger with
+**resistance** (damped travel, so the content feels elastic, not 1:1). Once the
+pull passes a **threshold** (~72px of damped travel) the indicator becomes
+**armed** (a subtle "let go now" cue). Releasing:
+
+- **armed** (`pull ≥ threshold`) → enters **refreshing**: the content settles at
+  a small resting offset (~64px), the indicator spins, and `onRefresh()` runs.
+- **not armed** (`pull < threshold`) → springs back to rest, no refresh.
+
+A drag that is predominantly **horizontal**, or that did **not** start at the top,
+is ignored — the browser scrolls / swipes normally.
+
+### 4.2 The indicator (MD3-consistent)
+
+A circular "puck": `bg-surface-c`, fully rounded (`--md-shape-full`),
+`md-elevation-3`, centred horizontally, that **descends** with the pull. Inside:
+
+- **pulling** — a progress ring/arrow rotates in proportion to pull distance
+  (visual "loading up" of intent). Opacity/scale ramps in from the top edge.
+- **armed** — the ring completes / arrow flips as a "release" affordance.
+- **refreshing** — an indeterminate spin (`text-primary`).
+- **success** — morphs to a `check` icon (`text-primary`) held briefly (~500ms),
+  then the whole indicator retracts up and out.
+- **error** — retracts immediately; the error is surfaced via Snackbar (§4.3).
+
+Motion uses the existing curves (`--md-emphasized`, `--md-spring` for the settle).
+The content translates via `transform: translateY(pull)` so nothing reflows.
+
+### 4.3 Feedback (loading / success / error)
+
+- **Loading:** the spinning indicator is the loading state.
+- **Success:** the brief check in the indicator, then content updates in place.
+  Quiet by design — no Snackbar on success.
+- **Error:** `onRefresh()` rejecting (or throwing) retracts the indicator and
+  shows the **MD3 Snackbar** with "Couldn't refresh — try again." The Snackbar is
+  rendered **internally** by the `PullToRefresh` wrapper, so consuming pages need
+  no extra wiring.
+
+### 4.4 Accessibility
+
+The gesture is inherently touch/pointer-based and not keyboard-operable — this is
+acceptable because it augments (never replaces) refresh-on-navigation. For screen
+readers, the indicator exposes an `aria-live="polite"` visually-hidden status that
+announces "Refreshing…" and "Refreshed" / "Couldn't refresh". The decorative puck
+graphics are `aria-hidden`.
+
+## 5. Architecture
+
+Chosen approach: **hook (logic) + presentational wrapper (DOM + visuals)**. This
+matches the repo's strong hook culture (`useShoppingList`, `useCatalogue`,
+`createDebouncedMergeScheduler`), keeps each page in control of *its* refresh and
+*when* the gesture is active, and makes the state machine unit-testable without a
+DOM — the test suite renders islands via `preact-render-to-string` and has **no**
+DOM event simulation, so gesture logic must be drivable by plain function calls.
+
+Two alternatives were rejected: a single self-contained component (conflates
+gesture + presentation, not DOM-free testable) and a global PTR in `AppChrome`
+driven by a per-page `onRefresh` signal (implicit global coupling; per-page
+disabling for open sheets / drag-reorder gets awkward — over-engineered for now).
+
+### 5.1 Hook — `hooks/usePullToRefresh.ts`
+
+The brain. Signal-based state machine, **no `window`/DOM access** (the component
+feeds it `atTop`). Modelled after `createDebouncedMergeScheduler` (a factory
+holding internal signals + timers).
+
+**Signature (shape, to be finalised in the plan):**
+
+```ts
+type PullStatus =
+  | "idle"
+  | "pulling"
+  | "armed"
+  | "refreshing"
+  | "success"
+  | "error";
+
+function usePullToRefresh(opts: {
+  onRefresh: () => Promise<unknown>;
+  threshold?: number;   // default 72 (px of damped travel to arm)
+  resistance?: number;  // default 0.5 (damping factor)
+  disabled?: boolean;
+}): {
+  status: Signal<PullStatus>;
+  pull: Signal<number>;       // current damped offset in px
+  begin(startY: number): void;
+  move(currentY: number, atTop: boolean): void;
+  end(): void;
+};
+```
+
+- `begin` records the drag origin.
+- `move(currentY, atTop)` computes damped `pull` from the delta; if the drag left
+  the top or reverses, it disengages. Transitions `pulling ↔ armed` around the
+  threshold.
+- `end` decides refresh vs spring-back. On refresh: `status = "refreshing"`, await
+  `onRefresh()`, then `"success"` (hold ~500ms via timer) → `"idle"`, or
+  `"error"` → `"idle"`. Self-ignores re-entrancy while `refreshing`.
+- `disabled` (or an in-flight refresh) makes `begin`/`move` no-ops.
+
+Timers (success hold, retract) use `setTimeout` so tests drive them with
+`FakeTime`, matching `useShoppingList.test.ts`.
+
+### 5.2 Component — `components/md3/PullToRefresh.tsx`
+
+The shell. A plain Preact component (used **inside** already-hydrated islands, so
+it needs no island of its own).
+
+**Props:** `{ onRefresh: () => Promise<unknown>; disabled?: boolean; children }`.
+
+Responsibilities:
+- Uses `usePullToRefresh({ onRefresh, disabled })`.
+- Attaches **touch** listeners on the wrapper element: `touchstart` (record
+  `startY`), `touchmove` (**non-passive**, so it can `preventDefault` the native
+  scroll / browser PTR while engaged), `touchend`/`touchcancel`. Computes
+  `atTop = window.scrollY <= 0` and forwards to the hook.
+- Applies `transform: translateY(pull)` to the content region and positions the
+  indicator puck above it.
+- Renders the indicator (per §4.2), the `aria-live` status, and an internal
+  `Snackbar` shown on `status === "error"`.
+
+### 5.3 Global CSS — `assets/styles.css`
+
+Add `overscroll-behavior-y: contain` to `body` as defense-in-depth against the
+browser's own pull-to-refresh (Chrome/Android) even where a `touchmove`
+`preventDefault` is missed. Harmless on desktop; improves PWA feel generally.
+
+### 5.4 Integration
+
+| Page | Island | `onRefresh` source | `disabled` when |
+| --- | --- | --- | --- |
+| `/shopping` (lists) | `islands/shopping-lists.tsx` | **new** local `refresh()` | new-list sheet open |
+| `/shopping/[id]` (detail) | `islands/items.tsx` | existing `useShoppingList().refresh` | add-items overlay open |
+| `/shopping/catalogue` | `islands/catalogue.tsx` | **new** `useCatalogue().refresh` | any editing sheet open |
+
+**Lists page refresh (count recomputation).** The `/shopping` page renders lists
+**with counts** (`total` / `done`), but `api.shoppingLists.getAll()` returns bare
+`ShoppingListInterface[]`. So the new local `refresh()` mirrors the server
+handler: fetch lists, then for each list fetch its items
+(`api.shoppingList.getItems`) to recompute `total` / `done`, and replace the
+`lists` signal. Household lists are few, so the N+1 fetch is an acceptable
+tradeoff for a smooth in-place update (vs a jarring full-page reload).
+
+**Catalogue refresh.** Add `refresh()` to `useCatalogue` that re-pulls
+`api.items.getAll()` + `api.categories.getAll()` in parallel and replaces the
+`items` / `categories` signals (mirroring `useShoppingList.refresh`, wrapped in
+`pendingCount`).
+
+## 6. File plan (for the implementation plan to expand)
+
+- **Create:** `hooks/usePullToRefresh.ts` (gesture state machine) + export from
+  `hooks/index.ts`.
+- **Create:** `components/md3/PullToRefresh.tsx` (wrapper + indicator + error
+  Snackbar), with usage JSDoc.
+- **Modify:** `assets/styles.css` (`overscroll-behavior-y: contain` on body;
+  any indicator keyframes if not expressible inline).
+- **Modify:** `hooks/useCatalogue.ts` (add `refresh`).
+- **Modify:** `islands/items.tsx` (wrap content; `disabled` = add overlay open).
+- **Modify:** `islands/shopping-lists.tsx` (add local `refresh` with count
+  recompute; wrap content; `disabled` = new-list sheet open).
+- **Modify:** `islands/catalogue.tsx` (wrap content; `disabled` = editing open).
+- **Reuse (no change):** `components/md3/Snackbar.tsx`, `components/md3/Icon.tsx`,
+  `services/api.ts`.
+- **Tests:** `hooks/usePullToRefresh.test.ts` (new),
+  `components/md3/PullToRefresh.test.tsx` (new); light additions to affected
+  island tests if needed.
+
+## 7. Testing
+
+- **Hook unit tests** (`hooks/usePullToRefresh.test.ts`, matching
+  `useShoppingList.test.ts` style — direct calls, `stub`, `FakeTime`):
+  - drag below threshold → `pulling`, `end` springs back to `idle`, `onRefresh`
+    **not** called;
+  - drag past threshold → `armed`, `end` → `refreshing` → (resolve) `success` →
+    `idle`, `onRefresh` called once;
+  - `onRefresh` rejects → `error` → `idle`;
+  - `move` with `atTop=false` (scrolled) or a horizontal-dominant delta → no
+    engagement;
+  - `disabled` / mid-refresh re-entrancy → `begin`/`move` are no-ops;
+  - resistance: `pull` is a damped fraction of raw delta.
+- **Component SSR test** (`components/md3/PullToRefresh.test.tsx`,
+  `preact-render-to-string`): renders `children` and the idle indicator markup;
+  no error Snackbar in the idle tree.
+- **Gates:** `deno task check`, `deno test`, `deno task build` all green.
+- **Live verification** (mobile viewport, via the browser preview): on each of the
+  three pages — pull below threshold springs back; pull past threshold spins and
+  updates content; a forced `onRefresh` rejection surfaces the error Snackbar;
+  the gesture does **not** fire mid-scroll or when the relevant sheet/overlay is
+  open.
+
+## 8. Rollout
+
+Feature branch `feature/issue-34-611333`. Implementation proceeds via the
+writing-plans → subagent-driven-development flow after this spec is approved.
+The primitive lands first (hook + component + CSS + tests), then the three page
+integrations, each independently verifiable.
+
+## 9. Risks & open points
+
+- **Native browser PTR conflict.** Non-standalone mobile browsers have their own
+  pull-to-refresh. Mitigation: `overscroll-behavior-y: contain` + `preventDefault`
+  on an engaged `touchmove`. To confirm live on Android Chrome during verification.
+- **`touchmove` passivity.** Preventing native scroll requires a **non-passive**
+  listener; must attach via `addEventListener(..., { passive: false })` (JSX
+  `onTouchMove` is passive by default in some engines). Flagged for the plan.
+- **Lists-page N+1 fetch.** Acceptable for the small number of household lists; if
+  lists ever grow large, add a counts-included list endpoint (future, out of
+  scope).
+- **iOS rubber-band.** iOS Safari overscroll can still bounce; the resistance +
+  transform approach keeps the indicator sensible, but exact feel is validated
+  live.

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from "./useShoppingList.ts";
 export * from "./useSearchBox.ts";
 export * from "./useSearchInput.ts";
+export * from "./usePullToRefresh.ts";

--- a/hooks/useCatalogue.test.ts
+++ b/hooks/useCatalogue.test.ts
@@ -159,3 +159,27 @@ Deno.test("pendingCount — returns to 0 after an operation", async () => {
   await hook.addItem("Cheese");
   assertEquals(hook.pendingCount.value, 0);
 });
+
+Deno.test("refresh — re-pulls items and categories from the API", async () => {
+  const hook = useCatalogue([item("i1", "Butter", "d")], [cat("d", "Dairy")]);
+
+  const itemsStub = stub(
+    api.items,
+    "getAll",
+    () => Promise.resolve([item("i2", "Milk", "d"), item("i3", "Bread", "b")]),
+  );
+  const catsStub = stub(
+    api.categories,
+    "getAll",
+    () => Promise.resolve([cat("d", "Dairy"), cat("b", "Bakery")]),
+  );
+  try {
+    await hook.refresh();
+  } finally {
+    itemsStub.restore();
+    catsStub.restore();
+  }
+
+  assertEquals(hook.items.value.map((i) => i.name), ["Milk", "Bread"]);
+  assertEquals(hook.categories.value.map((c) => c.label), ["Dairy", "Bakery"]);
+});

--- a/hooks/useCatalogue.ts
+++ b/hooks/useCatalogue.ts
@@ -137,10 +137,25 @@ export function useCatalogue(
     }
   };
 
+  const refresh = async (): Promise<void> => {
+    pendingCount.value++;
+    try {
+      const [newItems, newCategories] = await Promise.all([
+        api.items.getAll(),
+        api.categories.getAll(),
+      ]);
+      items.value = newItems;
+      categories.value = newCategories;
+    } finally {
+      pendingCount.value--;
+    }
+  };
+
   return {
     items,
     categories,
     pendingCount,
+    refresh,
     sortedCategories,
     itemNames,
     hasUncategorized,

--- a/hooks/usePullToRefresh.test.ts
+++ b/hooks/usePullToRefresh.test.ts
@@ -1,0 +1,130 @@
+import { assert, assertEquals } from "jsr:@std/assert@^1.0.19";
+import { FakeTime } from "jsr:@std/testing@^1.0.18/time";
+import { usePullToRefresh } from "@/hooks/usePullToRefresh.ts";
+
+Deno.test("usePullToRefresh — pull below threshold springs back, no refresh", () => {
+  let calls = 0;
+  const c = usePullToRefresh({
+    threshold: 72,
+    resistance: 0.5,
+    onRefresh: () => {
+      calls++;
+      return Promise.resolve();
+    },
+  });
+  c.begin(100);
+  const engaged = c.move(220, true); // raw 120 * 0.5 = 60 < 72
+  assert(engaged);
+  assertEquals(c.status.value, "pulling");
+  assertEquals(c.pull.value, 60);
+  c.end();
+  assertEquals(c.status.value, "idle");
+  assertEquals(c.pull.value, 0);
+  assertEquals(calls, 0);
+});
+
+Deno.test("usePullToRefresh — past threshold arms, then refreshes and succeeds", async () => {
+  const time = new FakeTime();
+  try {
+    let calls = 0;
+    // deno-lint-ignore react-rules-of-hooks
+    const c = usePullToRefresh({
+      threshold: 72,
+      resistance: 0.5,
+      onRefresh: () => {
+        calls++;
+        return Promise.resolve();
+      },
+    });
+    c.begin(0);
+    c.move(200, true); // raw 200 * 0.5 = 100 >= 72 → armed
+    assertEquals(c.status.value, "armed");
+    c.end();
+    assertEquals(c.status.value, "refreshing");
+    assertEquals(calls, 1);
+    await time.tickAsync(0); // flush onRefresh microtasks
+    assertEquals(c.status.value, "success");
+    await time.tickAsync(600);
+    assertEquals(c.status.value, "idle");
+    assertEquals(c.pull.value, 0);
+  } finally {
+    time.restore();
+  }
+});
+
+Deno.test("usePullToRefresh — rejection goes to error then idle and calls onError", async () => {
+  const time = new FakeTime();
+  try {
+    let errored: unknown = null;
+    // deno-lint-ignore react-rules-of-hooks
+    const c = usePullToRefresh({
+      threshold: 72,
+      onRefresh: () => Promise.reject(new Error("boom")),
+      onError: (e: unknown) => (errored = e),
+    });
+    c.begin(0);
+    c.move(300, true);
+    c.end();
+    await time.tickAsync(0);
+    assertEquals(c.status.value, "error");
+    assert(errored instanceof Error);
+    await time.tickAsync(400);
+    assertEquals(c.status.value, "idle");
+  } finally {
+    time.restore();
+  }
+});
+
+Deno.test("usePullToRefresh — does not engage when not scrolled to top", () => {
+  let calls = 0;
+  const c = usePullToRefresh({
+    onRefresh: () => {
+      calls++;
+      return Promise.resolve();
+    },
+  });
+  c.begin(0);
+  const engaged = c.move(200, false); // atTop = false
+  assertEquals(engaged, false);
+  assertEquals(c.status.value, "idle");
+  c.end();
+  assertEquals(calls, 0);
+});
+
+Deno.test("usePullToRefresh — ignores new gestures while refreshing", async () => {
+  const time = new FakeTime();
+  try {
+    let calls = 0;
+    // deno-lint-ignore react-rules-of-hooks
+    const c = usePullToRefresh({
+      threshold: 72,
+      onRefresh: () => {
+        calls++;
+        return Promise.resolve();
+      },
+    });
+    c.begin(0);
+    c.move(300, true);
+    c.end();
+    assertEquals(c.status.value, "refreshing");
+    c.begin(0);
+    assertEquals(c.move(300, true), false); // no-op mid-refresh
+    c.end();
+    await time.tickAsync(0);
+    assertEquals(calls, 1);
+    await time.tickAsync(600);
+  } finally {
+    time.restore();
+  }
+});
+
+Deno.test("usePullToRefresh — resistance damps pull distance", () => {
+  const c = usePullToRefresh({
+    threshold: 72,
+    resistance: 0.4,
+    onRefresh: () => Promise.resolve(),
+  });
+  c.begin(0);
+  c.move(100, true); // 100 * 0.4 = 40
+  assertEquals(c.pull.value, 40);
+});

--- a/hooks/usePullToRefresh.test.ts
+++ b/hooks/usePullToRefresh.test.ts
@@ -128,3 +128,64 @@ Deno.test("usePullToRefresh — resistance damps pull distance", () => {
   c.move(100, true); // 100 * 0.4 = 40
   assertEquals(c.pull.value, 40);
 });
+
+Deno.test("usePullToRefresh — synchronous throw in onRefresh goes to error, not stuck refreshing", async () => {
+  const time = new FakeTime();
+  try {
+    let errored: unknown = null;
+    // deno-lint-ignore react-rules-of-hooks
+    const c = usePullToRefresh({
+      threshold: 72,
+      onRefresh: () => {
+        throw new Error("sync boom");
+      },
+      onError: (e) => (errored = e),
+    });
+    c.begin(0);
+    c.move(300, true);
+    c.end();
+    assertEquals(c.status.value, "error"); // caught synchronously, not stuck at "refreshing"
+    assert(errored instanceof Error);
+    await time.tickAsync(400);
+    assertEquals(c.status.value, "idle");
+  } finally {
+    time.restore();
+  }
+});
+
+Deno.test("usePullToRefresh — cancel() aborts an in-progress pull", () => {
+  const c = usePullToRefresh({
+    threshold: 72,
+    onRefresh: () => Promise.resolve(),
+  });
+  c.begin(0);
+  c.move(80, true); // 80 * 0.5 = 40 → pulling
+  assertEquals(c.status.value, "pulling");
+  c.cancel();
+  assertEquals(c.status.value, "idle");
+  assertEquals(c.pull.value, 0);
+});
+
+Deno.test("usePullToRefresh — ignores new gestures during the error linger", async () => {
+  const time = new FakeTime();
+  try {
+    // deno-lint-ignore react-rules-of-hooks
+    const c = usePullToRefresh({
+      threshold: 72,
+      onRefresh: () => Promise.reject(new Error("boom")),
+    });
+    c.begin(0);
+    c.move(300, true);
+    c.end();
+    await time.tickAsync(0);
+    assertEquals(c.status.value, "error");
+    // A new gesture during the error window is ignored (no clobber).
+    c.begin(0);
+    assertEquals(c.move(300, true), false);
+    assertEquals(c.status.value, "error");
+    await time.tickAsync(400);
+    assertEquals(c.status.value, "idle");
+  } finally {
+    time.restore();
+  }
+});

--- a/hooks/usePullToRefresh.ts
+++ b/hooks/usePullToRefresh.ts
@@ -56,7 +56,8 @@ export function usePullToRefresh(
   let resetTimer: ReturnType<typeof setTimeout> | null = null;
 
   const busy = () =>
-    status.value === "refreshing" || status.value === "success";
+    status.value === "refreshing" || status.value === "success" ||
+    status.value === "error";
 
   const scheduleIdle = (ms: number) => {
     if (resetTimer) clearTimeout(resetTimer);
@@ -64,6 +65,13 @@ export function usePullToRefresh(
       status.value = "idle";
       pull.value = 0;
     }, ms);
+  };
+
+  const fail = (error: unknown) => {
+    status.value = "error";
+    pull.value = 0;
+    onError?.(error);
+    scheduleIdle(ERROR_MS);
   };
 
   const begin = (y: number) => {
@@ -101,20 +109,18 @@ export function usePullToRefresh(
     }
     status.value = "refreshing";
     pull.value = threshold;
-    const result = onRefresh();
-    Promise.resolve(result).then(
-      () => {
-        status.value = "success";
-        onSuccess?.();
-        scheduleIdle(SUCCESS_MS);
-      },
-      (error) => {
-        status.value = "error";
-        pull.value = 0;
-        onError?.(error);
-        scheduleIdle(ERROR_MS);
-      },
-    );
+    let result: Promise<unknown> | unknown;
+    try {
+      result = onRefresh();
+    } catch (error) {
+      fail(error);
+      return;
+    }
+    Promise.resolve(result).then(() => {
+      status.value = "success";
+      onSuccess?.();
+      scheduleIdle(SUCCESS_MS);
+    }, fail);
   };
 
   const cancel = () => {

--- a/hooks/usePullToRefresh.ts
+++ b/hooks/usePullToRefresh.ts
@@ -1,0 +1,128 @@
+import { type Signal, signal } from "@preact/signals";
+
+export type PullStatus =
+  | "idle"
+  | "pulling"
+  | "armed"
+  | "refreshing"
+  | "success"
+  | "error";
+
+export interface UsePullToRefreshOptions {
+  /** The page's refresh action. May return a promise; rejection → error state. */
+  onRefresh: () => Promise<unknown> | unknown;
+  /** Damped pull distance (px) required to arm a refresh. Default 72. */
+  threshold?: number;
+  /** Fraction of raw finger travel applied to the pull. Default 0.5. */
+  resistance?: number;
+  onError?: (error: unknown) => void;
+  onSuccess?: () => void;
+}
+
+export interface PullToRefreshController {
+  status: Signal<PullStatus>;
+  pull: Signal<number>;
+  /** Record the touch origin. */
+  begin(startY: number): void;
+  /** Update from a move; returns true when engaged (caller should preventDefault). */
+  move(currentY: number, atTop: boolean): boolean;
+  /** Release: refresh if armed, else spring back. */
+  end(): void;
+  /** Abort an in-progress (non-refreshing) pull. */
+  cancel(): void;
+}
+
+const ENGAGE_SLOP = 6; // px of downward travel before we hijack the gesture
+const SUCCESS_MS = 600; // how long the success check lingers
+const ERROR_MS = 400; // how long the error state lingers before reset
+
+/**
+ * Gesture state machine for pull-to-refresh. DOM-free and signal-based so it can
+ * be unit-tested by calling its methods directly (see usePullToRefresh.test.ts).
+ * Created once per consumer via `useMemo(() => usePullToRefresh(...), [])`.
+ */
+export function usePullToRefresh(
+  opts: UsePullToRefreshOptions,
+): PullToRefreshController {
+  const { onRefresh, threshold = 72, resistance = 0.5, onError, onSuccess } =
+    opts;
+
+  const status = signal<PullStatus>("idle");
+  const pull = signal(0);
+  const maxPull = threshold + 48;
+
+  let startY = 0;
+  let engaged = false;
+  let resetTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const busy = () =>
+    status.value === "refreshing" || status.value === "success";
+
+  const scheduleIdle = (ms: number) => {
+    if (resetTimer) clearTimeout(resetTimer);
+    resetTimer = setTimeout(() => {
+      status.value = "idle";
+      pull.value = 0;
+    }, ms);
+  };
+
+  const begin = (y: number) => {
+    if (busy()) return;
+    startY = y;
+    engaged = false;
+  };
+
+  const move = (currentY: number, atTop: boolean): boolean => {
+    if (busy()) return false;
+    if (!engaged) {
+      if (atTop && currentY - startY > ENGAGE_SLOP) engaged = true;
+      else return false;
+    }
+    const raw = currentY - startY;
+    if (raw <= 0) {
+      pull.value = 0;
+      status.value = "idle";
+      engaged = false;
+      return false;
+    }
+    const damped = Math.min(raw * resistance, maxPull);
+    pull.value = damped;
+    status.value = damped >= threshold ? "armed" : "pulling";
+    return true;
+  };
+
+  const end = () => {
+    if (!engaged) return;
+    engaged = false;
+    if (status.value !== "armed") {
+      pull.value = 0;
+      status.value = "idle";
+      return;
+    }
+    status.value = "refreshing";
+    pull.value = threshold;
+    const result = onRefresh();
+    Promise.resolve(result).then(
+      () => {
+        status.value = "success";
+        onSuccess?.();
+        scheduleIdle(SUCCESS_MS);
+      },
+      (error) => {
+        status.value = "error";
+        pull.value = 0;
+        onError?.(error);
+        scheduleIdle(ERROR_MS);
+      },
+    );
+  };
+
+  const cancel = () => {
+    if (busy()) return;
+    pull.value = 0;
+    status.value = "idle";
+    engaged = false;
+  };
+
+  return { status, pull, begin, move, end, cancel };
+}

--- a/islands/catalogue.tsx
+++ b/islands/catalogue.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo } from "preact/hooks";
 import { useSignal } from "@preact/signals";
 import type { CategoryInterface, ItemInterface } from "@/models/index.ts";
 import { useCatalogue } from "@/hooks/useCatalogue.ts";
+import { PullToRefresh } from "@/components/md3/PullToRefresh.tsx";
 import { Segmented } from "@/components/md3/Segmented.tsx";
 import { Chip } from "@/components/md3/Chip.tsx";
 import { ListItem } from "@/components/md3/ListItem.tsx";
@@ -45,6 +46,7 @@ export default function Catalogue(
     createCategory,
     renameCategory,
     deleteCategory,
+    refresh,
   } = useMemo(
     () => useCatalogue(initialItems, initialCategories),
     [], // intentionally empty — signals are initialized once from SSR data
@@ -114,7 +116,7 @@ export default function Catalogue(
   );
 
   return (
-    <>
+    <PullToRefresh onRefresh={refresh} disabled={anySheetOpen}>
       {/* Lists / Catalogue selector */}
       <div class="px-4 pt-4 pb-2">
         <Segmented
@@ -352,7 +354,7 @@ export default function Catalogue(
           ]}
         />
       )}
-    </>
+    </PullToRefresh>
   );
 }
 

--- a/islands/items.tsx
+++ b/islands/items.tsx
@@ -23,6 +23,7 @@ import { RoundCheck } from "@/components/md3/RoundCheck.tsx";
 import { Snackbar } from "@/components/md3/Snackbar.tsx";
 import Fab from "@/islands/shell/Fab.tsx";
 import AddItems from "@/islands/add-items.tsx";
+import { PullToRefresh } from "@/components/md3/PullToRefresh.tsx";
 
 interface ItemsProps {
   listId: string;
@@ -184,7 +185,11 @@ export default function Items(
 
   // ─────────────────────────────────────────────────────────────────────────
   return (
-    <div class="flex flex-col gap-4 pb-24">
+    <PullToRefresh
+      onRefresh={refresh}
+      disabled={addOpen.value || mgmtOpen.value || editingId.value !== null}
+      class="flex flex-col gap-4 pb-24"
+    >
       {/* Mode toggle (Plan / Shop) — list options live in the top app bar */}
       <Segmented
         options={[
@@ -711,6 +716,6 @@ export default function Items(
 
       {/* ══════════════════════ Snackbar ══════════════════════ */}
       <Snackbar data={snackData.value} />
-    </div>
+    </PullToRefresh>
   );
 }

--- a/islands/shopping-lists.tsx
+++ b/islands/shopping-lists.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/md3/Button.tsx";
 import { Icon } from "@/components/md3/Icon.tsx";
 import { Segmented } from "@/components/md3/Segmented.tsx";
 import Fab from "@/islands/shell/Fab.tsx";
+import { PullToRefresh } from "@/components/md3/PullToRefresh.tsx";
 
 type ShoppingListWithCounts = ShoppingListInterface & {
   total: number;
@@ -62,8 +63,23 @@ export default function ShoppingLists({ initialLists }: ShoppingListsProps) {
     }
   };
 
+  const refresh = async () => {
+    const fresh = await api.shoppingLists.getAll();
+    const withCounts = await Promise.all(
+      fresh.map(async (l) => {
+        const items = await api.shoppingList.getItems(l.id);
+        return {
+          ...l,
+          total: items.length,
+          done: items.filter((i) => i.checked).length,
+        };
+      }),
+    );
+    lists.value = withCounts;
+  };
+
   return (
-    <>
+    <PullToRefresh onRefresh={refresh} disabled={newOpen.value}>
       {/* Lists / Catalogue selector */}
       <div class="px-4 pt-4 pb-2">
         <Segmented
@@ -188,6 +204,6 @@ export default function ShoppingLists({ initialLists }: ShoppingListsProps) {
           </Button>
         </div>
       </Sheet>
-    </>
+    </PullToRefresh>
   );
 }


### PR DESCRIPTION
## What & why

Closes #34. Adds a **reusable pull-to-refresh pattern** as a platform primitive (not shopping-specific) and wires it into the three shopping data pages. Each page defines its own refresh behaviour via an `onRefresh` callback.

## Design

- **`hooks/usePullToRefresh.ts`** — a DOM-free, `signal()`-based gesture state machine (`idle → pulling → armed → refreshing → success | error → idle`), following the repo's `useShoppingList`/`createDebouncedMergeScheduler` factory pattern so it's unit-testable by direct calls. Damped travel, ~72px arm threshold, re-entrancy guard, and both sync-throw and async-rejection routed to the error path.
- **`components/md3/PullToRefresh.tsx`** — presentational wrapper: touch-only listeners (non-passive `touchmove` so it can `preventDefault`), a Material-style **overlay** indicator puck, an `aria-live` status, and an internal error Snackbar. The indicator overlays static content (content is **not** transformed), so the wrapper safely encloses fixed FABs/sheets/overlays.
- **CSS** — `pull-spin` keyframe + `overscroll-behavior-y: contain` on `body` (defense against native browser PTR).

Feedback: spinner while loading → brief check on success → retract; on error, retract + Snackbar "Couldn't refresh — try again".

> Note: the spec described content translation; during planning this was deliberately changed to the overlay approach so the wrapper can enclose fixed elements without breaking their containing block. Documented in the plan.

## Integration

| Page | Refresh behaviour | Gesture disabled when |
| --- | --- | --- |
| `/shopping` (lists) | new local `refresh()` — re-fetches lists and **recomputes `total`/`done` counts** per list (mirrors the server handler) | new-list sheet open |
| `/shopping/[id]` (detail) | existing `useShoppingList().refresh` | add-items overlay / management / item-editor sheet open |
| `/shopping/catalogue` | new `useCatalogue().refresh` (re-pulls items + categories) | any editing sheet open |

Category-reorder and the `ComingSoon` placeholders are intentionally excluded.

## Testing & verification

**Automated:**
- `deno task check` (fmt + lint + type-check): **green**
- `deno test -A`: **104 passing** — includes 9 tests exhaustively covering the gesture state machine (engage/threshold/resistance/success/error/sync-throw/re-entrancy/error-window) and an SSR test for the component.
- `deno task build`: **green**

**Browser (mobile viewport 375×812, seeded user, synthetic `TouchEvent`s):** verified on all three pages that a pull past threshold engages (calls `preventDefault`) and fires the correct per-page refetch:
- `/shopping` → `GET /api/shopping/lists` + per-list `.../items` (count recompute)
- `/shopping/[id]` → items + `catalogue` + `categories`
- `/shopping/catalogue` → `catalogue` + `categories`

Also confirmed: a **below-threshold** pull springs back with **no** refresh; the indicator + `aria-live` status are present and the puck returns to hidden after; the gesture is **inert while an overlay/sheet is open** (add-items overlay: no engage, no refetch); **no console errors**.

**Remaining (optional, physical device):** confirm on real Android Chrome that the browser's own pull-to-refresh doesn't also fire — synthetic events can't exercise the native gesture, though `overscroll-behavior-y: contain` is in place as the guard.

## Known minor (non-blocking)

- On the list-detail page, the page's existing Snackbar and PullToRefresh's internal Snackbar share coordinates; they'd only visibly overlap if a save-error and a refresh-error fired simultaneously (rare). Left as-is rather than adding opt-out API.

Spec: `docs/superpowers/specs/2026-07-23-pull-to-refresh-design.md` · Plan: `docs/superpowers/plans/2026-07-23-pull-to-refresh.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
