### PR TITLE
fix(shopping): keep keyboard primer until add-items search takes focus

### DIFF
--- a/islands/add-items.tsx
+++ b/islands/add-items.tsx
@@ -26,6 +26,10 @@ interface AddItemsProps {
   // navigating. Its presence is what switches the back control from a link to a
   // button.
   onClose?: () => void;
+  // Called when the search field first receives focus. The overlay host uses
+  // this to retire its keyboard primer once the focus hand-off is complete —
+  // see the primer comment in islands/items.tsx.
+  onSearchFocus?: () => void;
 }
 
 export default function AddItems(
@@ -37,6 +41,7 @@ export default function AddItems(
     categories: initialCategories,
     initialQuery,
     onClose,
+    onSearchFocus,
   }: AddItemsProps,
 ) {
   // Instantiate the signal()-based hook exactly once (see CLAUDE.md).
@@ -79,9 +84,19 @@ export default function AddItems(
   // the full category-picker card (which also shows outright when nothing matches).
   const createExpanded = useSignal(false);
 
-  // Autofocus the search field on mount for a quick type-to-search flow.
+  // Autofocus the search field on mount for a quick type-to-search flow. The
+  // overlay mounts a tick after the FAB tap, so the host holds the soft keyboard
+  // open with a primer input until we take focus here; once we have, tell it the
+  // hand-off is done so it can retire the primer (see the primer comment in
+  // islands/items.tsx). Guarded on focus actually landing so the primer is never
+  // retired while focus is still on <body> — which would close the keyboard.
   useEffect(() => {
-    const t = setTimeout(() => inputRef.current?.focus(), 80);
+    const t = setTimeout(() => {
+      const el = inputRef.current;
+      if (!el) return;
+      el.focus();
+      if (document.activeElement === el) onSearchFocus?.();
+    }, 80);
     return () => clearTimeout(t);
   }, []);
 

--- a/islands/items.tsx
+++ b/islands/items.tsx
@@ -80,14 +80,20 @@ export default function Items(
   // navigation loses the tap's user-activation, so the keyboard never appears.
   const addOpen = useSignal(false);
   const primerRef = useRef<HTMLInputElement>(null);
+  // Set once the overlay's search field has taken focus, i.e. the keyboard
+  // hand-off is done and the primer can safely leave the DOM (see the primer
+  // comment near the bottom of the render).
+  const handoff = useSignal(false);
 
   const openAdd = () => {
+    handoff.value = false;
     primerRef.current?.focus();
     addOpen.value = true;
   };
 
   const closeAdd = () => {
     addOpen.value = false;
+    handoff.value = false;
     // The overlay runs its own useShoppingList instance, so pull the list back in
     // to reflect anything added while it was open.
     refresh();
@@ -696,14 +702,18 @@ export default function Items(
 
       {
         /* Keyboard primer — focused inside the FAB tap (see openAdd) so mobile
-          browsers open the soft keyboard; focus then transfers to the overlay's
-          search field, which keeps it open. Mounted only while the overlay is
-          closed: once open it's dead weight, and leaving it in the DOM makes it a
-          second form field, so iOS adds a prev/next field navigator to the
-          keyboard accessory bar. Unmounting it leaves the search box as the sole
-          field, so the navigator disappears. */
+          browsers open the soft keyboard within the tap's user activation. The
+          overlay mounts asynchronously (signal re-render), so its search field
+          focuses ~80ms later; the primer bridges that gap. It MUST stay mounted
+          and focused until the hand-off: unmounting it the instant the overlay
+          opens drops focus to <body>, the keyboard dismisses, and the later
+          programmatic focus of the search field can't reopen it without a fresh
+          user gesture (this was the autofocus regression). So it lingers until
+          AddItems reports its search field took focus (handoff → true), then
+          unmounts — which also removes the second form field iOS uses to add a
+          prev/next navigator to the keyboard accessory bar. */
       }
-      {!addOpen.value && (
+      {(!addOpen.value || !handoff.value) && (
         <input
           ref={primerRef}
           type="text"
@@ -730,6 +740,7 @@ export default function Items(
             categories={categories.value}
             initialQuery=""
             onClose={closeAdd}
+            onSearchFocus={() => (handoff.value = true)}
           />
         </div>
       )}


### PR DESCRIPTION
## Problem

Regression: opening **Add items** from a shopping-list detail no longer autofocused the search field, and the mobile soft keyboard didn't open.

## Root cause

The add-items overlay opens *in-page*, so mobile browsers only open the soft keyboard during the FAB tap. The tap focuses an offscreen **primer** input (opening the keyboard under user-activation), and ~80ms later — once the overlay has mounted — focus transfers to the real search field, keeping the keyboard up.

Commit `68f4dc6` (drop iOS keyboard field navigator) changed the primer from *always-mounted* to `{!addOpen && …}`, so the primer **unmounted the instant the overlay opened**. Focus then dropped to `<body>` during the hand-off gap — a focus-timeline probe confirmed:

```
tap → INPUT[primer] → BODY (focus dropped) → INPUT[search]
```

On mobile that `BODY` window dismisses the keyboard, and the later cold `.focus()` can't reopen it without a fresh gesture.

## Fix

Keep the primer mounted until the search field has actually taken focus, then retire it — restoring the focus hand-off **while still keeping** the field-navigator fix from `68f4dc6`.

- `items.tsx`: new `handoff` signal; primer renders while `!addOpen || !handoff`; `AddItems` reports back via a new `onSearchFocus` callback; reset on open/close.
- `add-items.tsx`: the autofocus effect calls `onSearchFocus()` after focusing, guarded on `document.activeElement === el` so the primer is never retired while focus is still on `<body>`.

## Verification (browser, mobile viewport)

- Focus stays continuous: `INPUT[primer] → … → INPUT[search]`, never `BODY`.
- At rest: search focused, primer retired, only 1 form field → no iOS prev/next navigator.
- Close → reopen cycle works (primer returns, re-focuses, retires again).
- `deno task check` ✅ · `deno task test` ✅ (116 passed).

> Note: verified the focus-continuity mechanism the keyboard depends on; the actual soft keyboard popping up should get a final confirmation on a real device (headless browser can't emulate it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)