### PR TITLE
feat(menu): dish catalogue management (CRUD) — #39

### DIFF
--- a/database/dish-tag-group.repo.test.ts
+++ b/database/dish-tag-group.repo.test.ts
@@ -1,0 +1,67 @@
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import { DishTagGroupRepo } from "@/database/dish-tag-group.repo.ts";
+import { getKv } from "@/database/db.ts";
+
+Deno.env.set("KV_PATH", ":memory:");
+
+async function clearGroups() {
+  const kv = await getKv();
+  for await (const e of kv.list({ prefix: ["dish_tag_groups"] })) {
+    await kv.delete(e.key);
+  }
+}
+
+Deno.test({
+  name: "ensureDefaults — seeds the three default groups with values",
+  sanitizeResources: false,
+  async fn() {
+    await clearGroups();
+    await DishTagGroupRepo.ensureDefaults();
+    const groups = await DishTagGroupRepo.getAll();
+    assertEquals(groups.map((g) => g.label), ["Type", "Meal", "Side type"]);
+    assertEquals(groups[0].values.map((v) => v.label), [
+      "Vegetarian",
+      "Fish",
+      "Meat",
+    ]);
+    // every value has a non-empty id
+    for (const g of groups) {
+      for (const v of g.values) assertEquals(typeof v.id, "string");
+    }
+  },
+});
+
+Deno.test({
+  name: "ensureDefaults — is idempotent (second call adds nothing)",
+  sanitizeResources: false,
+  async fn() {
+    await clearGroups();
+    await DishTagGroupRepo.ensureDefaults();
+    await DishTagGroupRepo.ensureDefaults();
+    const groups = await DishTagGroupRepo.getAll();
+    assertEquals(groups.length, 3);
+  },
+});
+
+Deno.test({
+  name: "addValue — appends a value to a group and returns it",
+  sanitizeResources: false,
+  async fn() {
+    await clearGroups();
+    await DishTagGroupRepo.ensureDefaults();
+    const [type] = await DishTagGroupRepo.getAll();
+    const created = await DishTagGroupRepo.addValue(type.id, "Vegan");
+    assertEquals(created?.label, "Vegan");
+    const reloaded = await DishTagGroupRepo.getById(type.id);
+    assertEquals(reloaded?.values.at(-1)?.label, "Vegan");
+  },
+});
+
+Deno.test({
+  name: "addValue — returns null for a missing group",
+  sanitizeResources: false,
+  async fn() {
+    await clearGroups();
+    assertEquals(await DishTagGroupRepo.addValue("nope", "x"), null);
+  },
+});

--- a/database/dish-tag-group.repo.ts
+++ b/database/dish-tag-group.repo.ts
@@ -1,0 +1,69 @@
+import {
+  DishTagGroupInterface,
+  DishTagValueInterface,
+} from "@/models/index.ts";
+import { getKv } from "./db.ts";
+
+const DEFAULT_GROUPS: { label: string; values: string[] }[] = [
+  { label: "Type", values: ["Vegetarian", "Fish", "Meat"] },
+  { label: "Meal", values: ["Main dish", "Breakfast", "Lunch", "Side dish"] },
+  { label: "Side type", values: ["Rice", "Potatoes", "Pasta"] },
+];
+
+export class DishTagGroupRepo {
+  static async getAll(): Promise<DishTagGroupInterface[]> {
+    const kv = await getKv();
+    const entries = kv.list<DishTagGroupInterface>({
+      prefix: ["dish_tag_groups"],
+    });
+    const groups: DishTagGroupInterface[] = [];
+    for await (const entry of entries) groups.push(entry.value);
+    return groups.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+  }
+
+  static async getById(id: string): Promise<DishTagGroupInterface | null> {
+    const kv = await getKv();
+    const res = await kv.get<DishTagGroupInterface>(["dish_tag_groups", id]);
+    return res.value;
+  }
+
+  static async ensureDefaults(): Promise<void> {
+    const kv = await getKv();
+    // Seed only when the collection is empty.
+    for await (const _ of kv.list({ prefix: ["dish_tag_groups"] })) return;
+    let atomic = kv.atomic();
+    DEFAULT_GROUPS.forEach((g, i) => {
+      const group: DishTagGroupInterface = {
+        id: crypto.randomUUID(),
+        label: g.label,
+        order: i,
+        values: g.values.map((label) => ({
+          id: crypto.randomUUID(),
+          label,
+        })),
+      };
+      atomic = atomic.set(["dish_tag_groups", group.id], group);
+    });
+    const ok = await atomic.commit();
+    if (!ok) throw new Error("Failed to seed dish tag groups.");
+  }
+
+  static async addValue(
+    groupId: string,
+    label: string,
+  ): Promise<DishTagValueInterface | null> {
+    const kv = await getKv();
+    const group = await this.getById(groupId);
+    if (!group) return null;
+    const value: DishTagValueInterface = {
+      id: crypto.randomUUID(),
+      label,
+    };
+    const updated: DishTagGroupInterface = {
+      ...group,
+      values: [...group.values, value],
+    };
+    await kv.set(["dish_tag_groups", groupId], updated);
+    return value;
+  }
+}

--- a/database/dish.repo.test.ts
+++ b/database/dish.repo.test.ts
@@ -82,6 +82,6 @@ Deno.test({
     });
     await DishRepo.delete(d.id);
     assertEquals(await DishRepo.getById(d.id), null);
-    assertEquals(await DishRepo.readAll(), []);
+    assertEquals(await DishRepo.getAll(), []);
   },
 });

--- a/database/dish.repo.test.ts
+++ b/database/dish.repo.test.ts
@@ -1,0 +1,72 @@
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import { DishRepo } from "@/database/dish.repo.ts";
+import { getKv } from "@/database/db.ts";
+
+// Isolated in-memory KV for this test process (see shopping-list-item.repo.test.ts).
+Deno.env.set("KV_PATH", ":memory:");
+
+async function clearDishes() {
+  const kv = await getKv();
+  for await (const e of kv.list({ prefix: ["dishes"] })) await kv.delete(e.key);
+}
+
+Deno.test({
+  name: "create + getById — round-trips fields and assigns id + createdAt",
+  sanitizeResources: false,
+  async fn() {
+    await clearDishes();
+    const created = await DishRepo.create({
+      name: "Pasta Bolognese",
+      ingredientIds: ["i1", "i2"],
+      tagValueIds: ["meat", "main"],
+    });
+    assertEquals(typeof created.id, "string");
+    assertEquals(typeof created.createdAt, "string");
+    const fetched = await DishRepo.getById(created.id);
+    assertEquals(fetched?.name, "Pasta Bolognese");
+    assertEquals(fetched?.ingredientIds, ["i1", "i2"]);
+    assertEquals(fetched?.tagValueIds, ["meat", "main"]);
+  },
+});
+
+Deno.test({
+  name: "update — partial patch does not clobber omitted fields",
+  sanitizeResources: false,
+  async fn() {
+    await clearDishes();
+    const d = await DishRepo.create({
+      name: "Curry",
+      ingredientIds: ["i1"],
+      tagValueIds: ["veg"],
+    });
+    const updated = await DishRepo.update(d.id, { name: "Veggie Curry" });
+    assertEquals(updated?.name, "Veggie Curry");
+    assertEquals(updated?.ingredientIds, ["i1"]); // untouched
+    assertEquals(updated?.tagValueIds, ["veg"]); // untouched
+  },
+});
+
+Deno.test({
+  name: "update — returns null for a missing dish",
+  sanitizeResources: false,
+  async fn() {
+    await clearDishes();
+    assertEquals(await DishRepo.update("nope", { name: "x" }), null);
+  },
+});
+
+Deno.test({
+  name: "delete — removes the dish",
+  sanitizeResources: false,
+  async fn() {
+    await clearDishes();
+    const d = await DishRepo.create({
+      name: "Toast",
+      ingredientIds: [],
+      tagValueIds: [],
+    });
+    await DishRepo.delete(d.id);
+    assertEquals(await DishRepo.getById(d.id), null);
+    assertEquals(await DishRepo.readAll(), []);
+  },
+});

--- a/database/dish.repo.test.ts
+++ b/database/dish.repo.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals } from "jsr:@std/assert@^1.0.19";
 import { DishRepo } from "@/database/dish.repo.ts";
 import { getKv } from "@/database/db.ts";
+import type { CreateDishDto } from "@/models/index.ts";
 
 // Isolated in-memory KV for this test process (see shopping-list-item.repo.test.ts).
 Deno.env.set("KV_PATH", ":memory:");
@@ -26,6 +27,20 @@ Deno.test({
     assertEquals(fetched?.name, "Pasta Bolognese");
     assertEquals(fetched?.ingredientIds, ["i1", "i2"]);
     assertEquals(fetched?.tagValueIds, ["meat", "main"]);
+  },
+});
+
+Deno.test({
+  name: "create — defaults ingredientIds/tagValueIds to [] when omitted",
+  sanitizeResources: false,
+  async fn() {
+    await clearDishes();
+    const created = await DishRepo.create(
+      { name: "Bare" } as CreateDishDto,
+    );
+    const fetched = await DishRepo.getById(created.id);
+    assertEquals(fetched?.ingredientIds, []);
+    assertEquals(fetched?.tagValueIds, []);
   },
 });
 

--- a/database/dish.repo.ts
+++ b/database/dish.repo.ts
@@ -1,0 +1,49 @@
+import { CreateDishDto, DishInterface } from "@/models/index.ts";
+import { getKv } from "./db.ts";
+import { mergeDefinedPatch } from "./merge-patch.ts";
+
+export class DishRepo {
+  static async create(dish: CreateDishDto): Promise<DishInterface> {
+    const kv = await getKv();
+    const id = crypto.randomUUID();
+    const record: DishInterface = {
+      ...dish,
+      id,
+      createdAt: dish.createdAt ?? new Date().toISOString(),
+    };
+    const ok = await kv.atomic().set(["dishes", id], record).commit();
+    if (!ok) throw new Error("Failed to create dish.");
+    return record;
+  }
+
+  static async readAll(): Promise<DishInterface[]> {
+    const kv = await getKv();
+    const entries = kv.list<DishInterface>({ prefix: ["dishes"] });
+    const dishes: DishInterface[] = [];
+    for await (const entry of entries) dishes.push(entry.value);
+    return dishes;
+  }
+
+  static async getById(id: string): Promise<DishInterface | null> {
+    const kv = await getKv();
+    const res = await kv.get<DishInterface>(["dishes", id]);
+    return res.value;
+  }
+
+  static async update(
+    id: string,
+    patch: Partial<DishInterface>,
+  ): Promise<DishInterface | null> {
+    const kv = await getKv();
+    const existing = await this.getById(id);
+    if (!existing) return null;
+    const updated = mergeDefinedPatch(existing, patch);
+    await kv.set(["dishes", id], updated);
+    return updated;
+  }
+
+  static async delete(id: string): Promise<void> {
+    const kv = await getKv();
+    await kv.delete(["dishes", id]);
+  }
+}

--- a/database/dish.repo.ts
+++ b/database/dish.repo.ts
@@ -1,4 +1,4 @@
-import { CreateDishDto, DishInterface } from "@/models/index.ts";
+import { CreateDishDto, DishInterface, UpdateDishDto } from "@/models/index.ts";
 import { getKv } from "./db.ts";
 import { mergeDefinedPatch } from "./merge-patch.ts";
 
@@ -18,7 +18,7 @@ export class DishRepo {
     return record;
   }
 
-  static async readAll(): Promise<DishInterface[]> {
+  static async getAll(): Promise<DishInterface[]> {
     const kv = await getKv();
     const entries = kv.list<DishInterface>({ prefix: ["dishes"] });
     const dishes: DishInterface[] = [];
@@ -34,12 +34,12 @@ export class DishRepo {
 
   static async update(
     id: string,
-    patch: Partial<DishInterface>,
+    patch: UpdateDishDto,
   ): Promise<DishInterface | null> {
     const kv = await getKv();
     const existing = await this.getById(id);
     if (!existing) return null;
-    const updated = mergeDefinedPatch(existing, patch);
+    const updated = mergeDefinedPatch<DishInterface>(existing, patch);
     await kv.set(["dishes", id], updated);
     return updated;
   }

--- a/database/dish.repo.ts
+++ b/database/dish.repo.ts
@@ -9,6 +9,8 @@ export class DishRepo {
     const record: DishInterface = {
       ...dish,
       id,
+      ingredientIds: dish.ingredientIds ?? [],
+      tagValueIds: dish.tagValueIds ?? [],
       createdAt: dish.createdAt ?? new Date().toISOString(),
     };
     const ok = await kv.atomic().set(["dishes", id], record).commit();

--- a/database/index.ts
+++ b/database/index.ts
@@ -6,3 +6,4 @@ export * from "./shopping-list.repo.ts";
 export * from "./shopping-list-item.repo.ts";
 export * from "./household.repo.ts";
 export * from "./category.repo.ts";
+export * from "./dish.repo.ts";

--- a/database/index.ts
+++ b/database/index.ts
@@ -7,3 +7,4 @@ export * from "./shopping-list-item.repo.ts";
 export * from "./household.repo.ts";
 export * from "./category.repo.ts";
 export * from "./dish.repo.ts";
+export * from "./dish-tag-group.repo.ts";

--- a/docs/superpowers/plans/2026-07-26-dish-catalogue.md
+++ b/docs/superpowers/plans/2026-07-26-dish-catalogue.md
@@ -1,0 +1,1704 @@
+# Dish Catalogue (CRUD) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a household dish catalogue in the Menu module with full CRUD, structured tag groups, catalogue-item ingredient references, and faceted filtering — the data foundation for the meal-suggestion system (#14).
+
+**Architecture:** Mirror the existing shopping-catalogue stack (model → repo → API route → client wrapper → signals hook → island). Dishes and tag groups are new global Deno KV collections. The `/menu` route (today a `ComingSoon`) becomes the dish list; a full-screen editor route handles create/view/edit/delete. Optimistic client writes reuse the `beginBusy/endBusy` loading integration.
+
+**Tech Stack:** Deno + Fresh 2 (`jsr:@fresh/core@^2.2.0`) + Preact + `@preact/signals` + Deno KV (`--unstable-kv`) + Tailwind CSS v4. Tests via `deno test --unstable-kv -A` with `jsr:@std/assert` and `npm:preact-render-to-string`.
+
+## Global Constraints
+
+- Imports use the `@/` project-root alias (e.g. `import { db } from "@/database/db.ts"`).
+- JSX uses `class`, never `className` (`jsx: "precompile"`).
+- Inside island component bodies use `useSignal()` (never bare `signal()`); bare `signal()` is only for module scope or inside a hook that the island calls once via `useMemo(() => useHook(...), [])` (the established `useCatalogue` pattern).
+- Repositories are the only KV access point; never call `Deno.openKv()` in routes. KV key pattern `["collection", id]`; IDs via `crypto.randomUUID()`.
+- Partial updates go through `mergeDefinedPatch(existing, patch)` so omitted fields are never clobbered.
+- Per CLAUDE.md, before writing Fresh 2 handler code or Deno KV calls, verify current signatures via Context7 (`resolve-library-id` → `query-docs`). The code below matches the in-repo patterns (`routes/api/shopping/catalogue.ts`, `database/category.repo.ts`); use Context7 to confirm nothing has drifted.
+- Commits follow Conventional Commits; scope `menu` (e.g. `feat(menu): ...`).
+- Storage is **global** (not household-scoped) to match the existing catalogue; per-household scoping is deferred to #42. Full tag-group management (create/rename/delete groups, rename/delete values) is deferred to #43.
+- Gates for the whole feature: `deno task check`, `deno task test`, `deno task build` all green.
+
+---
+
+### Task 1: Dish model + `DishRepo`
+
+**Files:**
+- Create: `models/dish/dish.interface.ts`
+- Create: `models/dish/index.ts`
+- Modify: `models/index.ts` (add dish export)
+- Create: `database/dish.repo.ts`
+- Modify: `database/index.ts` (export `DishRepo`)
+- Test: `database/dish.repo.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `DishInterface { id: string; name: string; ingredientIds: string[]; tagValueIds: string[]; createdAt?: string; createdBy?: string }`
+  - `CreateDishDto = Omit<DishInterface, "id">`
+  - `UpdateDishDto = Pick<DishInterface, "id"> & Partial<Omit<DishInterface, "id">>`
+  - `DishRepo.create(dish: CreateDishDto): Promise<DishInterface>`
+  - `DishRepo.readAll(): Promise<DishInterface[]>`
+  - `DishRepo.getById(id: string): Promise<DishInterface | null>`
+  - `DishRepo.update(id: string, patch: Partial<DishInterface>): Promise<DishInterface | null>`
+  - `DishRepo.delete(id: string): Promise<void>`
+
+- [ ] **Step 1: Create the model files**
+
+`models/dish/dish.interface.ts`:
+```ts
+export interface DishInterface {
+  id: string;
+  name: string;
+  ingredientIds: string[]; // → catalogue Item ids (["items", id])
+  tagValueIds: string[]; // → DishTagValue ids, flat across all groups
+  createdAt?: string;
+  createdBy?: string;
+}
+
+// Derived type for creation (no ID)
+export type CreateDishDto = Omit<DishInterface, "id">;
+
+// Derived type for updating (ID + partial fields)
+export type UpdateDishDto =
+  & Pick<DishInterface, "id">
+  & Partial<Omit<DishInterface, "id">>;
+```
+
+`models/dish/index.ts`:
+```ts
+export * from "./dish.interface.ts";
+```
+
+Add to `models/index.ts` (append):
+```ts
+export * from "./dish/index.ts";
+```
+
+- [ ] **Step 2: Write the failing repo test**
+
+`database/dish.repo.test.ts`:
+```ts
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import { DishRepo } from "@/database/dish.repo.ts";
+import { getKv } from "@/database/db.ts";
+
+// Isolated in-memory KV for this test process (see shopping-list-item.repo.test.ts).
+Deno.env.set("KV_PATH", ":memory:");
+
+async function clearDishes() {
+  const kv = await getKv();
+  for await (const e of kv.list({ prefix: ["dishes"] })) await kv.delete(e.key);
+}
+
+Deno.test({
+  name: "create + getById — round-trips fields and assigns id + createdAt",
+  sanitizeResources: false,
+  async fn() {
+    await clearDishes();
+    const created = await DishRepo.create({
+      name: "Pasta Bolognese",
+      ingredientIds: ["i1", "i2"],
+      tagValueIds: ["meat", "main"],
+    });
+    assertEquals(typeof created.id, "string");
+    assertEquals(typeof created.createdAt, "string");
+    const fetched = await DishRepo.getById(created.id);
+    assertEquals(fetched?.name, "Pasta Bolognese");
+    assertEquals(fetched?.ingredientIds, ["i1", "i2"]);
+    assertEquals(fetched?.tagValueIds, ["meat", "main"]);
+  },
+});
+
+Deno.test({
+  name: "update — partial patch does not clobber omitted fields",
+  sanitizeResources: false,
+  async fn() {
+    await clearDishes();
+    const d = await DishRepo.create({
+      name: "Curry",
+      ingredientIds: ["i1"],
+      tagValueIds: ["veg"],
+    });
+    const updated = await DishRepo.update(d.id, { name: "Veggie Curry" });
+    assertEquals(updated?.name, "Veggie Curry");
+    assertEquals(updated?.ingredientIds, ["i1"]); // untouched
+    assertEquals(updated?.tagValueIds, ["veg"]); // untouched
+  },
+});
+
+Deno.test({
+  name: "update — returns null for a missing dish",
+  sanitizeResources: false,
+  async fn() {
+    await clearDishes();
+    assertEquals(await DishRepo.update("nope", { name: "x" }), null);
+  },
+});
+
+Deno.test({
+  name: "delete — removes the dish",
+  sanitizeResources: false,
+  async fn() {
+    await clearDishes();
+    const d = await DishRepo.create({
+      name: "Toast",
+      ingredientIds: [],
+      tagValueIds: [],
+    });
+    await DishRepo.delete(d.id);
+    assertEquals(await DishRepo.getById(d.id), null);
+    assertEquals(await DishRepo.readAll(), []);
+  },
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `deno test --unstable-kv -A database/dish.repo.test.ts`
+Expected: FAIL — `Module not found "database/dish.repo.ts"`.
+
+- [ ] **Step 4: Implement `DishRepo`**
+
+`database/dish.repo.ts`:
+```ts
+import { CreateDishDto, DishInterface } from "@/models/index.ts";
+import { getKv } from "./db.ts";
+import { mergeDefinedPatch } from "./merge-patch.ts";
+
+export class DishRepo {
+  static async create(dish: CreateDishDto): Promise<DishInterface> {
+    const kv = await getKv();
+    const id = crypto.randomUUID();
+    const record: DishInterface = {
+      ...dish,
+      id,
+      createdAt: dish.createdAt ?? new Date().toISOString(),
+    };
+    const ok = await kv.atomic().set(["dishes", id], record).commit();
+    if (!ok) throw new Error("Failed to create dish.");
+    return record;
+  }
+
+  static async readAll(): Promise<DishInterface[]> {
+    const kv = await getKv();
+    const entries = kv.list<DishInterface>({ prefix: ["dishes"] });
+    const dishes: DishInterface[] = [];
+    for await (const entry of entries) dishes.push(entry.value);
+    return dishes;
+  }
+
+  static async getById(id: string): Promise<DishInterface | null> {
+    const kv = await getKv();
+    const res = await kv.get<DishInterface>(["dishes", id]);
+    return res.value;
+  }
+
+  static async update(
+    id: string,
+    patch: Partial<DishInterface>,
+  ): Promise<DishInterface | null> {
+    const kv = await getKv();
+    const existing = await this.getById(id);
+    if (!existing) return null;
+    const updated = mergeDefinedPatch(existing, patch);
+    await kv.set(["dishes", id], updated);
+    return updated;
+  }
+
+  static async delete(id: string): Promise<void> {
+    const kv = await getKv();
+    await kv.delete(["dishes", id]);
+  }
+}
+```
+
+Add to `database/index.ts` (append):
+```ts
+export * from "./dish.repo.ts";
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `deno test --unstable-kv -A database/dish.repo.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Format + commit**
+
+```bash
+deno fmt models/dish database/dish.repo.ts database/dish.repo.test.ts models/index.ts database/index.ts
+git add models/dish models/index.ts database/dish.repo.ts database/dish.repo.test.ts database/index.ts
+git commit -m "feat(menu): add Dish model and DishRepo CRUD"
+```
+
+---
+
+### Task 2: DishTagGroup model + `DishTagGroupRepo`
+
+**Files:**
+- Create: `models/dish/dish-tag-group.interface.ts`
+- Modify: `models/dish/index.ts` (add export)
+- Create: `database/dish-tag-group.repo.ts`
+- Modify: `database/index.ts` (export `DishTagGroupRepo`)
+- Test: `database/dish-tag-group.repo.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `DishTagValueInterface { id: string; label: string }`
+  - `DishTagGroupInterface { id: string; label: string; order?: number; values: DishTagValueInterface[] }`
+  - `DishTagGroupRepo.ensureDefaults(): Promise<void>` (idempotent seed)
+  - `DishTagGroupRepo.getAll(): Promise<DishTagGroupInterface[]>` (sorted by `order`)
+  - `DishTagGroupRepo.getById(id: string): Promise<DishTagGroupInterface | null>`
+  - `DishTagGroupRepo.addValue(groupId: string, label: string): Promise<DishTagValueInterface | null>`
+
+- [ ] **Step 1: Create the model file + export**
+
+`models/dish/dish-tag-group.interface.ts`:
+```ts
+export interface DishTagValueInterface {
+  id: string;
+  label: string;
+}
+
+export interface DishTagGroupInterface {
+  id: string;
+  label: string; // "Type", "Meal", "Side type"
+  order?: number;
+  values: DishTagValueInterface[]; // values embedded in the group
+}
+```
+
+Update `models/dish/index.ts`:
+```ts
+export * from "./dish.interface.ts";
+export * from "./dish-tag-group.interface.ts";
+```
+
+- [ ] **Step 2: Write the failing repo test**
+
+`database/dish-tag-group.repo.test.ts`:
+```ts
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import { DishTagGroupRepo } from "@/database/dish-tag-group.repo.ts";
+import { getKv } from "@/database/db.ts";
+
+Deno.env.set("KV_PATH", ":memory:");
+
+async function clearGroups() {
+  const kv = await getKv();
+  for await (const e of kv.list({ prefix: ["dish_tag_groups"] })) {
+    await kv.delete(e.key);
+  }
+}
+
+Deno.test({
+  name: "ensureDefaults — seeds the three default groups with values",
+  sanitizeResources: false,
+  async fn() {
+    await clearGroups();
+    await DishTagGroupRepo.ensureDefaults();
+    const groups = await DishTagGroupRepo.getAll();
+    assertEquals(groups.map((g) => g.label), ["Type", "Meal", "Side type"]);
+    assertEquals(groups[0].values.map((v) => v.label), [
+      "Vegetarian",
+      "Fish",
+      "Meat",
+    ]);
+    // every value has a non-empty id
+    for (const g of groups) {
+      for (const v of g.values) assertEquals(typeof v.id, "string");
+    }
+  },
+});
+
+Deno.test({
+  name: "ensureDefaults — is idempotent (second call adds nothing)",
+  sanitizeResources: false,
+  async fn() {
+    await clearGroups();
+    await DishTagGroupRepo.ensureDefaults();
+    await DishTagGroupRepo.ensureDefaults();
+    const groups = await DishTagGroupRepo.getAll();
+    assertEquals(groups.length, 3);
+  },
+});
+
+Deno.test({
+  name: "addValue — appends a value to a group and returns it",
+  sanitizeResources: false,
+  async fn() {
+    await clearGroups();
+    await DishTagGroupRepo.ensureDefaults();
+    const [type] = await DishTagGroupRepo.getAll();
+    const created = await DishTagGroupRepo.addValue(type.id, "Vegan");
+    assertEquals(created?.label, "Vegan");
+    const reloaded = await DishTagGroupRepo.getById(type.id);
+    assertEquals(reloaded?.values.at(-1)?.label, "Vegan");
+  },
+});
+
+Deno.test({
+  name: "addValue — returns null for a missing group",
+  sanitizeResources: false,
+  async fn() {
+    await clearGroups();
+    assertEquals(await DishTagGroupRepo.addValue("nope", "x"), null);
+  },
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `deno test --unstable-kv -A database/dish-tag-group.repo.test.ts`
+Expected: FAIL — `Module not found "database/dish-tag-group.repo.ts"`.
+
+- [ ] **Step 4: Implement `DishTagGroupRepo`**
+
+`database/dish-tag-group.repo.ts`:
+```ts
+import {
+  DishTagGroupInterface,
+  DishTagValueInterface,
+} from "@/models/index.ts";
+import { getKv } from "./db.ts";
+
+const DEFAULT_GROUPS: { label: string; values: string[] }[] = [
+  { label: "Type", values: ["Vegetarian", "Fish", "Meat"] },
+  { label: "Meal", values: ["Main dish", "Breakfast", "Lunch", "Side dish"] },
+  { label: "Side type", values: ["Rice", "Potatoes", "Pasta"] },
+];
+
+export class DishTagGroupRepo {
+  static async getAll(): Promise<DishTagGroupInterface[]> {
+    const kv = await getKv();
+    const entries = kv.list<DishTagGroupInterface>({
+      prefix: ["dish_tag_groups"],
+    });
+    const groups: DishTagGroupInterface[] = [];
+    for await (const entry of entries) groups.push(entry.value);
+    return groups.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+  }
+
+  static async getById(id: string): Promise<DishTagGroupInterface | null> {
+    const kv = await getKv();
+    const res = await kv.get<DishTagGroupInterface>(["dish_tag_groups", id]);
+    return res.value;
+  }
+
+  static async ensureDefaults(): Promise<void> {
+    const kv = await getKv();
+    // Seed only when the collection is empty.
+    for await (const _ of kv.list({ prefix: ["dish_tag_groups"] })) return;
+    let atomic = kv.atomic();
+    DEFAULT_GROUPS.forEach((g, i) => {
+      const group: DishTagGroupInterface = {
+        id: crypto.randomUUID(),
+        label: g.label,
+        order: i,
+        values: g.values.map((label) => ({
+          id: crypto.randomUUID(),
+          label,
+        })),
+      };
+      atomic = atomic.set(["dish_tag_groups", group.id], group);
+    });
+    const ok = await atomic.commit();
+    if (!ok) throw new Error("Failed to seed dish tag groups.");
+  }
+
+  static async addValue(
+    groupId: string,
+    label: string,
+  ): Promise<DishTagValueInterface | null> {
+    const kv = await getKv();
+    const group = await this.getById(groupId);
+    if (!group) return null;
+    const value: DishTagValueInterface = {
+      id: crypto.randomUUID(),
+      label,
+    };
+    const updated: DishTagGroupInterface = {
+      ...group,
+      values: [...group.values, value],
+    };
+    await kv.set(["dish_tag_groups", groupId], updated);
+    return value;
+  }
+}
+```
+
+Add to `database/index.ts` (append):
+```ts
+export * from "./dish-tag-group.repo.ts";
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `deno test --unstable-kv -A database/dish-tag-group.repo.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Format + commit**
+
+```bash
+deno fmt models/dish database/dish-tag-group.repo.ts database/dish-tag-group.repo.test.ts database/index.ts
+git add models/dish/dish-tag-group.interface.ts models/dish/index.ts database/dish-tag-group.repo.ts database/dish-tag-group.repo.test.ts database/index.ts
+git commit -m "feat(menu): add DishTagGroup model and repo with seeded defaults"
+```
+
+---
+
+### Task 3: API routes for dishes + tag groups
+
+**Files:**
+- Create: `routes/api/menu/dishes.ts`
+- Create: `routes/api/menu/tag-groups.ts`
+- Test: `routes/api/menu/dishes.test.ts`
+- Test: `routes/api/menu/tag-groups.test.ts`
+
+**Interfaces:**
+- Consumes: `DishRepo` (Task 1), `DishTagGroupRepo` (Task 2).
+- Produces (HTTP contract used by the client wrappers in Task 4):
+  - `GET /api/menu/dishes` → `200` JSON `DishInterface[]`
+  - `POST /api/menu/dishes` → create (no `id`) `201` dish; update (`id` present) `200` dish or `404`
+  - `DELETE /api/menu/dishes` → body `{ id }` → `204`, or `400` when `id` missing
+  - `GET /api/menu/tag-groups` → `ensureDefaults` then `200` JSON `DishTagGroupInterface[]`
+  - `POST /api/menu/tag-groups` → body `{ groupId, label }` → `201` value, `404` missing group, `400` missing fields
+
+- [ ] **Step 1: Write the failing handler tests**
+
+These call the handler object directly with a minimal fake context (the handlers only read `ctx.req`), matching `routes/api/shopping/catalogue.ts`'s `Context<unknown>` shape.
+
+`routes/api/menu/dishes.test.ts`:
+```ts
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import { type Context } from "fresh";
+import { handler } from "@/routes/api/menu/dishes.ts";
+import { getKv } from "@/database/db.ts";
+
+Deno.env.set("KV_PATH", ":memory:");
+
+function ctx(req: Request): Context<unknown> {
+  return { req } as unknown as Context<unknown>;
+}
+async function clearDishes() {
+  const kv = await getKv();
+  for await (const e of kv.list({ prefix: ["dishes"] })) await kv.delete(e.key);
+}
+const post = (body: unknown) =>
+  new Request("http://x/api/menu/dishes", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+Deno.test({
+  name: "POST creates (201), GET lists it, POST with id updates (200)",
+  sanitizeResources: false,
+  async fn() {
+    await clearDishes();
+    const createRes = await handler.POST(
+      ctx(post({ name: "Curry", ingredientIds: [], tagValueIds: [] })),
+    );
+    assertEquals(createRes.status, 201);
+    const created = await createRes.json();
+
+    const listRes = await handler.GET(
+      ctx(new Request("http://x/api/menu/dishes")),
+    );
+    assertEquals(listRes.status, 200);
+    const list = await listRes.json();
+    assertEquals(list.map((d: { name: string }) => d.name), ["Curry"]);
+
+    const updateRes = await handler.POST(
+      ctx(post({ id: created.id, name: "Veggie Curry" })),
+    );
+    assertEquals(updateRes.status, 200);
+    assertEquals((await updateRes.json()).name, "Veggie Curry");
+  },
+});
+
+Deno.test({
+  name: "POST with unknown id returns 404",
+  sanitizeResources: false,
+  async fn() {
+    await clearDishes();
+    const res = await handler.POST(ctx(post({ id: "nope", name: "x" })));
+    assertEquals(res.status, 404);
+  },
+});
+
+Deno.test({
+  name: "DELETE removes a dish (204); missing id is 400",
+  sanitizeResources: false,
+  async fn() {
+    await clearDishes();
+    const created = await (await handler.POST(
+      ctx(post({ name: "Toast", ingredientIds: [], tagValueIds: [] })),
+    )).json();
+    const delReq = new Request("http://x/api/menu/dishes", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: created.id }),
+    });
+    assertEquals((await handler.DELETE(ctx(delReq))).status, 204);
+
+    const badReq = new Request("http://x/api/menu/dishes", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    assertEquals((await handler.DELETE(ctx(badReq))).status, 400);
+  },
+});
+```
+
+`routes/api/menu/tag-groups.test.ts`:
+```ts
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import { type Context } from "fresh";
+import { handler } from "@/routes/api/menu/tag-groups.ts";
+import { getKv } from "@/database/db.ts";
+
+Deno.env.set("KV_PATH", ":memory:");
+
+function ctx(req: Request): Context<unknown> {
+  return { req } as unknown as Context<unknown>;
+}
+async function clearGroups() {
+  const kv = await getKv();
+  for await (const e of kv.list({ prefix: ["dish_tag_groups"] })) {
+    await kv.delete(e.key);
+  }
+}
+
+Deno.test({
+  name: "GET seeds defaults and returns the groups",
+  sanitizeResources: false,
+  async fn() {
+    await clearGroups();
+    const res = await handler.GET(
+      ctx(new Request("http://x/api/menu/tag-groups")),
+    );
+    assertEquals(res.status, 200);
+    const groups = await res.json();
+    assertEquals(groups.map((g: { label: string }) => g.label), [
+      "Type",
+      "Meal",
+      "Side type",
+    ]);
+  },
+});
+
+Deno.test({
+  name: "POST adds a value to a group (201); missing group is 404",
+  sanitizeResources: false,
+  async fn() {
+    await clearGroups();
+    const groups = await (await handler.GET(
+      ctx(new Request("http://x/api/menu/tag-groups")),
+    )).json();
+    const addReq = (body: unknown) =>
+      new Request("http://x/api/menu/tag-groups", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+    const okRes = await handler.POST(
+      ctx(addReq({ groupId: groups[0].id, label: "Vegan" })),
+    );
+    assertEquals(okRes.status, 201);
+    assertEquals((await okRes.json()).label, "Vegan");
+
+    const missRes = await handler.POST(
+      ctx(addReq({ groupId: "nope", label: "x" })),
+    );
+    assertEquals(missRes.status, 404);
+  },
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `deno test --unstable-kv -A routes/api/menu/`
+Expected: FAIL — modules `routes/api/menu/dishes.ts` / `tag-groups.ts` not found.
+
+- [ ] **Step 3: Implement the routes**
+
+`routes/api/menu/dishes.ts`:
+```ts
+import { type Context } from "fresh";
+import { DishRepo } from "@/database/dish.repo.ts";
+
+export const handler = {
+  async GET(_ctx: Context<unknown>) {
+    const dishes = await DishRepo.readAll();
+    return new Response(JSON.stringify(dishes), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  },
+  async POST(_ctx: Context<unknown>) {
+    const body = await _ctx.req.json();
+    if (body.id) {
+      const updated = await DishRepo.update(body.id, body);
+      if (!updated) return new Response("Dish not found", { status: 404 });
+      return new Response(JSON.stringify(updated), { status: 200 });
+    }
+    const created = await DishRepo.create(body);
+    return new Response(JSON.stringify(created), { status: 201 });
+  },
+  async DELETE(_ctx: Context<unknown>) {
+    const { id } = await _ctx.req.json();
+    if (!id) return new Response("ID is required", { status: 400 });
+    await DishRepo.delete(id);
+    return new Response(null, { status: 204 });
+  },
+};
+```
+
+`routes/api/menu/tag-groups.ts`:
+```ts
+import { type Context } from "fresh";
+import { DishTagGroupRepo } from "@/database/dish-tag-group.repo.ts";
+
+export const handler = {
+  async GET(_ctx: Context<unknown>) {
+    await DishTagGroupRepo.ensureDefaults();
+    const groups = await DishTagGroupRepo.getAll();
+    return new Response(JSON.stringify(groups), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  },
+  async POST(_ctx: Context<unknown>) {
+    const { groupId, label } = await _ctx.req.json();
+    if (!groupId || !label?.trim()) {
+      return new Response("groupId and label are required", { status: 400 });
+    }
+    const value = await DishTagGroupRepo.addValue(groupId, label.trim());
+    if (!value) return new Response("Group not found", { status: 404 });
+    return new Response(JSON.stringify(value), { status: 201 });
+  },
+};
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `deno test --unstable-kv -A routes/api/menu/`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Format + commit**
+
+```bash
+deno fmt routes/api/menu
+git add routes/api/menu
+git commit -m "feat(menu): add dish and tag-group API routes"
+```
+
+---
+
+### Task 4: Client API wrappers + `useDishes` hook
+
+**Files:**
+- Modify: `services/api.ts` (add `api.dishes`, `api.dishTagGroups`, dish model imports)
+- Create: `hooks/useDishes.ts`
+- Test: `hooks/useDishes.test.ts`
+
+**Interfaces:**
+- Consumes: the HTTP contract from Task 3; `beginBusy`/`endBusy` from `@/utils/loading.ts`.
+- Produces:
+  - `api.dishes.getAll() / create(dish: CreateDishDto) / update(id, patch: Partial<DishInterface>) / delete(id)`
+  - `api.dishTagGroups.getAll() / addValue(groupId, label)`
+  - `useDishes(initialDishes, initialTagGroups)` returning signals `dishes`, `tagGroups`, `query`, `selectedTagValueIds`, `pendingCount`, computed `filtered`, and methods `toggleTagValue(valueId)`, `clearFilters()`, `removeDish(id)`, `refresh()`. Filtering is **OR within a tag group, AND across groups**, combined with a case-insensitive name-substring match; results sorted by name.
+
+- [ ] **Step 1: Write the failing hook test**
+
+`hooks/useDishes.test.ts`:
+```ts
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import { stub } from "jsr:@std/testing@^1.0.18/mock";
+import { api } from "@/services/api.ts";
+import { useDishes } from "@/hooks/useDishes.ts";
+import type { DishInterface, DishTagGroupInterface } from "@/models/index.ts";
+
+const dish = (
+  id: string,
+  name: string,
+  tagValueIds: string[] = [],
+): DishInterface => ({ id, name, ingredientIds: [], tagValueIds });
+
+const group = (
+  id: string,
+  label: string,
+  values: [string, string][],
+  order = 0,
+): DishTagGroupInterface => ({
+  id,
+  label,
+  order,
+  values: values.map(([vid, l]) => ({ id: vid, label: l })),
+});
+
+Deno.test("filtered — case-insensitive name query", () => {
+  const hook = useDishes(
+    [dish("1", "Pasta Bolognese"), dish("2", "Veggie Curry")],
+    [],
+  );
+  hook.query.value = "curry";
+  assertEquals(hook.filtered.value.map((d) => d.name), ["Veggie Curry"]);
+});
+
+Deno.test("filtered — OR within a group, AND across groups", () => {
+  const groups = [
+    group("type", "Type", [["veg", "Vegetarian"], ["fish", "Fish"], [
+      "meat",
+      "Meat",
+    ]]),
+    group("meal", "Meal", [["main", "Main dish"], ["side", "Side dish"]], 1),
+  ];
+  const hook = useDishes([
+    dish("1", "Veg Main", ["veg", "main"]),
+    dish("2", "Fish Main", ["fish", "main"]),
+    dish("3", "Veg Side", ["veg", "side"]),
+    dish("4", "Meat Main", ["meat", "main"]),
+  ], groups);
+  hook.toggleTagValue("veg"); // Type: veg
+  hook.toggleTagValue("fish"); // Type: veg OR fish
+  hook.toggleTagValue("main"); // Meal: main  → (veg|fish) AND main
+  assertEquals(hook.filtered.value.map((d) => d.name), ["Fish Main", "Veg Main"]);
+});
+
+Deno.test("clearFilters — removes all selected tag values", () => {
+  const hook = useDishes([dish("1", "A", ["veg"])], []);
+  hook.toggleTagValue("veg");
+  hook.clearFilters();
+  assertEquals(hook.selectedTagValueIds.value.size, 0);
+});
+
+Deno.test("removeDish — optimistically removes and calls the API", async () => {
+  const del = stub(api.dishes, "delete", () => Promise.resolve());
+  try {
+    const hook = useDishes([dish("1", "A"), dish("2", "B")], []);
+    await hook.removeDish("1");
+    assertEquals(hook.dishes.value.map((d) => d.id), ["2"]);
+    assertEquals(del.calls.length, 1);
+  } finally {
+    del.restore();
+  }
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `deno test --unstable-kv -A hooks/useDishes.test.ts`
+Expected: FAIL — `useDishes` module not found (and `api.dishes` undefined).
+
+- [ ] **Step 3: Add the client wrappers**
+
+In `services/api.ts`, add this import near the existing model imports:
+```ts
+import {
+  CreateDishDto,
+  DishInterface,
+  DishTagGroupInterface,
+  DishTagValueInterface,
+} from "@/models/index.ts";
+```
+
+Add these two keys to the `api` object (e.g. after `items`):
+```ts
+  dishes: {
+    getAll: async (): Promise<DishInterface[]> => {
+      const res = await fetch("/api/menu/dishes");
+      if (!res.ok) return [];
+      return res.json();
+    },
+    create: async (dish: CreateDishDto): Promise<DishInterface | null> => {
+      const res = await fetch("/api/menu/dishes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(dish),
+      });
+      if (!res.ok) return null;
+      return res.json();
+    },
+    update: async (
+      id: string,
+      patch: Partial<DishInterface>,
+    ): Promise<DishInterface | null> => {
+      const res = await fetch("/api/menu/dishes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...patch, id }),
+      });
+      if (!res.ok) return null;
+      return res.json();
+    },
+    delete: async (id: string): Promise<void> => {
+      await fetch("/api/menu/dishes", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id }),
+      });
+    },
+  },
+  dishTagGroups: {
+    getAll: async (): Promise<DishTagGroupInterface[]> => {
+      const res = await fetch("/api/menu/tag-groups");
+      if (!res.ok) return [];
+      return res.json();
+    },
+    addValue: async (
+      groupId: string,
+      label: string,
+    ): Promise<DishTagValueInterface | null> => {
+      const res = await fetch("/api/menu/tag-groups", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ groupId, label }),
+      });
+      if (!res.ok) return null;
+      return res.json();
+    },
+  },
+```
+
+- [ ] **Step 4: Implement the hook**
+
+`hooks/useDishes.ts`:
+```ts
+import { computed, signal } from "@preact/signals";
+import type { DishInterface, DishTagGroupInterface } from "@/models/index.ts";
+import { api } from "@/services/api.ts";
+import { beginBusy, endBusy } from "@/utils/loading.ts";
+
+export function useDishes(
+  initialDishes: DishInterface[],
+  initialTagGroups: DishTagGroupInterface[],
+) {
+  const dishes = signal<DishInterface[]>(initialDishes ?? []);
+  const tagGroups = signal<DishTagGroupInterface[]>(initialTagGroups ?? []);
+  const query = signal("");
+  const selectedTagValueIds = signal<Set<string>>(new Set());
+  const pendingCount = signal(0);
+
+  const startPending = () => {
+    pendingCount.value++;
+    beginBusy();
+  };
+  const endPending = () => {
+    pendingCount.value--;
+    endBusy();
+  };
+
+  const filtered = computed<DishInterface[]>(() => {
+    const q = query.value.trim().toLowerCase();
+    const selected = selectedTagValueIds.value;
+
+    // Map each selectable value id → its group id, then bucket the *selected*
+    // ids by group so we can require a match within each active group (OR)
+    // while requiring every active group to match (AND).
+    const valueToGroup = new Map<string, string>();
+    for (const g of tagGroups.value) {
+      for (const v of g.values) valueToGroup.set(v.id, g.id);
+    }
+    const byGroup = new Map<string, Set<string>>();
+    for (const vid of selected) {
+      const gid = valueToGroup.get(vid);
+      if (!gid) continue;
+      if (!byGroup.has(gid)) byGroup.set(gid, new Set());
+      byGroup.get(gid)!.add(vid);
+    }
+
+    return dishes.value
+      .filter((d) => {
+        if (q && !d.name.toLowerCase().includes(q)) return false;
+        for (const [, valueIds] of byGroup) {
+          if (!d.tagValueIds.some((t) => valueIds.has(t))) return false;
+        }
+        return true;
+      })
+      .sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+  });
+
+  const toggleTagValue = (valueId: string) => {
+    const next = new Set(selectedTagValueIds.value);
+    next.has(valueId) ? next.delete(valueId) : next.add(valueId);
+    selectedTagValueIds.value = next;
+  };
+
+  const clearFilters = () => {
+    selectedTagValueIds.value = new Set();
+  };
+
+  const removeDish = async (id: string): Promise<void> => {
+    dishes.value = dishes.value.filter((d) => d.id !== id);
+    startPending();
+    try {
+      await api.dishes.delete(id);
+    } finally {
+      endPending();
+    }
+  };
+
+  const refresh = async (): Promise<void> => {
+    pendingCount.value++;
+    try {
+      const [d, g] = await Promise.all([
+        api.dishes.getAll(),
+        api.dishTagGroups.getAll(),
+      ]);
+      dishes.value = d;
+      tagGroups.value = g;
+    } finally {
+      pendingCount.value--;
+    }
+  };
+
+  return {
+    dishes,
+    tagGroups,
+    query,
+    selectedTagValueIds,
+    pendingCount,
+    filtered,
+    toggleTagValue,
+    clearFilters,
+    removeDish,
+    refresh,
+  };
+}
+```
+
+Note: `deno lint` may flag the ternary-as-statement in `toggleTagValue`. If it does, rewrite as an `if/else`:
+```ts
+    if (next.has(valueId)) next.delete(valueId);
+    else next.add(valueId);
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `deno test --unstable-kv -A hooks/useDishes.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Format + commit**
+
+```bash
+deno fmt services/api.ts hooks/useDishes.ts hooks/useDishes.test.ts
+git add services/api.ts hooks/useDishes.ts hooks/useDishes.test.ts
+git commit -m "feat(menu): add dish API client wrappers and useDishes hook"
+```
+
+---
+
+### Task 5: `/menu` list route + `DishCatalogue` island
+
+**Files:**
+- Modify: `routes/menu/index.tsx` (replace `ComingSoon` with the dish list)
+- Create: `islands/dishes/DishCatalogue.tsx`
+- Test: `islands/dishes/DishCatalogue.test.tsx`
+
+**Interfaces:**
+- Consumes: `useDishes` (Task 4); `DishRepo` + `DishTagGroupRepo` (Tasks 1–2); `navigateTo` from `@/utils/loading.ts`; MD3 `Chip`, `Icon`, `IconButton`, `Pressable`, `Button`, `PullToRefresh`.
+- Produces: `DishCatalogue` default export with props `{ initialDishes: DishInterface[]; initialTagGroups: DishTagGroupInterface[] }`. Tiles link to `/menu/{id}`; FAB and empty-state button link to `/menu/new`.
+
+- [ ] **Step 1: Write the failing island render test**
+
+`islands/dishes/DishCatalogue.test.tsx`:
+```tsx
+import { assertStringIncludes } from "jsr:@std/assert@^1.0.19";
+import { render } from "npm:preact-render-to-string@^6.6.3";
+import { h } from "preact";
+import DishCatalogue from "./DishCatalogue.tsx";
+
+Deno.test("DishCatalogue — renders dishes, tag filter groups, and the add FAB", () => {
+  const html = render(h(DishCatalogue, {
+    initialDishes: [
+      { id: "1", name: "Pasta Bolognese", ingredientIds: ["a", "b"], tagValueIds: ["meat"] },
+      { id: "2", name: "Veggie Curry", ingredientIds: ["c"], tagValueIds: ["veg"] },
+    ],
+    initialTagGroups: [
+      {
+        id: "type",
+        label: "Type",
+        order: 0,
+        values: [{ id: "veg", label: "Vegetarian" }, { id: "meat", label: "Meat" }],
+      },
+    ],
+  }));
+  assertStringIncludes(html, "Pasta Bolognese");
+  assertStringIncludes(html, "Veggie Curry");
+  assertStringIncludes(html, "Type"); // group label
+  assertStringIncludes(html, "Vegetarian"); // value chip
+  assertStringIncludes(html, "Add dish"); // FAB label
+});
+
+Deno.test("DishCatalogue — empty state prompts adding a dish", () => {
+  const html = render(h(DishCatalogue, {
+    initialDishes: [],
+    initialTagGroups: [],
+  }));
+  assertStringIncludes(html, "No dishes yet");
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `deno test --unstable-kv -A islands/dishes/DishCatalogue.test.tsx`
+Expected: FAIL — `./DishCatalogue.tsx` not found.
+
+- [ ] **Step 3: Implement the island**
+
+`islands/dishes/DishCatalogue.tsx`:
+```tsx
+import { useMemo } from "preact/hooks";
+import type { DishInterface, DishTagGroupInterface } from "@/models/index.ts";
+import { useDishes } from "@/hooks/useDishes.ts";
+import { PullToRefresh } from "@/components/md3/PullToRefresh.tsx";
+import { Chip } from "@/components/md3/Chip.tsx";
+import { Icon } from "@/components/md3/Icon.tsx";
+import { IconButton } from "@/components/md3/IconButton.tsx";
+import { Pressable } from "@/components/md3/Pressable.tsx";
+import { Button } from "@/components/md3/Button.tsx";
+import { navigateTo } from "@/utils/loading.ts";
+
+interface Props {
+  initialDishes: DishInterface[];
+  initialTagGroups: DishTagGroupInterface[];
+}
+
+export default function DishCatalogue(
+  { initialDishes, initialTagGroups }: Props,
+) {
+  // useMemo([]) so the hook's signals are created once from SSR props.
+  const {
+    dishes,
+    tagGroups,
+    query,
+    selectedTagValueIds,
+    filtered,
+    toggleTagValue,
+    clearFilters,
+    refresh,
+  } = useMemo(() => useDishes(initialDishes, initialTagGroups), []);
+
+  const groups = tagGroups.value;
+  const selected = selectedTagValueIds.value;
+  const list = filtered.value;
+
+  return (
+    <PullToRefresh onRefresh={refresh}>
+      <div class="px-4 pt-4 pb-[calc(96px+env(safe-area-inset-bottom))] flex flex-col gap-4">
+        {/* search */}
+        <div class="flex items-center gap-2 bg-surface-chighest rounded-[var(--md-shape-full)] h-12 pl-4 pr-1.5">
+          <Icon name="search" size={20} class="text-on-surface-variant" />
+          <input
+            value={query.value}
+            onInput={(e) => (query.value = e.currentTarget.value)}
+            placeholder="Search dishes"
+            class="flex-1 min-w-0 bg-transparent border-0 outline-none md-body-large text-on-surface"
+          />
+          {query.value && (
+            <IconButton
+              name="x"
+              size={36}
+              iconSize={18}
+              aria-label="Clear search"
+              onClick={() => (query.value = "")}
+            />
+          )}
+        </div>
+
+        {/* tag filter rail — one row of chips per dimension */}
+        {groups.map((g) => (
+          <div key={g.id} class="flex flex-col gap-1.5">
+            <div class="md-label-medium uppercase text-on-surface-variant px-1">
+              {g.label}
+            </div>
+            <div class="flex gap-2 overflow-x-auto pr-1">
+              {g.values.map((v) => (
+                <Chip
+                  key={v.id}
+                  selected={selected.has(v.id)}
+                  leadingCheck={false}
+                  onClick={() => toggleTagValue(v.id)}
+                >
+                  {v.label}
+                </Chip>
+              ))}
+            </div>
+          </div>
+        ))}
+        {selected.size > 0 && (
+          <Pressable
+            onClick={clearFilters}
+            class="self-start md-label-large text-primary px-1"
+          >
+            Clear filters
+          </Pressable>
+        )}
+
+        {/* count */}
+        <div class="md-body-medium text-on-surface-variant px-1">
+          {list.length} dish{list.length === 1 ? "" : "es"}
+        </div>
+
+        {/* dish grid / empty state */}
+        {list.length === 0
+          ? (
+            <div class="px-2 pt-2 text-center flex flex-col items-center gap-4">
+              <div class="md-title-medium text-on-surface">
+                {dishes.value.length === 0
+                  ? "No dishes yet"
+                  : "No dishes match your filters"}
+              </div>
+              <Button
+                variant="tonal"
+                icon="plus"
+                onClick={() => navigateTo("/menu/new")}
+              >
+                Add a dish
+              </Button>
+            </div>
+          )
+          : (
+            <div class="grid grid-cols-2 gap-2.5">
+              {list.map((d) => (
+                <Pressable
+                  key={d.id}
+                  onClick={() => navigateTo(`/menu/${d.id}`)}
+                  class="flex flex-col gap-1 bg-surface border border-outline-variant rounded-[var(--md-shape-md)] px-4 py-3.5 text-left"
+                >
+                  <span class="md-body-large text-on-surface truncate">
+                    {d.name}
+                  </span>
+                  <span class="md-body-small text-on-surface-variant truncate">
+                    {d.ingredientIds.length} ingredient{d.ingredientIds.length ===
+                        1
+                      ? ""
+                      : "s"}
+                  </span>
+                </Pressable>
+              ))}
+            </div>
+          )}
+      </div>
+
+      {/* Add-dish FAB (styled like islands/shell/Fab.tsx, fixed above the nav) */}
+      <div
+        class="fixed right-4 z-40"
+        style={{ bottom: "calc(96px + env(safe-area-inset-bottom))" }}
+      >
+        <Pressable
+          onClick={() => navigateTo("/menu/new")}
+          aria-label="Add dish"
+          class="inline-flex items-center gap-3 bg-primary-container text-on-primary-container md-elevation-3"
+          style={{ height: 56, borderRadius: "var(--md-shape-lg)", padding: "0 20px" }}
+        >
+          <Icon name="plus" size={24} />
+          <span class="md-label-large" style={{ fontSize: 15 }}>Add dish</span>
+        </Pressable>
+      </div>
+    </PullToRefresh>
+  );
+}
+```
+
+- [ ] **Step 4: Replace the `/menu` route**
+
+Replace the entire contents of `routes/menu/index.tsx` with:
+```tsx
+import { page } from "fresh";
+import { DishRepo, DishTagGroupRepo } from "@/database/index.ts";
+import DishCatalogue from "@/islands/dishes/DishCatalogue.tsx";
+import { define } from "@/utils/index.ts";
+
+export const handler = define.handlers({
+  async GET(_ctx) {
+    await DishTagGroupRepo.ensureDefaults();
+    const [dishes, tagGroups] = await Promise.all([
+      DishRepo.readAll(),
+      DishTagGroupRepo.getAll(),
+    ]);
+    return page({ dishes, tagGroups });
+  },
+});
+
+export default define.page<typeof handler>(function MenuPage({ data }) {
+  return (
+    <main class="max-w-md mx-auto">
+      <DishCatalogue
+        initialDishes={data.dishes}
+        initialTagGroups={data.tagGroups}
+      />
+    </main>
+  );
+});
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `deno test --unstable-kv -A islands/dishes/DishCatalogue.test.tsx`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Format + commit**
+
+```bash
+deno fmt routes/menu/index.tsx islands/dishes
+git add routes/menu/index.tsx islands/dishes/DishCatalogue.tsx islands/dishes/DishCatalogue.test.tsx
+git commit -m "feat(menu): dish catalogue list with search and tag filters"
+```
+
+---
+
+### Task 6: Dish editor routes + `DishEditor` island
+
+**Files:**
+- Create: `islands/dishes/DishEditor.tsx`
+- Create: `routes/menu/new.tsx`
+- Create: `routes/menu/[id]/index.tsx`
+- Test: `islands/dishes/DishEditor.test.tsx`
+
+**Interfaces:**
+- Consumes: `api.dishes` + `api.dishTagGroups` + `api.items` (existing); `navigateTo`; MD3 `Chip`, `Button`, `Icon`, `IconButton`, `Sheet`, `Pressable`, `ListItem`. Routes use `DishRepo`, `DishTagGroupRepo`, `ItemRepo`, `page`, `define`.
+- Produces: `DishEditor` default export with props `{ dish?: DishInterface; tagGroups: DishTagGroupInterface[]; items: ItemInterface[] }`. Routes: `/menu/new` (create) and `/menu/[id]` (view/edit/delete), both setting `appBar { mode: "detail", title, backUrl: "/menu" }`.
+
+- [ ] **Step 1: Write the failing island render test**
+
+`islands/dishes/DishEditor.test.tsx`:
+```tsx
+import { assertStringIncludes } from "jsr:@std/assert@^1.0.19";
+import { render } from "npm:preact-render-to-string@^6.6.3";
+import { h } from "preact";
+import DishEditor from "./DishEditor.tsx";
+
+const groups = [{
+  id: "type",
+  label: "Type",
+  order: 0,
+  values: [{ id: "veg", label: "Vegetarian" }],
+}];
+const items = [{ id: "a", name: "Onion" }];
+
+Deno.test("DishEditor — new dish renders name, tags, add-ingredient, create button", () => {
+  const html = render(h(DishEditor, { tagGroups: groups, items }));
+  assertStringIncludes(html, "Name");
+  assertStringIncludes(html, "Type"); // tag group label
+  assertStringIncludes(html, "Vegetarian"); // tag value chip
+  assertStringIncludes(html, "Add ingredient");
+  assertStringIncludes(html, "Create dish");
+});
+
+Deno.test("DishEditor — existing dish prefills name, shows ingredient chip + delete", () => {
+  const html = render(h(DishEditor, {
+    dish: { id: "1", name: "Pasta", ingredientIds: ["a"], tagValueIds: ["veg"] },
+    tagGroups: groups,
+    items,
+  }));
+  assertStringIncludes(html, 'value="Pasta"'); // prefilled name field
+  assertStringIncludes(html, "Onion"); // resolved ingredient chip
+  assertStringIncludes(html, "Save changes");
+  assertStringIncludes(html, "Delete dish");
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `deno test --unstable-kv -A islands/dishes/DishEditor.test.tsx`
+Expected: FAIL — `./DishEditor.tsx` not found.
+
+- [ ] **Step 3: Implement the editor island**
+
+`islands/dishes/DishEditor.tsx`:
+```tsx
+import { useSignal } from "@preact/signals";
+import type {
+  DishInterface,
+  DishTagGroupInterface,
+  ItemInterface,
+} from "@/models/index.ts";
+import { api } from "@/services/api.ts";
+import { Chip } from "@/components/md3/Chip.tsx";
+import { Button } from "@/components/md3/Button.tsx";
+import { Icon } from "@/components/md3/Icon.tsx";
+import { IconButton } from "@/components/md3/IconButton.tsx";
+import { Sheet } from "@/components/md3/Sheet.tsx";
+import { Pressable } from "@/components/md3/Pressable.tsx";
+import { ListItem } from "@/components/md3/ListItem.tsx";
+import { navigateTo } from "@/utils/loading.ts";
+
+const fieldClass =
+  "flex-1 min-w-0 md-body-large text-on-surface bg-surface-chighest rounded-t-[var(--md-shape-sm)] border-0 border-b-2 border-primary px-4 py-3 focus:outline-none";
+
+interface Props {
+  dish?: DishInterface;
+  tagGroups: DishTagGroupInterface[];
+  items: ItemInterface[];
+}
+
+export default function DishEditor({ dish, tagGroups, items }: Props) {
+  const name = useSignal(dish?.name ?? "");
+  const ingredientIds = useSignal<string[]>(dish?.ingredientIds ?? []);
+  const tagValueIds = useSignal<string[]>(dish?.tagValueIds ?? []);
+  const localItems = useSignal<ItemInterface[]>(items);
+  const localGroups = useSignal<DishTagGroupInterface[]>(tagGroups);
+  const pickerOpen = useSignal(false);
+  const ingredientQuery = useSignal("");
+  const newValueFor = useSignal<string | null>(null);
+  const newValueLabel = useSignal("");
+  const saving = useSignal(false);
+
+  const itemById = (id: string) => localItems.value.find((i) => i.id === id);
+
+  const toggleTag = (valueId: string) => {
+    tagValueIds.value = tagValueIds.value.includes(valueId)
+      ? tagValueIds.value.filter((v) => v !== valueId)
+      : [...tagValueIds.value, valueId];
+  };
+  const addIngredient = (itemId: string) => {
+    if (!ingredientIds.value.includes(itemId)) {
+      ingredientIds.value = [...ingredientIds.value, itemId];
+    }
+  };
+  const removeIngredient = (itemId: string) => {
+    ingredientIds.value = ingredientIds.value.filter((i) => i !== itemId);
+  };
+  const createCatalogueItem = async (label: string) => {
+    const created = await api.items.create({ name: label });
+    if (created?.id) {
+      localItems.value = [...localItems.value, created];
+      addIngredient(created.id);
+    }
+  };
+  const addValue = async (groupId: string, label: string) => {
+    const created = await api.dishTagGroups.addValue(groupId, label);
+    if (created) {
+      localGroups.value = localGroups.value.map((g) =>
+        g.id === groupId ? { ...g, values: [...g.values, created] } : g
+      );
+      toggleTag(created.id);
+    }
+  };
+  const save = async () => {
+    const n = name.value.trim();
+    if (!n) return;
+    saving.value = true;
+    const payload = {
+      name: n,
+      ingredientIds: ingredientIds.value,
+      tagValueIds: tagValueIds.value,
+    };
+    if (dish) await api.dishes.update(dish.id, payload);
+    else await api.dishes.create(payload);
+    navigateTo("/menu");
+  };
+  const remove = async () => {
+    if (!dish) return;
+    await api.dishes.delete(dish.id);
+    navigateTo("/menu");
+  };
+
+  const q = ingredientQuery.value.trim().toLowerCase();
+  const chosen = new Set(ingredientIds.value);
+  const results = localItems.value
+    .filter((i) => !chosen.has(i.id) && (!q || i.name.toLowerCase().includes(q)))
+    .sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+  const exactMatch = !!q &&
+    localItems.value.some((i) => i.name.trim().toLowerCase() === q);
+
+  return (
+    <div class="px-4 pt-4 pb-[calc(96px+env(safe-area-inset-bottom))] flex flex-col gap-6">
+      {/* Name */}
+      <div>
+        <div class="md-label-medium uppercase text-on-surface-variant mb-2">
+          Name
+        </div>
+        <input
+          value={name.value}
+          onInput={(e) => (name.value = e.currentTarget.value)}
+          placeholder="Dish name"
+          class={fieldClass}
+        />
+      </div>
+
+      {/* Ingredients */}
+      <div>
+        <div class="md-label-medium uppercase text-on-surface-variant mb-2">
+          Ingredients
+        </div>
+        <div class="flex flex-wrap gap-2">
+          {ingredientIds.value.map((id) => (
+            <span
+              key={id}
+              class="inline-flex items-center gap-1 md-label-large bg-secondary-container text-on-secondary-container rounded-[var(--md-shape-full)] pl-3 pr-1 py-1"
+            >
+              {itemById(id)?.name ?? "Unknown"}
+              <IconButton
+                name="x"
+                size={28}
+                iconSize={14}
+                aria-label="Remove ingredient"
+                onClick={() => removeIngredient(id)}
+              />
+            </span>
+          ))}
+          <Chip
+            icon="plus"
+            leadingCheck={false}
+            onClick={() => {
+              ingredientQuery.value = "";
+              pickerOpen.value = true;
+            }}
+          >
+            Add ingredient
+          </Chip>
+        </div>
+      </div>
+
+      {/* Tags — one chip group per dimension */}
+      {localGroups.value.map((g) => (
+        <div key={g.id}>
+          <div class="md-label-medium uppercase text-on-surface-variant mb-2">
+            {g.label}
+          </div>
+          <div class="flex flex-wrap gap-2 items-center">
+            {g.values.map((v) => (
+              <Chip
+                key={v.id}
+                selected={tagValueIds.value.includes(v.id)}
+                leadingCheck={false}
+                onClick={() => toggleTag(v.id)}
+              >
+                {v.label}
+              </Chip>
+            ))}
+            {newValueFor.value === g.id
+              ? (
+                <span class="inline-flex items-center gap-2">
+                  <input
+                    value={newValueLabel.value}
+                    onInput={(e) => (newValueLabel.value = e.currentTarget.value)}
+                    placeholder="New value"
+                    class="md-body-large bg-surface-chighest rounded-t-[var(--md-shape-sm)] border-0 border-b-2 border-primary px-3 py-1.5 focus:outline-none"
+                  />
+                  <Button
+                    variant="filled"
+                    disabled={!newValueLabel.value.trim()}
+                    onClick={async () => {
+                      await addValue(g.id, newValueLabel.value.trim());
+                      newValueFor.value = null;
+                      newValueLabel.value = "";
+                    }}
+                  >
+                    Add
+                  </Button>
+                </span>
+              )
+              : (
+                <Chip
+                  icon="plus"
+                  leadingCheck={false}
+                  onClick={() => {
+                    newValueFor.value = g.id;
+                    newValueLabel.value = "";
+                  }}
+                >
+                  New
+                </Chip>
+              )}
+          </div>
+        </div>
+      ))}
+
+      {/* Save / Delete */}
+      <div class="flex flex-col gap-3 pt-2">
+        <Button
+          variant="filled"
+          disabled={!name.value.trim() || saving.value}
+          onClick={save}
+        >
+          {dish ? "Save changes" : "Create dish"}
+        </Button>
+        {dish && (
+          <Button variant="error" icon="trash" onClick={remove}>
+            Delete dish
+          </Button>
+        )}
+      </div>
+
+      {/* Ingredient picker — search the catalogue, or create a new item inline */}
+      <Sheet
+        open={pickerOpen.value}
+        onClose={() => (pickerOpen.value = false)}
+        title="Add ingredient"
+        size="large"
+      >
+        <div class="flex items-center gap-2 bg-surface-chighest rounded-[var(--md-shape-full)] h-12 pl-4 pr-1.5 mb-3">
+          <Icon name="search" size={20} class="text-on-surface-variant" />
+          <input
+            value={ingredientQuery.value}
+            onInput={(e) => (ingredientQuery.value = e.currentTarget.value)}
+            placeholder="Search or add an item"
+            class="flex-1 min-w-0 bg-transparent border-0 outline-none md-body-large text-on-surface"
+          />
+        </div>
+        {q && !exactMatch && (
+          <Pressable
+            onClick={async () => {
+              await createCatalogueItem(ingredientQuery.value.trim());
+              ingredientQuery.value = "";
+            }}
+            color="var(--md-primary)"
+            class="flex items-center gap-2.5 w-full text-left border-[1.5px] border-dashed border-outline rounded-[var(--md-shape-md)] px-4 py-3 text-primary md-label-large mb-2"
+          >
+            <Icon name="plus" size={20} stroke={2.3} /> Create “{ingredientQuery
+              .value.trim()}”
+          </Pressable>
+        )}
+        <div class="max-h-[360px] overflow-y-auto -mx-1">
+          {results.map((it) => (
+            <ListItem
+              key={it.id}
+              headline={it.name}
+              onClick={() => addIngredient(it.id)}
+              trailing={<Icon name="plus" size={20} class="text-primary" />}
+            />
+          ))}
+        </div>
+      </Sheet>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `deno test --unstable-kv -A islands/dishes/DishEditor.test.tsx`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Create the two editor routes**
+
+`routes/menu/new.tsx`:
+```tsx
+import { page } from "fresh";
+import { DishTagGroupRepo, ItemRepo } from "@/database/index.ts";
+import DishEditor from "@/islands/dishes/DishEditor.tsx";
+import { define } from "@/utils/index.ts";
+
+export const handler = define.handlers({
+  async GET(ctx) {
+    await DishTagGroupRepo.ensureDefaults();
+    ctx.state.appBar = { mode: "detail", title: "New dish", backUrl: "/menu" };
+    const [tagGroups, items] = await Promise.all([
+      DishTagGroupRepo.getAll(),
+      ItemRepo.readAll(),
+    ]);
+    return page({ tagGroups, items });
+  },
+});
+
+export default define.page<typeof handler>(function NewDishPage({ data }) {
+  return (
+    <main class="max-w-md mx-auto">
+      <DishEditor tagGroups={data.tagGroups} items={data.items} />
+    </main>
+  );
+});
+```
+
+`routes/menu/[id]/index.tsx`:
+```tsx
+import { page } from "fresh";
+import { DishRepo, DishTagGroupRepo, ItemRepo } from "@/database/index.ts";
+import DishEditor from "@/islands/dishes/DishEditor.tsx";
+import { define } from "@/utils/index.ts";
+
+export const handler = define.handlers({
+  async GET(ctx) {
+    const dish = await DishRepo.getById(ctx.params.id);
+    if (!dish) return new Response("Not found", { status: 404 });
+    await DishTagGroupRepo.ensureDefaults();
+    ctx.state.appBar = { mode: "detail", title: dish.name, backUrl: "/menu" };
+    const [tagGroups, items] = await Promise.all([
+      DishTagGroupRepo.getAll(),
+      ItemRepo.readAll(),
+    ]);
+    return page({ dish, tagGroups, items });
+  },
+});
+
+export default define.page<typeof handler>(function DishDetailPage({ data }) {
+  return (
+    <main class="max-w-md mx-auto">
+      <DishEditor
+        dish={data.dish}
+        tagGroups={data.tagGroups}
+        items={data.items}
+      />
+    </main>
+  );
+});
+```
+
+- [ ] **Step 6: Verify the full test suite + type check pass**
+
+Run: `deno test --unstable-kv -A`
+Expected: PASS (all existing tests + the new dish tests).
+
+Run: `deno task check`
+Expected: no format/lint/type errors. Fix any `deno fmt`/lint issues and re-run.
+
+- [ ] **Step 7: Format + commit**
+
+```bash
+deno fmt islands/dishes routes/menu
+git add islands/dishes/DishEditor.tsx islands/dishes/DishEditor.test.tsx routes/menu/new.tsx "routes/menu/[id]/index.tsx"
+git commit -m "feat(menu): full-screen dish editor with create, edit, delete"
+```
+
+---
+
+### Task 7: Full-suite gates + live verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run all gates**
+
+```bash
+deno task check
+deno task test
+deno task build
+```
+Expected: all green. If `deno task check` reports format issues, run `deno fmt` and re-commit; fix any lint/type errors surfaced.
+
+- [ ] **Step 2: Live end-to-end verification (browser preview)**
+
+Start the dev server via the preview tooling (do NOT use raw `deno task dev` in a blocking shell — use the preview_start browser tool with the project's dev config; seed/login per the existing browser-e2e steps). Then exercise the full loop and capture evidence:
+1. Navigate to `/menu` → the dish catalogue renders (not `ComingSoon`); the three seeded tag groups (Type/Meal/Side type) show as filter rails.
+2. Tap the **Add dish** FAB → `/menu/new` opens full-screen with a back arrow titled "New dish".
+3. Enter a name; open **Add ingredient**, search the catalogue, add one existing item, and create a brand-new item inline (verify it becomes a selected ingredient chip).
+4. Select one value in **Type** and one in **Meal**; use **+ New** to add a value to a group and confirm it is selected.
+5. Tap **Create dish** → returns to `/menu`; the new dish tile appears.
+6. Filter by name and by a tag value (verify OR-within-group / AND-across-groups behaviour); clear filters.
+7. Open the dish → edit the name and toggle a tag → **Save changes** → verify the change on `/menu`.
+8. Open the dish → **Delete dish** → verify it disappears from `/menu`.
+9. Check `read_console_messages` / `preview_logs` for errors; capture a screenshot of `/menu` with dishes.
+
+- [ ] **Step 3: Final commit if any fixes were needed**
+
+```bash
+git add -A
+git commit -m "fix(menu): address issues found during live verification"
+```
+(Skip if step 1–2 required no changes.)
+
+---
+
+## Notes for the implementer
+
+- **Fresh 2 confirmation:** the API route uses a plain handler object (`{ GET, POST, DELETE }` taking `Context<unknown>`), matching `routes/api/shopping/catalogue.ts`; pages/handlers use `define.handlers` + `define.page` + `page()`, matching `routes/shopping/[id]/add.tsx`. Confirm via Context7 (`@fresh/core@^2.2.0`) if anything fails to type-check.
+- **Shared in-memory KV in tests:** the process-wide KV singleton is reused across tests in a file, so every repo/handler test clears its prefix (`["dishes"]` / `["dish_tag_groups"]`) before asserting, and uses `sanitizeResources: false` (the singleton is never closed by design).
+- **Signals discipline:** `useDishes` uses bare `signal()` and is therefore called once via `useMemo(() => useDishes(...), [])` in `DishCatalogue` (the `useCatalogue` pattern). `DishEditor` holds only local form state, so it uses `useSignal()` directly.
+- **Navigation highlight:** `resolveActiveTab` already prefix-matches `/menu/*` to the Menu tab, so no `config/navigation.ts` change is needed.
+- **Delete UX:** in v1 a dish is deleted from the **editor** (`/menu/[id]` → "Delete dish"), which satisfies the "delete a dish" acceptance criterion without cluttering the grid or risking accidental taps. The `useDishes.removeDish` optimistic primitive is intentionally retained and unit-tested even though the list grid doesn't surface it yet — it's the basis for a future swipe/long-press-to-delete affordance on the list. Leaving it unused by the list UI is deliberate, not an oversight.
+```

--- a/docs/superpowers/specs/2026-07-26-dish-catalogue-design.md
+++ b/docs/superpowers/specs/2026-07-26-dish-catalogue-design.md
@@ -1,0 +1,296 @@
+# Dish Catalogue Management (CRUD) — Design
+
+**Date:** 2026-07-26
+**Status:** Draft (awaiting review)
+**Issue:** #39 (Add Dish Catalogue Management — CRUD Operations)
+**Module:** Menu planner (`/menu`) — currently a `ComingSoon` placeholder
+**Follow-ups spun out:** #42 (household scoping), #43 (full tag-group management)
+
+---
+
+## 1. Problem & context
+
+Issue #39 asks for a central **catalogue of dishes** with full CRUD, as the
+foundation for the meal-suggestion system in #14. A dish has:
+
+- **Name**
+- **Ingredients** — items from the shopping catalogue, so a future meal plan can
+  push a dish's ingredients onto a shopping list.
+- **Tags** — characteristics grouped by dimension for organising and filtering:
+  Type (Vegetarian/Fish/Meat), Meal (Main dish/Breakfast/Lunch/Side dish),
+  Side type (Rice/Potatoes/Pasta).
+
+The **Menu** tab already exists in the bottom navigation (`config/navigation.ts`,
+id `menu`, route `/menu`) and renders `ComingSoon`. #14 ("Add Dish Management and
+Meal Suggestion Feature") is the parent; this feature builds the dish-management
+half. The suggestion engine stays in #14.
+
+The shopping **Catalogue** (`islands/catalogue.tsx`, `hooks/useCatalogue.ts`,
+`ItemRepo`, `CategoryRepo`, `routes/api/shopping/catalogue.ts`) is a close analog
+and the template for this feature's stack.
+
+## 2. Goals / non-goals
+
+**Goals**
+- Full CRUD for dishes: create, list, view details, update, delete.
+- Structured **tags** modelled as named groups (dimensions) with values; a dish
+  selects any number of values across groups.
+- **Ingredients** as references to existing catalogue items; add a brand-new
+  catalogue item inline while editing a dish.
+- **Filter** the dish list by name (search) and by tag values.
+- Seed three default tag groups on first use; allow adding a **value** to an
+  existing group inline.
+- Replace the `/menu` `ComingSoon` placeholder with the dish catalogue.
+- Reuse existing conventions: repos, `services/api.ts`, MD3 components, the
+  optimistic-signals hook pattern, `beginBusy/endBusy` loading, `appBarAction`.
+
+**Non-goals (v1)**
+- Meal suggestion / weekly planning (#14).
+- Per-household scoping of dishes/tags — stored globally like the existing
+  catalogue (`items`/`categories`). Deferred to **#42**.
+- Creating/renaming/deleting whole tag **groups**, and renaming/deleting tag
+  **values**. v1 ships seeded groups + inline add-value only. Deferred to **#43**.
+- Per-ingredient **quantities/amounts** — ingredients are item references only.
+- Adding a dish's ingredients to a shopping list (a #14 concern; the data model
+  makes it possible).
+- Dish images, ratings, notes/recipe steps.
+
+## 3. Product alignment
+
+Happie is a household manager; the shopping list is the first module and the
+Menu planner is the next. The dish catalogue is a **shared household library**
+(like the shopping catalogue) that each member contributes to. UX stays warm and
+simple: pick from chips, tap to add, no clinical forms. Mobile-first — a
+full-screen editor keeps the richer dish form comfortable on a phone.
+
+## 4. Data model
+
+New model directory `models/dish/`, exported from `models/index.ts`.
+
+```ts
+// models/dish/dish.interface.ts
+export interface DishInterface {
+  id: string;
+  name: string;
+  ingredientIds: string[]; // → catalogue Item ids (["items", id])
+  tagValueIds: string[];   // → DishTagValue ids, flat across all groups
+  createdAt?: string;
+  createdBy?: string;
+}
+export type CreateDishDto = Omit<DishInterface, "id">;
+export type UpdateDishDto =
+  & Pick<DishInterface, "id">
+  & Partial<Omit<DishInterface, "id">>;
+
+// models/dish/dish-tag-group.interface.ts
+export interface DishTagValueInterface {
+  id: string;
+  label: string;
+}
+export interface DishTagGroupInterface {
+  id: string;
+  label: string;                    // "Type", "Meal", "Side type"
+  order?: number;
+  values: DishTagValueInterface[];  // values embedded in the group
+}
+```
+
+**Rationale**
+- A dish stores a **flat** `tagValueIds`; a value's group is derived by looking
+  it up in the groups collection. Embedding values inside the group keeps a group
+  to one KV entry (groups are small, read together).
+- `ingredientIds` reference catalogue `Item`s — the same entities shopping lists
+  reference — which is exactly what a later "add dish to list" flow needs.
+- Field/DTO shape mirrors `ItemInterface`/`CategoryInterface` for consistency.
+
+**KV keys** (global, matching the existing catalogue; see #42):
+- `["dishes", id]`
+- `["dish_tag_groups", id]`
+
+## 5. Default tag groups & seeding
+
+`DishTagGroupRepo.ensureDefaults()` creates the following if the collection is
+empty (idempotent — no-op when any group exists). Called by the `/menu` GET
+handler before reading, so the feature is useful immediately without a re-seed.
+
+| Group (order) | Values |
+| --- | --- |
+| Type (0) | Vegetarian, Fish, Meat |
+| Meal (1) | Main dish, Breakfast, Lunch, Side dish |
+| Side type (2) | Rice, Potatoes, Pasta |
+
+Value and group ids are `crypto.randomUUID()`. Labels are the seed defaults;
+adding a value is the only mutation in v1 (§7). Full management → #43.
+
+## 6. Architecture
+
+### 6.1 Repositories
+
+`database/dish.repo.ts` — mirrors `ItemRepo`/`CategoryRepo`:
+- `create(dish: CreateDishDto)` → assigns id + `createdAt`, atomic set.
+- `readAll()` → all dishes.
+- `getById(id)`.
+- `update(id, patch)` → `mergeDefinedPatch(existing, patch)` (partial-safe, like
+  `CategoryRepo.update`), returns updated or `null` if missing.
+- `delete(id)`.
+
+`database/dish-tag-group.repo.ts`:
+- `ensureDefaults()` → seed if empty (idempotent).
+- `getAll()` → groups sorted by `order`.
+- `getById(id)`.
+- `addValue(groupId, label)` → append a `{ id, label }` value to the group,
+  return the created value (used by inline "+ New").
+
+Both exported from `database/index.ts`.
+
+> **Research note (per CLAUDE.md):** confirm Fresh 2 handler signatures and Deno
+> KV atomic APIs via Context7 during implementation before writing route/repos.
+
+### 6.2 API routes (mirror `routes/api/shopping/catalogue.ts`)
+
+- `routes/api/menu/dishes.ts`
+  - `GET` → all dishes (JSON).
+  - `POST` → create when no `id`; update when `id` present (404 if missing).
+    Returns the saved dish. (Same create-or-update-on-POST shape as
+    `catalogue.ts`.)
+  - `DELETE` → `{ id }` body → delete (400 if no id, 204 on success).
+- `routes/api/menu/tag-groups.ts`
+  - `GET` → all groups (after `ensureDefaults`).
+  - `POST` → `{ groupId, label }` → add a value, return the created value (201).
+
+Handlers derive nothing household-specific in v1 (global store; see #42). Auth is
+already enforced by `_middleware.ts` (401 for `/api/*` when unauthenticated).
+
+### 6.3 Client service (`services/api.ts`)
+
+Add, mirroring `api.items`:
+
+```ts
+api.dishes = {
+  getAll(): Promise<DishInterface[]>,
+  create(dish: CreateDishDto): Promise<DishInterface | null>,
+  update(id, patch: Partial<DishInterface>): Promise<DishInterface | null>,
+  delete(id): Promise<void>,
+};
+api.dishTagGroups = {
+  getAll(): Promise<DishTagGroupInterface[]>,
+  addValue(groupId, label): Promise<DishTagValueInterface | null>,
+};
+```
+
+### 6.4 Hook (`hooks/useDishes.ts`) — list surface only
+
+Mirrors `useCatalogue`: `signal`s for `dishes` and `tagGroups`, computed helpers,
+`beginBusy/endBusy` on each in-flight write.
+
+- `filtered` (computed) — dishes matching the name query **and** the selected
+  tag-value filters, using faceted semantics: **OR within a group, AND across
+  groups** (e.g. selecting Type=Vegetarian + Meal=Main dish → vegetarian mains;
+  selecting Type=Vegetarian + Type=Fish → vegetarian *or* fish). Implemented by
+  grouping selected value ids by their group; a dish matches when, for every
+  group that has any selected value, the dish holds at least one of them.
+- `removeDish(id)` — optimistic remove + `api.dishes.delete`.
+- `refresh()` — reload dishes + tag groups (for pull-to-refresh).
+- Selection/query state for the filter UI (name query signal, selected
+  tag-value id set).
+
+The **editor** does not use this hook; it owns local form state and SSR-loads its
+own data per route (roomier, no shared in-memory state between islands — same
+approach as `add-items.tsx`). Create/edit/delete then navigate back to `/menu`,
+which re-renders fresh from the server.
+
+### 6.5 Routes & islands
+
+**List — `routes/menu/index.tsx`** (replaces `ComingSoon`):
+- `define.handlers` GET: `DishTagGroupRepo.ensureDefaults()`, then load
+  `dishes`, `tagGroups`, and catalogue `items` (to resolve ingredient names for
+  display). `page({ dishes, tagGroups, items })`.
+- Renders `islands/dishes/DishCatalogue.tsx`.
+
+`DishCatalogue` island (uses `useDishes`), top → bottom:
+- **Search field** (filter by name) — same rounded search input as the catalogue.
+- **Tag filter rail** — chips grouped by dimension; tapping toggles a value
+  filter (multi-select). A "clear filters" affordance when any is active.
+- **Dish grid** — tiles showing the dish name (and a small ingredient/tag hint).
+  Tap a tile → `/menu/{id}`. Empty state ("No dishes yet") + an add affordance.
+- **FAB** (`islands/shell/Fab.tsx` / `FabMenu` pattern) → navigate to
+  `/menu/new`.
+- Wrapped in `PullToRefresh` (`onRefresh={refresh}`), like the catalogue.
+
+**Editor — `routes/menu/new.tsx` and `routes/menu/[id]/index.tsx`**:
+- GET sets `ctx.state.appBar = { mode: "detail", title, backUrl: "/menu" }`
+  (title "New dish" / the dish name). Loads `tagGroups` + catalogue `items`; the
+  `[id]` route also loads the dish (404 if missing).
+- Renders `islands/dishes/DishEditor.tsx` with the dish (or blank), tag groups,
+  and catalogue items.
+
+`DishEditor` island (local `useSignal` form state):
+- **Name** field.
+- **Ingredients** — chips of chosen catalogue items + "Add ingredient" opens a
+  searchable catalogue picker (reuse/adapt `CategoryPickerList`/search patterns).
+  A no-match "Create '‹query›'" affordance creates a catalogue item via
+  `api.items.create` and selects it. Selected ingredients removable via chip.
+- **Tags** — one chip group per dimension (multi-select values); a "+ New" chip
+  per group adds a value inline via `api.dishTagGroups.addValue` and selects it.
+- **Save** — a trailing app-bar action set via the module-scope `appBarAction`
+  signal (set on mount, cleared on unmount, as documented in `utils/app-bar.ts`);
+  POSTs create/update, then `navigateTo("/menu")`.
+- **Delete** (edit route only) — an error-styled button; deletes then returns to
+  `/menu`.
+
+Navigation: `resolveActiveTab` already maps `/menu` and `/menu/*` to the Menu
+tab (prefix match), so the bottom nav highlights correctly on all sub-routes.
+
+## 7. Tag management scope (v1 vs #43)
+
+- **v1:** seeded groups (§5) + add a **value** to an existing group inline from
+  the editor.
+- **#43 (deferred):** create/rename/delete tag **groups**; rename/delete tag
+  **values**; reference cleanup on delete (strip removed `tagValueId`s from
+  dishes, warn about affected dishes — mirroring the catalogue's "N items become
+  uncategorized" pattern).
+
+## 8. File plan (for the implementation plan to expand)
+
+- **Create:** `models/dish/{index.ts,dish.interface.ts,dish-tag-group.interface.ts}`;
+  export from `models/index.ts`.
+- **Create:** `database/dish.repo.ts`, `database/dish-tag-group.repo.ts`; export
+  from `database/index.ts`.
+- **Create:** `routes/api/menu/dishes.ts`, `routes/api/menu/tag-groups.ts`.
+- **Create:** `hooks/useDishes.ts` (export from `hooks/index.ts` if present).
+- **Create:** `islands/dishes/DishCatalogue.tsx`, `islands/dishes/DishEditor.tsx`.
+- **Create:** `routes/menu/new.tsx`, `routes/menu/[id]/index.tsx`.
+- **Modify:** `routes/menu/index.tsx` (replace `ComingSoon` with the list).
+- **Modify:** `services/api.ts` (`api.dishes`, `api.dishTagGroups`).
+- **Reuse (no change):** `components/md3/*` (Chip, Sheet, Segmented, Button,
+  IconButton, Icon, ListItem, Pressable, FabMenu, PullToRefresh),
+  `utils/app-bar.ts`, `utils/loading.ts`, `ItemRepo`, `mergeDefinedPatch`.
+
+## 9. Testing
+
+Matching existing conventions (`--unstable-kv -A` for KV-backed repo tests):
+- **Repo tests** (like `shopping-list-item.repo.test.ts`): dish CRUD incl.
+  partial `update`; tag-group `ensureDefaults` **idempotency** + `addValue`.
+- **Hook test** (like `useCatalogue.test.ts`): `useDishes` name+tag filtering
+  (OR-within-group / AND-across-groups semantics) and optimistic `removeDish`.
+- **Island render tests** (preact-render-to-string, like `catalogue.test.tsx`):
+  `DishCatalogue` (renders dishes, filter chips, empty state) and `DishEditor`
+  (renders name/ingredients/tags, and delete only on the edit route).
+- **Gates:** `deno task check`, `deno task test`, `deno task build` all green.
+- **Live verification** (mobile viewport): create a dish with ingredients + tags
+  → appears on `/menu` → filter by name and by tag → open → edit → delete.
+
+## 10. Risks & open points
+
+- **Seeding on read path:** `ensureDefaults()` runs in the `/menu` GET handler.
+  It's idempotent and cheap, but a first-visit write on a GET is a mild wart;
+  acceptable for a single seed. Alternative (add to `db:seed`) rejected to keep
+  the feature self-contained.
+- **Ingredient/tag reference integrity:** deleting a catalogue item leaves
+  dangling `ingredientId`s on dishes (the list resolves names defensively and
+  skips unknown ids). Full cleanup is out of scope; note for #43/#42.
+- **Global storage:** intentional for consistency with the existing catalogue;
+  per-household isolation tracked in #42.
+- **Editor Save affordance:** app-bar trailing action vs an in-form button —
+  design uses the app-bar action (matches list-detail "options" precedent); a
+  bottom Save button is an easy alternative if it reads better on device.

--- a/hooks/useDishes.test.ts
+++ b/hooks/useDishes.test.ts
@@ -63,12 +63,39 @@ Deno.test("clearFilters — removes all selected tag values", () => {
 
 Deno.test("removeDish — optimistically removes and calls the API", async () => {
   const del = stub(api.dishes, "delete", () => Promise.resolve());
+  const hook = useDishes([dish("1", "A"), dish("2", "B")], []);
   try {
-    const hook = useDishes([dish("1", "A"), dish("2", "B")], []);
     await hook.removeDish("1");
     assertEquals(hook.dishes.value.map((d) => d.id), ["2"]);
     assertEquals(del.calls.length, 1);
   } finally {
     del.restore();
   }
+});
+
+Deno.test("refresh — re-pulls dishes and tag groups from the API", async () => {
+  const hook = useDishes(
+    [dish("1", "Old Dish", ["veg"])],
+    [group("type", "Type", [["veg", "Vegetarian"]])],
+  );
+
+  const dishesStub = stub(
+    api.dishes,
+    "getAll",
+    () => Promise.resolve([dish("2", "Pasta"), dish("3", "Curry")]),
+  );
+  const groupsStub = stub(
+    api.dishTagGroups,
+    "getAll",
+    () => Promise.resolve([group("meal", "Meal", [["main", "Main dish"]])]),
+  );
+  try {
+    await hook.refresh();
+  } finally {
+    dishesStub.restore();
+    groupsStub.restore();
+  }
+
+  assertEquals(hook.dishes.value.map((d) => d.name), ["Pasta", "Curry"]);
+  assertEquals(hook.tagGroups.value.map((g) => g.label), ["Meal"]);
 });

--- a/hooks/useDishes.test.ts
+++ b/hooks/useDishes.test.ts
@@ -1,0 +1,74 @@
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import { stub } from "jsr:@std/testing@^1.0.18/mock";
+import { api } from "@/services/api.ts";
+import { useDishes } from "@/hooks/useDishes.ts";
+import type { DishInterface, DishTagGroupInterface } from "@/models/index.ts";
+
+const dish = (
+  id: string,
+  name: string,
+  tagValueIds: string[] = [],
+): DishInterface => ({ id, name, ingredientIds: [], tagValueIds });
+
+const group = (
+  id: string,
+  label: string,
+  values: [string, string][],
+  order = 0,
+): DishTagGroupInterface => ({
+  id,
+  label,
+  order,
+  values: values.map(([vid, l]) => ({ id: vid, label: l })),
+});
+
+Deno.test("filtered — case-insensitive name query", () => {
+  const hook = useDishes(
+    [dish("1", "Pasta Bolognese"), dish("2", "Veggie Curry")],
+    [],
+  );
+  hook.query.value = "curry";
+  assertEquals(hook.filtered.value.map((d) => d.name), ["Veggie Curry"]);
+});
+
+Deno.test("filtered — OR within a group, AND across groups", () => {
+  const groups = [
+    group("type", "Type", [["veg", "Vegetarian"], ["fish", "Fish"], [
+      "meat",
+      "Meat",
+    ]]),
+    group("meal", "Meal", [["main", "Main dish"], ["side", "Side dish"]], 1),
+  ];
+  const hook = useDishes([
+    dish("1", "Veg Main", ["veg", "main"]),
+    dish("2", "Fish Main", ["fish", "main"]),
+    dish("3", "Veg Side", ["veg", "side"]),
+    dish("4", "Meat Main", ["meat", "main"]),
+  ], groups);
+  hook.toggleTagValue("veg"); // Type: veg
+  hook.toggleTagValue("fish"); // Type: veg OR fish
+  hook.toggleTagValue("main"); // Meal: main  → (veg|fish) AND main
+  assertEquals(hook.filtered.value.map((d) => d.name), [
+    "Fish Main",
+    "Veg Main",
+  ]);
+});
+
+Deno.test("clearFilters — removes all selected tag values", () => {
+  const hook = useDishes([dish("1", "A", ["veg"])], []);
+  hook.toggleTagValue("veg");
+  hook.clearFilters();
+  assertEquals(hook.selectedTagValueIds.value.size, 0);
+});
+
+Deno.test("removeDish — optimistically removes and calls the API", async () => {
+  const del = stub(api.dishes, "delete", () => Promise.resolve());
+  try {
+    const hook = useDishes([dish("1", "A"), dish("2", "B")], []);
+    await hook.removeDish("1");
+    assertEquals(hook.dishes.value.map((d) => d.id), ["2"]);
+    assertEquals(del.calls.length, 1);
+  } finally {
+    del.restore();
+  }
+});

--- a/hooks/useDishes.ts
+++ b/hooks/useDishes.ts
@@ -1,0 +1,102 @@
+import { computed, signal } from "@preact/signals";
+import type { DishInterface, DishTagGroupInterface } from "@/models/index.ts";
+import { api } from "@/services/api.ts";
+import { beginBusy, endBusy } from "@/utils/loading.ts";
+
+export function useDishes(
+  initialDishes: DishInterface[],
+  initialTagGroups: DishTagGroupInterface[],
+) {
+  const dishes = signal<DishInterface[]>(initialDishes ?? []);
+  const tagGroups = signal<DishTagGroupInterface[]>(initialTagGroups ?? []);
+  const query = signal("");
+  const selectedTagValueIds = signal<Set<string>>(new Set());
+  const pendingCount = signal(0);
+
+  const startPending = () => {
+    pendingCount.value++;
+    beginBusy();
+  };
+  const endPending = () => {
+    pendingCount.value--;
+    endBusy();
+  };
+
+  const filtered = computed<DishInterface[]>(() => {
+    const q = query.value.trim().toLowerCase();
+    const selected = selectedTagValueIds.value;
+
+    // Map each selectable value id → its group id, then bucket the *selected*
+    // ids by group so we can require a match within each active group (OR)
+    // while requiring every active group to match (AND).
+    const valueToGroup = new Map<string, string>();
+    for (const g of tagGroups.value) {
+      for (const v of g.values) valueToGroup.set(v.id, g.id);
+    }
+    const byGroup = new Map<string, Set<string>>();
+    for (const vid of selected) {
+      const gid = valueToGroup.get(vid);
+      if (!gid) continue;
+      if (!byGroup.has(gid)) byGroup.set(gid, new Set());
+      byGroup.get(gid)!.add(vid);
+    }
+
+    return dishes.value
+      .filter((d) => {
+        if (q && !d.name.toLowerCase().includes(q)) return false;
+        for (const [, valueIds] of byGroup) {
+          if (!d.tagValueIds.some((t) => valueIds.has(t))) return false;
+        }
+        return true;
+      })
+      .sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+  });
+
+  const toggleTagValue = (valueId: string) => {
+    const next = new Set(selectedTagValueIds.value);
+    if (next.has(valueId)) next.delete(valueId);
+    else next.add(valueId);
+    selectedTagValueIds.value = next;
+  };
+
+  const clearFilters = () => {
+    selectedTagValueIds.value = new Set();
+  };
+
+  const removeDish = async (id: string): Promise<void> => {
+    dishes.value = dishes.value.filter((d) => d.id !== id);
+    startPending();
+    try {
+      await api.dishes.delete(id);
+    } finally {
+      endPending();
+    }
+  };
+
+  const refresh = async (): Promise<void> => {
+    pendingCount.value++;
+    try {
+      const [d, g] = await Promise.all([
+        api.dishes.getAll(),
+        api.dishTagGroups.getAll(),
+      ]);
+      dishes.value = d;
+      tagGroups.value = g;
+    } finally {
+      pendingCount.value--;
+    }
+  };
+
+  return {
+    dishes,
+    tagGroups,
+    query,
+    selectedTagValueIds,
+    pendingCount,
+    filtered,
+    toggleTagValue,
+    clearFilters,
+    removeDish,
+    refresh,
+  };
+}

--- a/islands/dishes/DishCatalogue.test.tsx
+++ b/islands/dishes/DishCatalogue.test.tsx
@@ -1,0 +1,47 @@
+import { assertStringIncludes } from "jsr:@std/assert@^1.0.19";
+import { render } from "npm:preact-render-to-string@^6.6.3";
+import { h } from "preact";
+import DishCatalogue from "./DishCatalogue.tsx";
+
+Deno.test("DishCatalogue — renders dishes, tag filter groups, and the add FAB", () => {
+  const html = render(h(DishCatalogue, {
+    initialDishes: [
+      {
+        id: "1",
+        name: "Pasta Bolognese",
+        ingredientIds: ["a", "b"],
+        tagValueIds: ["meat"],
+      },
+      {
+        id: "2",
+        name: "Veggie Curry",
+        ingredientIds: ["c"],
+        tagValueIds: ["veg"],
+      },
+    ],
+    initialTagGroups: [
+      {
+        id: "type",
+        label: "Type",
+        order: 0,
+        values: [{ id: "veg", label: "Vegetarian" }, {
+          id: "meat",
+          label: "Meat",
+        }],
+      },
+    ],
+  }));
+  assertStringIncludes(html, "Pasta Bolognese");
+  assertStringIncludes(html, "Veggie Curry");
+  assertStringIncludes(html, "Type"); // group label
+  assertStringIncludes(html, "Vegetarian"); // value chip
+  assertStringIncludes(html, "Add dish"); // FAB label
+});
+
+Deno.test("DishCatalogue — empty state prompts adding a dish", () => {
+  const html = render(h(DishCatalogue, {
+    initialDishes: [],
+    initialTagGroups: [],
+  }));
+  assertStringIncludes(html, "No dishes yet");
+});

--- a/islands/dishes/DishCatalogue.tsx
+++ b/islands/dishes/DishCatalogue.tsx
@@ -1,0 +1,156 @@
+import { useMemo } from "preact/hooks";
+import type { DishInterface, DishTagGroupInterface } from "@/models/index.ts";
+import { useDishes } from "@/hooks/useDishes.ts";
+import { PullToRefresh } from "@/components/md3/PullToRefresh.tsx";
+import { Chip } from "@/components/md3/Chip.tsx";
+import { Icon } from "@/components/md3/Icon.tsx";
+import { IconButton } from "@/components/md3/IconButton.tsx";
+import { Pressable } from "@/components/md3/Pressable.tsx";
+import { Button } from "@/components/md3/Button.tsx";
+import { navigateTo } from "@/utils/loading.ts";
+
+interface Props {
+  initialDishes: DishInterface[];
+  initialTagGroups: DishTagGroupInterface[];
+}
+
+export default function DishCatalogue(
+  { initialDishes, initialTagGroups }: Props,
+) {
+  // useMemo([]) so the hook's signals are created once from SSR props.
+  const {
+    dishes,
+    tagGroups,
+    query,
+    selectedTagValueIds,
+    filtered,
+    toggleTagValue,
+    clearFilters,
+    refresh,
+  } = useMemo(() => useDishes(initialDishes, initialTagGroups), []);
+
+  const groups = tagGroups.value;
+  const selected = selectedTagValueIds.value;
+  const list = filtered.value;
+
+  return (
+    <PullToRefresh onRefresh={refresh}>
+      <div class="px-4 pt-4 pb-[calc(96px+env(safe-area-inset-bottom))] flex flex-col gap-4">
+        {/* search */}
+        <div class="flex items-center gap-2 bg-surface-chighest rounded-[var(--md-shape-full)] h-12 pl-4 pr-1.5">
+          <Icon name="search" size={20} class="text-on-surface-variant" />
+          <input
+            value={query.value}
+            onInput={(e) => (query.value = e.currentTarget.value)}
+            placeholder="Search dishes"
+            class="flex-1 min-w-0 bg-transparent border-0 outline-none md-body-large text-on-surface"
+          />
+          {query.value && (
+            <IconButton
+              name="x"
+              size={36}
+              iconSize={18}
+              aria-label="Clear search"
+              onClick={() => (query.value = "")}
+            />
+          )}
+        </div>
+
+        {/* tag filter rail — one row of chips per dimension */}
+        {groups.map((g) => (
+          <div key={g.id} class="flex flex-col gap-1.5">
+            <div class="md-label-medium uppercase text-on-surface-variant px-1">
+              {g.label}
+            </div>
+            <div class="flex gap-2 overflow-x-auto pr-1">
+              {g.values.map((v) => (
+                <Chip
+                  key={v.id}
+                  selected={selected.has(v.id)}
+                  leadingCheck={false}
+                  onClick={() => toggleTagValue(v.id)}
+                >
+                  {v.label}
+                </Chip>
+              ))}
+            </div>
+          </div>
+        ))}
+        {selected.size > 0 && (
+          <Pressable
+            onClick={clearFilters}
+            class="self-start md-label-large text-primary px-1"
+          >
+            Clear filters
+          </Pressable>
+        )}
+
+        {/* count */}
+        <div class="md-body-medium text-on-surface-variant px-1">
+          {list.length} dish{list.length === 1 ? "" : "es"}
+        </div>
+
+        {/* dish grid / empty state */}
+        {list.length === 0
+          ? (
+            <div class="px-2 pt-2 text-center flex flex-col items-center gap-4">
+              <div class="md-title-medium text-on-surface">
+                {dishes.value.length === 0
+                  ? "No dishes yet"
+                  : "No dishes match your filters"}
+              </div>
+              <Button
+                variant="tonal"
+                icon="plus"
+                onClick={() => navigateTo("/menu/new")}
+              >
+                Add a dish
+              </Button>
+            </div>
+          )
+          : (
+            <div class="grid grid-cols-2 gap-2.5">
+              {list.map((d) => (
+                <Pressable
+                  key={d.id}
+                  onClick={() => navigateTo(`/menu/${d.id}`)}
+                  class="flex flex-col gap-1 bg-surface border border-outline-variant rounded-[var(--md-shape-md)] px-4 py-3.5 text-left"
+                >
+                  <span class="md-body-large text-on-surface truncate">
+                    {d.name}
+                  </span>
+                  <span class="md-body-small text-on-surface-variant truncate">
+                    {d.ingredientIds.length}{" "}
+                    ingredient{d.ingredientIds.length ===
+                        1
+                      ? ""
+                      : "s"}
+                  </span>
+                </Pressable>
+              ))}
+            </div>
+          )}
+      </div>
+
+      {/* Add-dish FAB (styled like islands/shell/Fab.tsx, fixed above the nav) */}
+      <div
+        class="fixed right-4 z-40"
+        style={{ bottom: "calc(96px + env(safe-area-inset-bottom))" }}
+      >
+        <Pressable
+          onClick={() => navigateTo("/menu/new")}
+          aria-label="Add dish"
+          class="inline-flex items-center gap-3 bg-primary-container text-on-primary-container md-elevation-3"
+          style={{
+            height: 56,
+            borderRadius: "var(--md-shape-lg)",
+            padding: "0 20px",
+          }}
+        >
+          <Icon name="plus" size={24} />
+          <span class="md-label-large" style={{ fontSize: 15 }}>Add dish</span>
+        </Pressable>
+      </div>
+    </PullToRefresh>
+  );
+}

--- a/islands/dishes/DishCatalogue.tsx
+++ b/islands/dishes/DishCatalogue.tsx
@@ -7,6 +7,7 @@ import { Icon } from "@/components/md3/Icon.tsx";
 import { IconButton } from "@/components/md3/IconButton.tsx";
 import { Pressable } from "@/components/md3/Pressable.tsx";
 import { Button } from "@/components/md3/Button.tsx";
+import Fab from "@/islands/shell/Fab.tsx";
 import { navigateTo } from "@/utils/loading.ts";
 
 interface Props {
@@ -43,6 +44,7 @@ export default function DishCatalogue(
             value={query.value}
             onInput={(e) => (query.value = e.currentTarget.value)}
             placeholder="Search dishes"
+            aria-label="Search dishes"
             class="flex-1 min-w-0 bg-transparent border-0 outline-none md-body-large text-on-surface"
           />
           {query.value && (
@@ -132,24 +134,17 @@ export default function DishCatalogue(
           )}
       </div>
 
-      {/* Add-dish FAB (styled like islands/shell/Fab.tsx, fixed above the nav) */}
+      {/* Add-dish FAB — shared component, fixed below the nav chrome */}
       <div
-        class="fixed right-4 z-40"
+        class="fixed right-4 z-30"
         style={{ bottom: "calc(96px + env(safe-area-inset-bottom))" }}
       >
-        <Pressable
-          onClick={() => navigateTo("/menu/new")}
+        <Fab
+          icon="plus"
+          label="Add dish"
           aria-label="Add dish"
-          class="inline-flex items-center gap-3 bg-primary-container text-on-primary-container md-elevation-3"
-          style={{
-            height: 56,
-            borderRadius: "var(--md-shape-lg)",
-            padding: "0 20px",
-          }}
-        >
-          <Icon name="plus" size={24} />
-          <span class="md-label-large" style={{ fontSize: 15 }}>Add dish</span>
-        </Pressable>
+          onClick={() => navigateTo("/menu/new")}
+        />
       </div>
     </PullToRefresh>
   );

--- a/islands/dishes/DishEditor.test.tsx
+++ b/islands/dishes/DishEditor.test.tsx
@@ -1,0 +1,38 @@
+import { assertStringIncludes } from "jsr:@std/assert@^1.0.19";
+import { render } from "npm:preact-render-to-string@^6.6.3";
+import { h } from "preact";
+import DishEditor from "./DishEditor.tsx";
+
+const groups = [{
+  id: "type",
+  label: "Type",
+  order: 0,
+  values: [{ id: "veg", label: "Vegetarian" }],
+}];
+const items = [{ id: "a", name: "Onion" }];
+
+Deno.test("DishEditor — new dish renders name, tags, add-ingredient, create button", () => {
+  const html = render(h(DishEditor, { tagGroups: groups, items }));
+  assertStringIncludes(html, "Name");
+  assertStringIncludes(html, "Type"); // tag group label
+  assertStringIncludes(html, "Vegetarian"); // tag value chip
+  assertStringIncludes(html, "Add ingredient");
+  assertStringIncludes(html, "Create dish");
+});
+
+Deno.test("DishEditor — existing dish prefills name, shows ingredient chip + delete", () => {
+  const html = render(h(DishEditor, {
+    dish: {
+      id: "1",
+      name: "Pasta",
+      ingredientIds: ["a"],
+      tagValueIds: ["veg"],
+    },
+    tagGroups: groups,
+    items,
+  }));
+  assertStringIncludes(html, 'value="Pasta"'); // prefilled name field
+  assertStringIncludes(html, "Onion"); // resolved ingredient chip
+  assertStringIncludes(html, "Save changes");
+  assertStringIncludes(html, "Delete dish");
+});

--- a/islands/dishes/DishEditor.tsx
+++ b/islands/dishes/DishEditor.tsx
@@ -1,0 +1,262 @@
+import { useSignal } from "@preact/signals";
+import type {
+  DishInterface,
+  DishTagGroupInterface,
+  ItemInterface,
+} from "@/models/index.ts";
+import { api } from "@/services/api.ts";
+import { Chip } from "@/components/md3/Chip.tsx";
+import { Button } from "@/components/md3/Button.tsx";
+import { Icon } from "@/components/md3/Icon.tsx";
+import { IconButton } from "@/components/md3/IconButton.tsx";
+import { Sheet } from "@/components/md3/Sheet.tsx";
+import { Pressable } from "@/components/md3/Pressable.tsx";
+import { ListItem } from "@/components/md3/ListItem.tsx";
+import { navigateTo } from "@/utils/loading.ts";
+
+const fieldClass =
+  "flex-1 min-w-0 md-body-large text-on-surface bg-surface-chighest rounded-t-[var(--md-shape-sm)] border-0 border-b-2 border-primary px-4 py-3 focus:outline-none";
+
+interface Props {
+  dish?: DishInterface;
+  tagGroups: DishTagGroupInterface[];
+  items: ItemInterface[];
+}
+
+export default function DishEditor({ dish, tagGroups, items }: Props) {
+  const name = useSignal(dish?.name ?? "");
+  const ingredientIds = useSignal<string[]>(dish?.ingredientIds ?? []);
+  const tagValueIds = useSignal<string[]>(dish?.tagValueIds ?? []);
+  const localItems = useSignal<ItemInterface[]>(items);
+  const localGroups = useSignal<DishTagGroupInterface[]>(tagGroups);
+  const pickerOpen = useSignal(false);
+  const ingredientQuery = useSignal("");
+  const newValueFor = useSignal<string | null>(null);
+  const newValueLabel = useSignal("");
+  const saving = useSignal(false);
+
+  const itemById = (id: string) => localItems.value.find((i) => i.id === id);
+
+  const toggleTag = (valueId: string) => {
+    tagValueIds.value = tagValueIds.value.includes(valueId)
+      ? tagValueIds.value.filter((v) => v !== valueId)
+      : [...tagValueIds.value, valueId];
+  };
+  const addIngredient = (itemId: string) => {
+    if (!ingredientIds.value.includes(itemId)) {
+      ingredientIds.value = [...ingredientIds.value, itemId];
+    }
+  };
+  const removeIngredient = (itemId: string) => {
+    ingredientIds.value = ingredientIds.value.filter((i) => i !== itemId);
+  };
+  const createCatalogueItem = async (label: string) => {
+    const created = await api.items.create({ name: label });
+    if (created?.id) {
+      localItems.value = [...localItems.value, created];
+      addIngredient(created.id);
+    }
+  };
+  const addValue = async (groupId: string, label: string) => {
+    const created = await api.dishTagGroups.addValue(groupId, label);
+    if (created) {
+      localGroups.value = localGroups.value.map((g) =>
+        g.id === groupId ? { ...g, values: [...g.values, created] } : g
+      );
+      toggleTag(created.id);
+    }
+  };
+  const save = async () => {
+    const n = name.value.trim();
+    if (!n) return;
+    saving.value = true;
+    const payload = {
+      name: n,
+      ingredientIds: ingredientIds.value,
+      tagValueIds: tagValueIds.value,
+    };
+    if (dish) await api.dishes.update(dish.id, payload);
+    else await api.dishes.create(payload);
+    navigateTo("/menu");
+  };
+  const remove = async () => {
+    if (!dish) return;
+    await api.dishes.delete(dish.id);
+    navigateTo("/menu");
+  };
+
+  const q = ingredientQuery.value.trim().toLowerCase();
+  const chosen = new Set(ingredientIds.value);
+  const results = localItems.value
+    .filter((i) =>
+      !chosen.has(i.id) && (!q || i.name.toLowerCase().includes(q))
+    )
+    .sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+  const exactMatch = !!q &&
+    localItems.value.some((i) => i.name.trim().toLowerCase() === q);
+
+  return (
+    <div class="px-4 pt-4 pb-[calc(96px+env(safe-area-inset-bottom))] flex flex-col gap-6">
+      {/* Name */}
+      <div>
+        <div class="md-label-medium uppercase text-on-surface-variant mb-2">
+          Name
+        </div>
+        <input
+          value={name.value}
+          onInput={(e) => (name.value = e.currentTarget.value)}
+          placeholder="Dish name"
+          class={fieldClass}
+        />
+      </div>
+
+      {/* Ingredients */}
+      <div>
+        <div class="md-label-medium uppercase text-on-surface-variant mb-2">
+          Ingredients
+        </div>
+        <div class="flex flex-wrap gap-2">
+          {ingredientIds.value.map((id) => (
+            <span
+              key={id}
+              class="inline-flex items-center gap-1 md-label-large bg-secondary-container text-on-secondary-container rounded-[var(--md-shape-full)] pl-3 pr-1 py-1"
+            >
+              {itemById(id)?.name ?? "Unknown"}
+              <IconButton
+                name="x"
+                size={28}
+                iconSize={14}
+                aria-label="Remove ingredient"
+                onClick={() => removeIngredient(id)}
+              />
+            </span>
+          ))}
+          <Chip
+            icon="plus"
+            leadingCheck={false}
+            onClick={() => {
+              ingredientQuery.value = "";
+              pickerOpen.value = true;
+            }}
+          >
+            Add ingredient
+          </Chip>
+        </div>
+      </div>
+
+      {/* Tags — one chip group per dimension */}
+      {localGroups.value.map((g) => (
+        <div key={g.id}>
+          <div class="md-label-medium uppercase text-on-surface-variant mb-2">
+            {g.label}
+          </div>
+          <div class="flex flex-wrap gap-2 items-center">
+            {g.values.map((v) => (
+              <Chip
+                key={v.id}
+                selected={tagValueIds.value.includes(v.id)}
+                leadingCheck={false}
+                onClick={() => toggleTag(v.id)}
+              >
+                {v.label}
+              </Chip>
+            ))}
+            {newValueFor.value === g.id
+              ? (
+                <span class="inline-flex items-center gap-2">
+                  <input
+                    value={newValueLabel.value}
+                    onInput={(
+                      e,
+                    ) => (newValueLabel.value = e.currentTarget.value)}
+                    placeholder="New value"
+                    class="md-body-large bg-surface-chighest rounded-t-[var(--md-shape-sm)] border-0 border-b-2 border-primary px-3 py-1.5 focus:outline-none"
+                  />
+                  <Button
+                    variant="filled"
+                    disabled={!newValueLabel.value.trim()}
+                    onClick={async () => {
+                      await addValue(g.id, newValueLabel.value.trim());
+                      newValueFor.value = null;
+                      newValueLabel.value = "";
+                    }}
+                  >
+                    Add
+                  </Button>
+                </span>
+              )
+              : (
+                <Chip
+                  icon="plus"
+                  leadingCheck={false}
+                  onClick={() => {
+                    newValueFor.value = g.id;
+                    newValueLabel.value = "";
+                  }}
+                >
+                  New
+                </Chip>
+              )}
+          </div>
+        </div>
+      ))}
+
+      {/* Save / Delete */}
+      <div class="flex flex-col gap-3 pt-2">
+        <Button
+          variant="filled"
+          disabled={!name.value.trim() || saving.value}
+          onClick={save}
+        >
+          {dish ? "Save changes" : "Create dish"}
+        </Button>
+        {dish && (
+          <Button variant="error" icon="trash" onClick={remove}>
+            Delete dish
+          </Button>
+        )}
+      </div>
+
+      {/* Ingredient picker — search the catalogue, or create a new item inline */}
+      <Sheet
+        open={pickerOpen.value}
+        onClose={() => (pickerOpen.value = false)}
+        title="Add ingredient"
+        size="large"
+      >
+        <div class="flex items-center gap-2 bg-surface-chighest rounded-[var(--md-shape-full)] h-12 pl-4 pr-1.5 mb-3">
+          <Icon name="search" size={20} class="text-on-surface-variant" />
+          <input
+            value={ingredientQuery.value}
+            onInput={(e) => (ingredientQuery.value = e.currentTarget.value)}
+            placeholder="Search or add an item"
+            class="flex-1 min-w-0 bg-transparent border-0 outline-none md-body-large text-on-surface"
+          />
+        </div>
+        {q && !exactMatch && (
+          <Pressable
+            onClick={async () => {
+              await createCatalogueItem(ingredientQuery.value.trim());
+              ingredientQuery.value = "";
+            }}
+            color="var(--md-primary)"
+            class="flex items-center gap-2.5 w-full text-left border-[1.5px] border-dashed border-outline rounded-[var(--md-shape-md)] px-4 py-3 text-primary md-label-large mb-2"
+          >
+            <Icon name="plus" size={20} stroke={2.3} /> Create “{ingredientQuery
+              .value.trim()}”
+          </Pressable>
+        )}
+        <div class="max-h-[360px] overflow-y-auto -mx-1">
+          {results.map((it) => (
+            <ListItem
+              key={it.id}
+              headline={it.name}
+              onClick={() => addIngredient(it.id)}
+              trailing={<Icon name="plus" size={20} class="text-primary" />}
+            />
+          ))}
+        </div>
+      </Sheet>
+    </div>
+  );
+}

--- a/islands/dishes/DishEditor.tsx
+++ b/islands/dishes/DishEditor.tsx
@@ -75,9 +75,18 @@ export default function DishEditor({ dish, tagGroups, items }: Props) {
       ingredientIds: ingredientIds.value,
       tagValueIds: tagValueIds.value,
     };
-    if (dish) await api.dishes.update(dish.id, payload);
-    else await api.dishes.create(payload);
-    navigateTo("/menu");
+    try {
+      const result = dish
+        ? await api.dishes.update(dish.id, payload)
+        : await api.dishes.create(payload);
+      if (result) {
+        navigateTo("/menu");
+      } else {
+        saving.value = false; // failed — re-enable so the user can retry
+      }
+    } catch (_) {
+      saving.value = false; // network error — re-enable
+    }
   };
   const remove = async () => {
     if (!dish) return;
@@ -206,6 +215,7 @@ export default function DishEditor({ dish, tagGroups, items }: Props) {
         <Button
           variant="filled"
           disabled={!name.value.trim() || saving.value}
+          loading={saving.value}
           onClick={save}
         >
           {dish ? "Save changes" : "Create dish"}

--- a/models/dish/dish-tag-group.interface.ts
+++ b/models/dish/dish-tag-group.interface.ts
@@ -1,0 +1,11 @@
+export interface DishTagValueInterface {
+  id: string;
+  label: string;
+}
+
+export interface DishTagGroupInterface {
+  id: string;
+  label: string; // "Type", "Meal", "Side type"
+  order?: number;
+  values: DishTagValueInterface[]; // values embedded in the group
+}

--- a/models/dish/dish.interface.ts
+++ b/models/dish/dish.interface.ts
@@ -10,7 +10,5 @@ export interface DishInterface {
 // Derived type for creation (no ID)
 export type CreateDishDto = Omit<DishInterface, "id">;
 
-// Derived type for updating (ID + partial fields)
-export type UpdateDishDto =
-  & Pick<DishInterface, "id">
-  & Partial<Omit<DishInterface, "id">>;
+// Derived type for patch/update operations: never the id, all other fields optional
+export type UpdateDishDto = Partial<Omit<DishInterface, "id">>;

--- a/models/dish/dish.interface.ts
+++ b/models/dish/dish.interface.ts
@@ -1,0 +1,16 @@
+export interface DishInterface {
+  id: string;
+  name: string;
+  ingredientIds: string[]; // → catalogue Item ids (["items", id])
+  tagValueIds: string[]; // → DishTagValue ids, flat across all groups
+  createdAt?: string;
+  createdBy?: string;
+}
+
+// Derived type for creation (no ID)
+export type CreateDishDto = Omit<DishInterface, "id">;
+
+// Derived type for updating (ID + partial fields)
+export type UpdateDishDto =
+  & Pick<DishInterface, "id">
+  & Partial<Omit<DishInterface, "id">>;

--- a/models/dish/index.ts
+++ b/models/dish/index.ts
@@ -1,0 +1,1 @@
+export * from "./dish.interface.ts";

--- a/models/dish/index.ts
+++ b/models/dish/index.ts
@@ -1,1 +1,2 @@
 export * from "./dish.interface.ts";
+export * from "./dish-tag-group.interface.ts";

--- a/models/index.ts
+++ b/models/index.ts
@@ -4,3 +4,4 @@ export * from "./session/index.ts";
 export * from "./shopping-list/index.ts";
 export * from "./category/index.ts";
 export * from "./household/index.ts";
+export * from "./dish/index.ts";

--- a/routes/api/menu/dishes.test.ts
+++ b/routes/api/menu/dishes.test.ts
@@ -1,0 +1,80 @@
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import { type Context } from "fresh";
+import { handler } from "@/routes/api/menu/dishes.ts";
+import { getKv } from "@/database/db.ts";
+
+Deno.env.set("KV_PATH", ":memory:");
+
+function ctx(req: Request): Context<unknown> {
+  return { req } as unknown as Context<unknown>;
+}
+async function clearDishes() {
+  const kv = await getKv();
+  for await (const e of kv.list({ prefix: ["dishes"] })) await kv.delete(e.key);
+}
+const post = (body: unknown) =>
+  new Request("http://x/api/menu/dishes", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+Deno.test({
+  name: "POST creates (201), GET lists it, POST with id updates (200)",
+  sanitizeResources: false,
+  async fn() {
+    await clearDishes();
+    const createRes = await handler.POST(
+      ctx(post({ name: "Curry", ingredientIds: [], tagValueIds: [] })),
+    );
+    assertEquals(createRes.status, 201);
+    const created = await createRes.json();
+
+    const listRes = await handler.GET(
+      ctx(new Request("http://x/api/menu/dishes")),
+    );
+    assertEquals(listRes.status, 200);
+    const list = await listRes.json();
+    assertEquals(list.map((d: { name: string }) => d.name), ["Curry"]);
+
+    const updateRes = await handler.POST(
+      ctx(post({ id: created.id, name: "Veggie Curry" })),
+    );
+    assertEquals(updateRes.status, 200);
+    assertEquals((await updateRes.json()).name, "Veggie Curry");
+  },
+});
+
+Deno.test({
+  name: "POST with unknown id returns 404",
+  sanitizeResources: false,
+  async fn() {
+    await clearDishes();
+    const res = await handler.POST(ctx(post({ id: "nope", name: "x" })));
+    assertEquals(res.status, 404);
+  },
+});
+
+Deno.test({
+  name: "DELETE removes a dish (204); missing id is 400",
+  sanitizeResources: false,
+  async fn() {
+    await clearDishes();
+    const created = await (await handler.POST(
+      ctx(post({ name: "Toast", ingredientIds: [], tagValueIds: [] })),
+    )).json();
+    const delReq = new Request("http://x/api/menu/dishes", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: created.id }),
+    });
+    assertEquals((await handler.DELETE(ctx(delReq))).status, 204);
+
+    const badReq = new Request("http://x/api/menu/dishes", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    assertEquals((await handler.DELETE(ctx(badReq))).status, 400);
+  },
+});

--- a/routes/api/menu/dishes.ts
+++ b/routes/api/menu/dishes.ts
@@ -1,0 +1,28 @@
+import { type Context } from "fresh";
+import { DishRepo } from "@/database/dish.repo.ts";
+
+export const handler = {
+  async GET(_ctx: Context<unknown>) {
+    const dishes = await DishRepo.readAll();
+    return new Response(JSON.stringify(dishes), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  },
+  async POST(_ctx: Context<unknown>) {
+    const body = await _ctx.req.json();
+    if (body.id) {
+      const updated = await DishRepo.update(body.id, body);
+      if (!updated) return new Response("Dish not found", { status: 404 });
+      return new Response(JSON.stringify(updated), { status: 200 });
+    }
+    const created = await DishRepo.create(body);
+    return new Response(JSON.stringify(created), { status: 201 });
+  },
+  async DELETE(_ctx: Context<unknown>) {
+    const { id } = await _ctx.req.json();
+    if (!id) return new Response("ID is required", { status: 400 });
+    await DishRepo.delete(id);
+    return new Response(null, { status: 204 });
+  },
+};

--- a/routes/api/menu/dishes.ts
+++ b/routes/api/menu/dishes.ts
@@ -3,7 +3,7 @@ import { DishRepo } from "@/database/dish.repo.ts";
 
 export const handler = {
   async GET(_ctx: Context<unknown>) {
-    const dishes = await DishRepo.readAll();
+    const dishes = await DishRepo.getAll();
     return new Response(JSON.stringify(dishes), {
       status: 200,
       headers: { "Content-Type": "application/json" },

--- a/routes/api/menu/tag-groups.test.ts
+++ b/routes/api/menu/tag-groups.test.ts
@@ -1,0 +1,61 @@
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import { type Context } from "fresh";
+import { handler } from "@/routes/api/menu/tag-groups.ts";
+import { getKv } from "@/database/db.ts";
+
+Deno.env.set("KV_PATH", ":memory:");
+
+function ctx(req: Request): Context<unknown> {
+  return { req } as unknown as Context<unknown>;
+}
+async function clearGroups() {
+  const kv = await getKv();
+  for await (const e of kv.list({ prefix: ["dish_tag_groups"] })) {
+    await kv.delete(e.key);
+  }
+}
+
+Deno.test({
+  name: "GET seeds defaults and returns the groups",
+  sanitizeResources: false,
+  async fn() {
+    await clearGroups();
+    const res = await handler.GET(
+      ctx(new Request("http://x/api/menu/tag-groups")),
+    );
+    assertEquals(res.status, 200);
+    const groups = await res.json();
+    assertEquals(groups.map((g: { label: string }) => g.label), [
+      "Type",
+      "Meal",
+      "Side type",
+    ]);
+  },
+});
+
+Deno.test({
+  name: "POST adds a value to a group (201); missing group is 404",
+  sanitizeResources: false,
+  async fn() {
+    await clearGroups();
+    const groups = await (await handler.GET(
+      ctx(new Request("http://x/api/menu/tag-groups")),
+    )).json();
+    const addReq = (body: unknown) =>
+      new Request("http://x/api/menu/tag-groups", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+    const okRes = await handler.POST(
+      ctx(addReq({ groupId: groups[0].id, label: "Vegan" })),
+    );
+    assertEquals(okRes.status, 201);
+    assertEquals((await okRes.json()).label, "Vegan");
+
+    const missRes = await handler.POST(
+      ctx(addReq({ groupId: "nope", label: "x" })),
+    );
+    assertEquals(missRes.status, 404);
+  },
+});

--- a/routes/api/menu/tag-groups.ts
+++ b/routes/api/menu/tag-groups.ts
@@ -1,0 +1,22 @@
+import { type Context } from "fresh";
+import { DishTagGroupRepo } from "@/database/dish-tag-group.repo.ts";
+
+export const handler = {
+  async GET(_ctx: Context<unknown>) {
+    await DishTagGroupRepo.ensureDefaults();
+    const groups = await DishTagGroupRepo.getAll();
+    return new Response(JSON.stringify(groups), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  },
+  async POST(_ctx: Context<unknown>) {
+    const { groupId, label } = await _ctx.req.json();
+    if (!groupId || !label?.trim()) {
+      return new Response("groupId and label are required", { status: 400 });
+    }
+    const value = await DishTagGroupRepo.addValue(groupId, label.trim());
+    if (!value) return new Response("Group not found", { status: 404 });
+    return new Response(JSON.stringify(value), { status: 201 });
+  },
+};

--- a/routes/menu/[id]/index.tsx
+++ b/routes/menu/[id]/index.tsx
@@ -1,0 +1,30 @@
+import { page } from "fresh";
+import { DishRepo, DishTagGroupRepo, ItemRepo } from "@/database/index.ts";
+import DishEditor from "@/islands/dishes/DishEditor.tsx";
+import { define } from "@/utils/index.ts";
+
+export const handler = define.handlers({
+  async GET(ctx) {
+    const dish = await DishRepo.getById(ctx.params.id);
+    if (!dish) return new Response("Not found", { status: 404 });
+    await DishTagGroupRepo.ensureDefaults();
+    ctx.state.appBar = { mode: "detail", title: dish.name, backUrl: "/menu" };
+    const [tagGroups, items] = await Promise.all([
+      DishTagGroupRepo.getAll(),
+      ItemRepo.readAll(),
+    ]);
+    return page({ dish, tagGroups, items });
+  },
+});
+
+export default define.page<typeof handler>(function DishDetailPage({ data }) {
+  return (
+    <main class="max-w-md mx-auto">
+      <DishEditor
+        dish={data.dish}
+        tagGroups={data.tagGroups}
+        items={data.items}
+      />
+    </main>
+  );
+});

--- a/routes/menu/index.tsx
+++ b/routes/menu/index.tsx
@@ -1,13 +1,25 @@
+import { page } from "fresh";
+import { DishRepo, DishTagGroupRepo } from "@/database/index.ts";
+import DishCatalogue from "@/islands/dishes/DishCatalogue.tsx";
 import { define } from "@/utils/index.ts";
-import { ComingSoon } from "@/components/md3/ComingSoon.tsx";
 
-export default define.page(function MenuPlanner() {
+export const handler = define.handlers({
+  async GET(_ctx) {
+    await DishTagGroupRepo.ensureDefaults();
+    const [dishes, tagGroups] = await Promise.all([
+      DishRepo.readAll(),
+      DishTagGroupRepo.getAll(),
+    ]);
+    return page({ dishes, tagGroups });
+  },
+});
+
+export default define.page<typeof handler>(function MenuPage({ data }) {
   return (
     <main class="max-w-md mx-auto">
-      <ComingSoon
-        icon="plate"
-        title="Menu planner"
-        blurb="Plan the week's meals together, then turn them into a shopping list in one tap. This module is on the way."
+      <DishCatalogue
+        initialDishes={data.dishes}
+        initialTagGroups={data.tagGroups}
       />
     </main>
   );

--- a/routes/menu/index.tsx
+++ b/routes/menu/index.tsx
@@ -7,7 +7,7 @@ export const handler = define.handlers({
   async GET(_ctx) {
     await DishTagGroupRepo.ensureDefaults();
     const [dishes, tagGroups] = await Promise.all([
-      DishRepo.readAll(),
+      DishRepo.getAll(),
       DishTagGroupRepo.getAll(),
     ]);
     return page({ dishes, tagGroups });

--- a/routes/menu/new.tsx
+++ b/routes/menu/new.tsx
@@ -1,0 +1,24 @@
+import { page } from "fresh";
+import { DishTagGroupRepo, ItemRepo } from "@/database/index.ts";
+import DishEditor from "@/islands/dishes/DishEditor.tsx";
+import { define } from "@/utils/index.ts";
+
+export const handler = define.handlers({
+  async GET(ctx) {
+    await DishTagGroupRepo.ensureDefaults();
+    ctx.state.appBar = { mode: "detail", title: "New dish", backUrl: "/menu" };
+    const [tagGroups, items] = await Promise.all([
+      DishTagGroupRepo.getAll(),
+      ItemRepo.readAll(),
+    ]);
+    return page({ tagGroups, items });
+  },
+});
+
+export default define.page<typeof handler>(function NewDishPage({ data }) {
+  return (
+    <main class="max-w-md mx-auto">
+      <DishEditor tagGroups={data.tagGroups} items={data.items} />
+    </main>
+  );
+});

--- a/services/api.ts
+++ b/services/api.ts
@@ -5,6 +5,12 @@ import {
   ShoppingListItemInterface,
 } from "@/models/index.ts";
 import { CreateItemDto } from "@/models/item/item.interface.ts";
+import {
+  CreateDishDto,
+  DishInterface,
+  DishTagGroupInterface,
+  DishTagValueInterface,
+} from "@/models/index.ts";
 
 export const api = {
   items: {
@@ -163,6 +169,60 @@ export const api = {
       if (!res.ok) return null;
       const data = await res.json();
       return data.cleared as number;
+    },
+  },
+  dishes: {
+    getAll: async (): Promise<DishInterface[]> => {
+      const res = await fetch("/api/menu/dishes");
+      if (!res.ok) return [];
+      return res.json();
+    },
+    create: async (dish: CreateDishDto): Promise<DishInterface | null> => {
+      const res = await fetch("/api/menu/dishes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(dish),
+      });
+      if (!res.ok) return null;
+      return res.json();
+    },
+    update: async (
+      id: string,
+      patch: Partial<DishInterface>,
+    ): Promise<DishInterface | null> => {
+      const res = await fetch("/api/menu/dishes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...patch, id }),
+      });
+      if (!res.ok) return null;
+      return res.json();
+    },
+    delete: async (id: string): Promise<void> => {
+      await fetch("/api/menu/dishes", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id }),
+      });
+    },
+  },
+  dishTagGroups: {
+    getAll: async (): Promise<DishTagGroupInterface[]> => {
+      const res = await fetch("/api/menu/tag-groups");
+      if (!res.ok) return [];
+      return res.json();
+    },
+    addValue: async (
+      groupId: string,
+      label: string,
+    ): Promise<DishTagValueInterface | null> => {
+      const res = await fetch("/api/menu/tag-groups", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ groupId, label }),
+      });
+      if (!res.ok) return null;
+      return res.json();
     },
   },
 };


### PR DESCRIPTION
## Overview

Implements **Dish Catalogue Management (CRUD)** — the data foundation for the Menu-planner / meal-suggestion system (#14). The `/menu` tab (previously a "coming soon" placeholder) is now a full dish catalogue: browse, search, filter by tags, and create/view/edit/delete dishes.

Closes #39.

## What's included

- **Dishes** with a name, **ingredients** (references to shared shopping-catalogue items — so a future meal plan can push them onto a shopping list), and **tags** grouped by dimension.
- **Structured tag groups** seeded on first use — **Type** (Vegetarian/Fish/Meat), **Meal** (Main dish/Breakfast/Lunch/Side dish), **Side type** (Rice/Potatoes/Pasta) — with inline "add a value" to an existing group.
- **`/menu` list island**: search by name + faceted tag filter (OR within a group, AND across groups), dish grid, empty state, add-dish FAB.
- **Full-screen editor** (`/menu/new`, `/menu/[id]`): name, ingredient picker (search the catalogue or create a new catalogue item inline), per-dimension tag chips, save (failure-guarded) and delete.

## Architecture

Mirrors the existing shopping-catalogue stack end-to-end: `models/dish/*` → `DishRepo` + `DishTagGroupRepo` (Deno KV, global collections) → `/api/menu/{dishes,tag-groups}.ts` → `services/api.ts` wrappers → `hooks/useDishes.ts` (optimistic signals) → `islands/dishes/{DishCatalogue,DishEditor}.tsx`. Design & plan under `docs/superpowers/`.

## Testing

- `deno task test` — **139 passing** (repo CRUD, tag-group seed idempotency + add-value, API handler status codes, `useDishes` faceted filtering + optimistic delete + refresh, island render tests).
- `deno task check` (fmt + lint + type) — clean; `deno task build` — OK.
- **Live E2E** on a running dev server: `/menu` renders the catalogue with the seeded tag rails; create a dish with an ingredient + tags → it appears on the SSR list and detail routes → update reflected → delete removes it; the Vegetarian filter narrows the list correctly.

## Deferred (tracked as sub-issues of #14)

- **#42** — scope the dish catalogue & tag groups to the household (they're global today, matching the existing catalogue).
- **#43** — full tag-group management (create/rename/delete groups, rename/delete values, reference cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
