### PR TITLE
feat(auth): skip login in local dev via auto-login

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,11 @@ middleware auto-authenticates as a seeded user, and `/login` redirects to the
 app. This never happens in production (it's disabled whenever
 `DENO_DEPLOYMENT_ID` is set, i.e. on Deno Deploy).
 
-- The dev user is `SEED_USERNAME` (defaults to `demo`). Seed it first (e.g. via
-  `deno task db:seed`); if the user doesn't exist yet, the normal login page is
-  shown instead.
-- To test the real login/session flow, set `DEV_AUTOLOGIN=false` in your `.env`.
+- The dev user is `SEED_USERNAME` (defaults to `demo`). Seed it first — set
+  `SEED_USERNAME`/`SEED_PASSWORD` in your `.env` and run `deno task db:seed`. If
+  the user doesn't exist yet, the normal login page is shown instead.
+- To test the real login/session flow — including logout and switching between
+  users — set `DEV_AUTOLOGIN=false` in your `.env` (any other value keeps
+  auto-login on).
 - Auto-login populates the request from the user record directly and sets no
   cookie, so it also works when testing on a device over plain HTTP.

--- a/README.md
+++ b/README.md
@@ -51,3 +51,17 @@ Demo credentials:
 Set `SEED_USERNAME` / `SEED_PASSWORD` in your `.env` to control the primary
 account. To edit the dataset, change `scripts/seed/fixtures.ts` and re-run
 `deno task db:seed`.
+
+## Development auto-login
+
+In local development the app **skips the login screen by default**: the
+middleware auto-authenticates as a seeded user, and `/login` redirects to the
+app. This never happens in production (it's disabled whenever
+`DENO_DEPLOYMENT_ID` is set, i.e. on Deno Deploy).
+
+- The dev user is `SEED_USERNAME` (defaults to `demo`). Seed it first (e.g. via
+  `deno task db:seed`); if the user doesn't exist yet, the normal login page is
+  shown instead.
+- To test the real login/session flow, set `DEV_AUTOLOGIN=false` in your `.env`.
+- Auto-login populates the request from the user record directly and sets no
+  cookie, so it also works when testing on a device over plain HTTP.

--- a/routes/_middleware.test.ts
+++ b/routes/_middleware.test.ts
@@ -1,0 +1,195 @@
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+
+// Isolated in-memory KV. getKv() reads KV_PATH lazily on first use (inside a
+// repo method), so setting it here at module load is early enough. Each test
+// creates its own users with distinct usernames because the process-wide KV
+// singleton is shared. sanitizeResources is disabled for the same reason as the
+// repo tests — the getKv() singleton is intentionally never closed.
+Deno.env.set("KV_PATH", ":memory:");
+
+import { handler } from "./_middleware.ts";
+import { SessionRepo, UserRepo } from "@/database/index.ts";
+
+type Ctx = Parameters<typeof handler>[0];
+
+interface TestState {
+  userId?: string;
+  householdId?: string;
+}
+
+function makeCtx(path: string, cookie?: string) {
+  const headers = new Headers();
+  if (cookie) headers.set("cookie", cookie);
+  const req = new Request(`http://localhost${path}`, { headers });
+  const state: TestState = {};
+  let nextCalled = false;
+  const next = () => {
+    nextCalled = true;
+    return Promise.resolve(new Response("NEXT", { status: 200 }));
+  };
+  const ctx = { req, state, next } as unknown as Ctx;
+  return { ctx, state, nextCalled: () => nextCalled };
+}
+
+/** Set env vars for the duration of fn, restoring previous values afterwards. */
+async function withEnv(
+  vars: Record<string, string | undefined>,
+  fn: () => Promise<void>,
+) {
+  const prev: Record<string, string | undefined> = {};
+  for (const key of Object.keys(vars)) prev[key] = Deno.env.get(key);
+  for (const [key, value] of Object.entries(vars)) {
+    if (value === undefined) Deno.env.delete(key);
+    else Deno.env.set(key, value);
+  }
+  try {
+    await fn();
+  } finally {
+    for (const [key, value] of Object.entries(prev)) {
+      if (value === undefined) Deno.env.delete(key);
+      else Deno.env.set(key, value);
+    }
+  }
+}
+
+const DEV = { DENO_DEPLOYMENT_ID: undefined };
+
+Deno.test({
+  name: "middleware — dev auto-login populates state and proceeds (no cookie)",
+  sanitizeResources: false,
+  async fn() {
+    const user = await UserRepo.create({
+      username: "mw-auto",
+      passwordHash: "x",
+    });
+    await withEnv(
+      { ...DEV, DEV_AUTOLOGIN: undefined, SEED_USERNAME: "mw-auto" },
+      async () => {
+        const { ctx, state, nextCalled } = makeCtx("/shopping");
+        const res = await handler(ctx);
+        assertEquals(nextCalled(), true);
+        assertEquals(state.userId, user.id);
+        assertEquals(state.householdId, user.householdId);
+        assertEquals(res.status, 200);
+      },
+    );
+  },
+});
+
+Deno.test({
+  name: "middleware — dev auto-login redirects /login to /shopping",
+  sanitizeResources: false,
+  async fn() {
+    await UserRepo.create({ username: "mw-login", passwordHash: "x" });
+    await withEnv(
+      { ...DEV, DEV_AUTOLOGIN: undefined, SEED_USERNAME: "mw-login" },
+      async () => {
+        const { ctx, nextCalled } = makeCtx("/login");
+        const res = await handler(ctx);
+        assertEquals(res.status, 303);
+        assertEquals(res.headers.get("location"), "/shopping");
+        assertEquals(nextCalled(), false);
+      },
+    );
+  },
+});
+
+Deno.test({
+  name: "middleware — no auto-login in production (redirects to /login)",
+  sanitizeResources: false,
+  async fn() {
+    await withEnv(
+      {
+        DENO_DEPLOYMENT_ID: "deploy-1",
+        DEV_AUTOLOGIN: undefined,
+        SEED_USERNAME: "demo",
+      },
+      async () => {
+        const { ctx, state, nextCalled } = makeCtx("/shopping");
+        const res = await handler(ctx);
+        assertEquals(res.status, 303);
+        assertEquals(res.headers.get("location"), "/login");
+        assertEquals(state.userId, undefined);
+        assertEquals(nextCalled(), false);
+      },
+    );
+  },
+});
+
+Deno.test({
+  name: "middleware — DEV_AUTOLOGIN=false disables auto-login",
+  sanitizeResources: false,
+  async fn() {
+    await withEnv(
+      { ...DEV, DEV_AUTOLOGIN: "false", SEED_USERNAME: "demo" },
+      async () => {
+        const { ctx, state } = makeCtx("/shopping");
+        const res = await handler(ctx);
+        assertEquals(res.status, 303);
+        assertEquals(res.headers.get("location"), "/login");
+        assertEquals(state.userId, undefined);
+      },
+    );
+  },
+});
+
+Deno.test({
+  name: "middleware — dev auto-login falls through when user not seeded",
+  sanitizeResources: false,
+  async fn() {
+    await withEnv(
+      { ...DEV, DEV_AUTOLOGIN: undefined, SEED_USERNAME: "nobody-xyz" },
+      async () => {
+        const { ctx } = makeCtx("/shopping");
+        const res = await handler(ctx);
+        assertEquals(res.status, 303);
+        assertEquals(res.headers.get("location"), "/login");
+      },
+    );
+  },
+});
+
+Deno.test({
+  name: "middleware — a real session still authenticates when auto-login off",
+  sanitizeResources: false,
+  async fn() {
+    const user = await UserRepo.create({
+      username: "mw-session",
+      passwordHash: "x",
+    });
+    const session = await SessionRepo.create(user.id);
+    await withEnv(
+      { ...DEV, DEV_AUTOLOGIN: "false", SEED_USERNAME: undefined },
+      async () => {
+        const { ctx, state, nextCalled } = makeCtx(
+          "/shopping",
+          `sessionId=${session.id}`,
+        );
+        const res = await handler(ctx);
+        assertEquals(nextCalled(), true);
+        assertEquals(state.userId, user.id);
+        assertEquals(state.householdId, user.householdId);
+        assertEquals(res.status, 200);
+      },
+    );
+  },
+});
+
+Deno.test({
+  name: "middleware — API stays 401 in production without a session",
+  sanitizeResources: false,
+  async fn() {
+    await withEnv(
+      {
+        DENO_DEPLOYMENT_ID: "deploy-1",
+        DEV_AUTOLOGIN: undefined,
+        SEED_USERNAME: undefined,
+      },
+      async () => {
+        const { ctx } = makeCtx("/api/shopping/items");
+        const res = await handler(ctx);
+        assertEquals(res.status, 401);
+      },
+    );
+  },
+});

--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -2,10 +2,17 @@ import { Context } from "fresh";
 import { getCookies } from "$std/http/cookie.ts";
 import { SessionRepo } from "@/database/session.repo.ts";
 import { UserRepo } from "@/database/user.repo.ts";
+import { devAutoLoginUsername } from "@/utils/index.ts";
 
 interface State {
   userId?: string;
   householdId?: string;
+}
+
+function seeOther(location: string): Response {
+  const headers = new Headers();
+  headers.set("location", location);
+  return new Response(null, { status: 303, headers });
 }
 
 export async function handler(
@@ -15,9 +22,8 @@ export async function handler(
   const url = new URL(req.url);
   const path = url.pathname;
 
-  // 1. Public Allowlist
+  // 1. Static assets — always public.
   if (
-    path === "/login" ||
     path.startsWith("/_fresh") ||
     path.startsWith("/static") ||
     path.startsWith("/assets") ||
@@ -26,7 +32,31 @@ export async function handler(
     return await ctx.next();
   }
 
-  // 2. Session Check
+  // 2. Dev auto-login. Never active in production — DENO_DEPLOYMENT_ID is always
+  //    set on Deno Deploy. When enabled and the seeded user exists, act as that
+  //    user without a session and skip the login page entirely.
+  const devUsername = devAutoLoginUsername(
+    Deno.env.get("DENO_DEPLOYMENT_ID"),
+    Deno.env.get("DEV_AUTOLOGIN"),
+    Deno.env.get("SEED_USERNAME"),
+  );
+  if (devUsername) {
+    const devUser = await UserRepo.findByUsername(devUsername);
+    if (devUser) {
+      if (path === "/login") return seeOther("/shopping");
+      ctx.state.userId = devUser.id;
+      ctx.state.householdId = devUser.householdId;
+      return await ctx.next();
+    }
+    // Dev user not seeded yet — fall through to the normal login flow.
+  }
+
+  // 3. Login page is public.
+  if (path === "/login") {
+    return await ctx.next();
+  }
+
+  // 4. Session check.
   const cookies = getCookies(req.headers);
   const sessionId = cookies.sessionId;
 
@@ -40,16 +70,11 @@ export async function handler(
     }
   }
 
-  // 3. Unauthorized Handling
+  // 5. Unauthorized handling.
   if (path.startsWith("/api")) {
     return new Response("Unauthorized", { status: 401 });
   }
 
-  // Redirect to login for page requests
-  const headers = new Headers();
-  headers.set("location", "/login");
-  return new Response(null, {
-    status: 303,
-    headers,
-  });
+  // Redirect to login for page requests.
+  return seeOther("/login");
 }

--- a/utils/dev-auth.test.ts
+++ b/utils/dev-auth.test.ts
@@ -1,0 +1,31 @@
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import { devAutoLoginUsername } from "./dev-auth.ts";
+
+// devAutoLoginUsername decides, from environment values, which seeded user the
+// dev server should auto-authenticate as — or null when auto-login must not
+// apply. It is pure so the decision can be tested without a live request.
+
+Deno.test("devAutoLoginUsername — null in production regardless of other vars", () => {
+  assertEquals(devAutoLoginUsername("deploy-abc", undefined, undefined), null);
+  assertEquals(devAutoLoginUsername("deploy-abc", "true", "alex"), null);
+});
+
+Deno.test("devAutoLoginUsername — defaults to 'demo' in dev", () => {
+  assertEquals(devAutoLoginUsername(undefined, undefined, undefined), "demo");
+});
+
+Deno.test("devAutoLoginUsername — disabled by DEV_AUTOLOGIN=false", () => {
+  assertEquals(devAutoLoginUsername(undefined, "false", "alex"), null);
+});
+
+Deno.test("devAutoLoginUsername — uses SEED_USERNAME when set", () => {
+  assertEquals(devAutoLoginUsername(undefined, undefined, "alex"), "alex");
+});
+
+Deno.test("devAutoLoginUsername — empty SEED_USERNAME falls back to 'demo'", () => {
+  assertEquals(devAutoLoginUsername(undefined, undefined, ""), "demo");
+});
+
+Deno.test("devAutoLoginUsername — explicit DEV_AUTOLOGIN=true stays enabled", () => {
+  assertEquals(devAutoLoginUsername(undefined, "true", undefined), "demo");
+});

--- a/utils/dev-auth.test.ts
+++ b/utils/dev-auth.test.ts
@@ -18,6 +18,11 @@ Deno.test("devAutoLoginUsername — disabled by DEV_AUTOLOGIN=false", () => {
   assertEquals(devAutoLoginUsername(undefined, "false", "alex"), null);
 });
 
+Deno.test("devAutoLoginUsername — DEV_AUTOLOGIN disable is case-insensitive", () => {
+  assertEquals(devAutoLoginUsername(undefined, "False", "alex"), null);
+  assertEquals(devAutoLoginUsername(undefined, "FALSE", "alex"), null);
+});
+
 Deno.test("devAutoLoginUsername — uses SEED_USERNAME when set", () => {
   assertEquals(devAutoLoginUsername(undefined, undefined, "alex"), "alex");
 });

--- a/utils/dev-auth.ts
+++ b/utils/dev-auth.ts
@@ -1,0 +1,26 @@
+// Dev-only auto-login decision. In local development the app can act as a
+// seeded user without a login round-trip. This is a pure decision so it can be
+// unit-tested; the middleware wires it to real env vars and a user lookup.
+//
+// It never applies in production: on Deno Deploy `DENO_DEPLOYMENT_ID` is always
+// set (the same signal `database/db.ts` and the seed script rely on).
+
+const DEFAULT_DEV_USERNAME = "demo";
+
+/**
+ * Returns the username the dev server should auto-authenticate as, or `null`
+ * when auto-login must not apply.
+ *
+ * @param deploymentId value of `DENO_DEPLOYMENT_ID` (set in production)
+ * @param autoLoginFlag value of `DEV_AUTOLOGIN` (`"false"` disables it)
+ * @param seedUsername value of `SEED_USERNAME` (overrides the default user)
+ */
+export function devAutoLoginUsername(
+  deploymentId: string | undefined,
+  autoLoginFlag: string | undefined,
+  seedUsername: string | undefined,
+): string | null {
+  if (deploymentId) return null; // production — never auto-login
+  if (autoLoginFlag === "false") return null; // explicitly disabled
+  return seedUsername || DEFAULT_DEV_USERNAME;
+}

--- a/utils/dev-auth.ts
+++ b/utils/dev-auth.ts
@@ -4,6 +4,12 @@
 //
 // It never applies in production: on Deno Deploy `DENO_DEPLOYMENT_ID` is always
 // set (the same signal `database/db.ts` and the seed script rely on).
+//
+// ASSUMPTION: the only production target is Deno Deploy. Auto-login is on by
+// default in dev and gated purely on the *absence* of `DENO_DEPLOYMENT_ID`. If
+// this app is ever self-hosted somewhere that does not set that variable (e.g.
+// a Docker/VPS deployment), this default would become an auth bypass and MUST
+// be revisited — e.g. require an explicit positive dev signal instead.
 
 const DEFAULT_DEV_USERNAME = "demo";
 
@@ -21,6 +27,6 @@ export function devAutoLoginUsername(
   seedUsername: string | undefined,
 ): string | null {
   if (deploymentId) return null; // production — never auto-login
-  if (autoLoginFlag === "false") return null; // explicitly disabled
+  if (autoLoginFlag?.toLowerCase() === "false") return null; // explicitly disabled
   return seedUsername || DEFAULT_DEV_USERNAME;
 }

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./security.ts";
 export * from "./debounce-update.ts";
 export * from "./define.ts";
+export * from "./dev-auth.ts";


### PR DESCRIPTION
## Summary

Skips the login screen in **local development** by default: the middleware auto-authenticates as a seeded user and redirects `/login` → the app. Removes repeated logins — especially handy since reseeding clears sessions, and the session cookie is `secure`-only (so it's dropped when testing on a device over plain-HTTP LAN).

**Never active in production** — disabled whenever `DENO_DEPLOYMENT_ID` is set (the same signal `database/db.ts` and the seed use). The gate is evaluated *before* any user lookup, so the production auth path is byte-for-byte unchanged.

## Behavior

- **Dev, default:** auto-login as `SEED_USERNAME` (default `demo`); `/login` → `/shopping`.
- **Not seeded yet:** falls through to the normal login page (no crash).
- **Opt out:** `DEV_AUTOLOGIN=false` (case-insensitive) restores the real login/session flow — needed to test logout and multi-user switching.
- **Production:** unchanged — session-cookie check, `/api` → 401, pages → 303 `/login`.
- No cookie is set; `ctx.state` is populated per request (works over plain HTTP for on-device testing).

## Design

- `utils/dev-auth.ts` — pure `devAutoLoginUsername(deploymentId, autoLoginFlag, seedUsername)` decision helper (unit-tested).
- `routes/_middleware.ts` — wires the helper in; extracts a small `seeOther()` redirect helper. Ordering: static assets → dev auto-login → `/login` public → session check → 401/redirect.

## Testing

- `utils/dev-auth.test.ts` — 7 cases (prod off, dev default, `SEED_USERNAME` override, empty-string fallback, case-insensitive disable, explicit-true).
- `routes/_middleware.test.ts` — 7 integration tests driving the **real** `handler` against in-memory KV: auto-login populates state + proceeds; `/login`→`/shopping`; production → `/login`; `DEV_AUTOLOGIN=false` → `/login`; unseeded → `/login`; real session still authenticates when auto-login off; `/api` → 401 in prod.
- Full suite **153 passed / 0 failed**; `deno task check` clean.
- **Verified live** on the dev server: `/shopping` renders the app for the auto-logged-in user; `/login` → 303 `/shopping`; no console errors.

## Note

The production guard assumes the only deploy target is Deno Deploy (per `CLAUDE.md`). Since auto-login is default-on and gated purely on the *absence* of `DENO_DEPLOYMENT_ID`, a future self-hosted deployment that doesn't set that variable would turn this into an auth bypass — flagged in a code comment in `utils/dev-auth.ts` so it's revisited if that ever changes.

Depends on a seeded user existing (pairs naturally with #44).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
