### PR TITLE
feat(cards): loyalty card management with barcode generation

### DIFF
--- a/components/cards/CardForm.tsx
+++ b/components/cards/CardForm.tsx
@@ -1,0 +1,198 @@
+import type { Signal } from "@preact/signals";
+import type { BarcodeFormat } from "@/models/index.ts";
+import {
+  detectFormat,
+  SUPPORTED_FORMATS,
+  validateBarcode,
+} from "@/utils/barcode.ts";
+import { Barcode } from "@/components/md3/Barcode.tsx";
+import { Button } from "@/components/md3/Button.tsx";
+import { Chip } from "@/components/md3/Chip.tsx";
+import { Icon } from "@/components/md3/Icon.tsx";
+import { Pressable } from "@/components/md3/Pressable.tsx";
+import { CARD_COLORS } from "./palette.ts";
+
+export interface CardFormSignals {
+  label: Signal<string>;
+  value: Signal<string>;
+  format: Signal<BarcodeFormat>;
+  color: Signal<string>;
+  /** True once the user overrides the auto-detected format by hand. */
+  manualFormat: Signal<boolean>;
+}
+
+interface CardFormProps {
+  form: CardFormSignals;
+  scannerAvailable: boolean;
+  saving: boolean;
+  onScan: () => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+}
+
+const NUMERIC: BarcodeFormat[] = ["ean13", "ean8", "upca"];
+
+const fieldLabel =
+  "md-label-medium uppercase tracking-wide text-on-surface-variant px-1 mb-1";
+
+export function CardForm(
+  { form, scannerAvailable, saving, onScan, onSubmit, onCancel }: CardFormProps,
+) {
+  const value = form.value.value;
+  const format = form.format.value;
+  const trimmed = value.trim();
+  const check = validateBarcode(value, format);
+  const canSave = form.label.value.trim().length > 0 && check.ok;
+
+  const onValueInput = (next: string) => {
+    form.value.value = next;
+    // Keep the format in sync with the value until the user picks one by hand.
+    if (!form.manualFormat.value) form.format.value = detectFormat(next);
+  };
+
+  const pickFormat = (f: BarcodeFormat) => {
+    form.manualFormat.value = true;
+    form.format.value = f;
+  };
+
+  return (
+    <div class="flex flex-col gap-5 pt-1">
+      {/* Label */}
+      <div class="flex flex-col">
+        <label class={fieldLabel}>Card name</label>
+        <div class="flex items-center bg-surface-chighest rounded-[var(--md-shape-sm)] h-12 px-4">
+          <input
+            value={form.label.value}
+            onInput={(e) => (form.label.value = e.currentTarget.value)}
+            placeholder="e.g. Delhaize"
+            aria-label="Card name"
+            class="flex-1 min-w-0 bg-transparent border-0 outline-none md-body-large text-on-surface"
+          />
+        </div>
+      </div>
+
+      {/* Value + scan */}
+      <div class="flex flex-col">
+        <label class={fieldLabel}>Barcode number</label>
+        <div class="flex items-center gap-2 bg-surface-chighest rounded-[var(--md-shape-sm)] h-12 pl-4 pr-1.5">
+          <input
+            value={value}
+            onInput={(e) => onValueInput(e.currentTarget.value)}
+            placeholder="Type or scan the number"
+            aria-label="Barcode number"
+            inputMode={NUMERIC.includes(format) ? "numeric" : "text"}
+            autocomplete="off"
+            autocapitalize="off"
+            spellcheck={false}
+            class="flex-1 min-w-0 bg-transparent border-0 outline-none md-body-large text-on-surface"
+          />
+          {scannerAvailable && (
+            <Pressable
+              onClick={onScan}
+              aria-label="Scan barcode with camera"
+              class="inline-flex items-center gap-1.5 h-9 px-3 rounded-[var(--md-shape-full)] bg-secondary-container text-on-secondary-container shrink-0"
+            >
+              <Icon name="expand" size={18} />
+              <span class="md-label-large">Scan</span>
+            </Pressable>
+          )}
+        </div>
+        {trimmed.length > 0 && !check.ok && (
+          <span class="md-body-small text-error px-1 mt-1">
+            {check.message}
+          </span>
+        )}
+      </div>
+
+      {/* Format */}
+      <div class="flex flex-col">
+        <label class={fieldLabel}>Barcode type</label>
+        <div class="flex gap-2 overflow-x-auto pr-1 pb-1">
+          {SUPPORTED_FORMATS.map((f) => (
+            <Chip
+              key={f.format}
+              selected={format === f.format}
+              leadingCheck={false}
+              onClick={() => pickFormat(f.format)}
+            >
+              {f.label}
+            </Chip>
+          ))}
+        </div>
+      </div>
+
+      {/* Colour */}
+      <div class="flex flex-col">
+        <label class={fieldLabel}>Colour</label>
+        <div class="flex gap-3 pl-1">
+          {CARD_COLORS.map((c) => {
+            const on = form.color.value === c.key;
+            return (
+              <Pressable
+                key={c.key}
+                onClick={() => (form.color.value = c.key)}
+                aria-label={`Colour ${c.key}`}
+                aria-pressed={on ? "true" : "false"}
+                class="grid place-items-center rounded-full shrink-0"
+                style={{
+                  width: 36,
+                  height: 36,
+                  background: c.bg,
+                  outline: on ? "2px solid var(--md-on-surface)" : "none",
+                  outlineOffset: 2,
+                }}
+              >
+                {on && (
+                  <span style={{ color: c.fg }}>
+                    <Icon name="check" size={18} stroke={2.6} />
+                  </span>
+                )}
+              </Pressable>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Live preview */}
+      <div class="flex flex-col">
+        <label class={fieldLabel}>Preview</label>
+        <div class="grid place-items-center bg-white rounded-[var(--md-shape-md)] border border-outline-variant min-h-24 p-3">
+          {check.ok
+            ? (
+              <div
+                class="w-full grid place-items-center"
+                style={{ maxWidth: format === "qrcode" ? 140 : 280 }}
+              >
+                <Barcode
+                  value={trimmed}
+                  format={format}
+                  includeText={false}
+                  class="w-full"
+                />
+              </div>
+            )
+            : (
+              <span class="md-body-small text-on-surface-variant">
+                Enter a valid number to preview the barcode.
+              </span>
+            )}
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div class="flex gap-3 pt-1">
+        <Button variant="text" full onClick={onCancel}>Cancel</Button>
+        <Button
+          variant="filled"
+          full
+          icon="plus"
+          disabled={!canSave}
+          loading={saving}
+          onClick={onSubmit}
+        >
+          Save card
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/cards/CardPresent.tsx
+++ b/components/cards/CardPresent.tsx
@@ -1,0 +1,86 @@
+import { useSignal } from "@preact/signals";
+import type { LoyaltyCardInterface } from "@/models/index.ts";
+import { Barcode } from "@/components/md3/Barcode.tsx";
+import { Button } from "@/components/md3/Button.tsx";
+import { IconButton } from "@/components/md3/IconButton.tsx";
+import { formatLabel } from "@/utils/barcode.ts";
+
+interface CardPresentProps {
+  card: LoyaltyCardInterface;
+  onClose: () => void;
+  onDelete: (id: string) => void;
+}
+
+/**
+ * Full-screen "show at the till" view: a large, high-contrast barcode on white
+ * so in-store scanners read it reliably, plus the label, number and a
+ * confirm-guarded remove action.
+ */
+export function CardPresent({ card, onClose, onDelete }: CardPresentProps) {
+  const confirming = useSignal(false);
+  const isQr = card.format === "qrcode";
+
+  return (
+    <div class="fixed inset-0 z-[350] bg-white text-on-surface flex flex-col">
+      <div
+        class="flex items-center justify-between px-2 pt-2"
+        style={{ paddingTop: "calc(8px + env(safe-area-inset-top))" }}
+      >
+        <IconButton name="back" aria-label="Close" onClick={onClose} />
+        <span class="md-title-medium truncate px-2">{card.label}</span>
+        <IconButton
+          name="trash"
+          aria-label="Remove card"
+          onClick={() => (confirming.value = true)}
+        />
+      </div>
+
+      <div class="flex-1 min-h-0 flex flex-col items-center justify-center gap-6 px-6">
+        <div class="text-center">
+          <div class="md-headline-small">{card.label}</div>
+          <div class="md-label-medium text-on-surface-variant uppercase tracking-wide mt-1">
+            {formatLabel(card.format)}
+          </div>
+        </div>
+
+        <div
+          class="w-full grid place-items-center"
+          style={{ maxWidth: isQr ? 260 : 360 }}
+        >
+          <Barcode value={card.value} format={card.format} class="w-full" />
+        </div>
+
+        {isQr && (
+          <div class="md-body-large tracking-wide break-all text-center text-on-surface-variant">
+            {card.value}
+          </div>
+        )}
+      </div>
+
+      {confirming.value && (
+        <div class="px-6 pb-8 pt-2 flex flex-col gap-3 border-t border-outline-variant">
+          <span class="md-body-medium text-on-surface-variant text-center">
+            Remove “{card.label}” from your cards?
+          </span>
+          <div class="flex gap-3">
+            <Button
+              variant="text"
+              full
+              onClick={() => (confirming.value = false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="error"
+              full
+              icon="trash"
+              onClick={() => onDelete(card.id)}
+            >
+              Remove
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/cards/ScannerOverlay.tsx
+++ b/components/cards/ScannerOverlay.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useRef } from "preact/hooks";
+import type { BarcodeFormat } from "@/models/index.ts";
+import { detectFormat } from "@/utils/barcode.ts";
+import { IconButton } from "@/components/md3/IconButton.tsx";
+
+// Minimal shape of the native BarcodeDetector API (not in Deno's DOM lib).
+interface DetectedBarcode {
+  rawValue: string;
+  format: string;
+}
+interface BarcodeDetectorLike {
+  detect(source: HTMLVideoElement): Promise<DetectedBarcode[]>;
+}
+interface BarcodeDetectorCtor {
+  new (options?: { formats?: string[] }): BarcodeDetectorLike;
+}
+
+/** Native BarcodeDetector format names → our supported symbologies. */
+const DETECTED_FORMAT: Record<string, BarcodeFormat> = {
+  ean_13: "ean13",
+  ean_8: "ean8",
+  upc_a: "upca",
+  code_128: "code128",
+  qr_code: "qrcode",
+};
+
+/** True when the browser can scan barcodes from the camera (Android/Chrome). */
+export function scannerSupported(): boolean {
+  return typeof globalThis !== "undefined" &&
+    "BarcodeDetector" in globalThis &&
+    !!navigator?.mediaDevices?.getUserMedia;
+}
+
+interface ScannerOverlayProps {
+  onDetect: (value: string, format: BarcodeFormat) => void;
+  onClose: () => void;
+  onError: (message: string) => void;
+}
+
+/**
+ * Full-screen camera scanner. Streams the rear camera and polls the native
+ * BarcodeDetector until a code is found, then hands the value + mapped format
+ * back. Only mounted when {@link scannerSupported} is true; any camera or
+ * permission error surfaces via `onError` and closes.
+ */
+export function ScannerOverlay(
+  { onDetect, onClose, onError }: ScannerOverlayProps,
+) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    let stream: MediaStream | null = null;
+    let timer = 0;
+    let done = false;
+
+    const Ctor = (globalThis as unknown as {
+      BarcodeDetector?: BarcodeDetectorCtor;
+    }).BarcodeDetector;
+
+    const stop = () => {
+      done = true;
+      clearTimeout(timer);
+      stream?.getTracks().forEach((t) => t.stop());
+    };
+
+    const finish = (value: string, format: BarcodeFormat) => {
+      if (done) return;
+      stop();
+      onDetect(value, format);
+    };
+
+    const start = async () => {
+      if (!Ctor) {
+        onError("Scanning isn't available on this device.");
+        onClose();
+        return;
+      }
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({
+          video: { facingMode: "environment" },
+        });
+        // The overlay may have been closed while the permission prompt was
+        // open — `stop()` ran before `stream` existed, so release it now
+        // rather than leaving the camera on.
+        const video = videoRef.current;
+        if (done || !video) {
+          stream.getTracks().forEach((t) => t.stop());
+          return;
+        }
+        video.srcObject = stream;
+        await video.play();
+
+        const detector = new Ctor();
+        // Poll a few times a second — plenty for scanning, far lighter than
+        // running the detector on every animation frame.
+        const scan = async () => {
+          if (done) return;
+          try {
+            const codes = await detector.detect(video);
+            if (codes.length > 0) {
+              const { rawValue, format } = codes[0];
+              finish(
+                rawValue,
+                DETECTED_FORMAT[format] ?? detectFormat(rawValue),
+              );
+              return;
+            }
+          } catch {
+            // Transient detect failures are fine — keep polling.
+          }
+          timer = setTimeout(scan, 200);
+        };
+        scan();
+      } catch (_err) {
+        onError("Couldn't access the camera. Check the permission and retry.");
+        stop();
+        onClose();
+      }
+    };
+
+    start();
+    return stop;
+  }, []);
+
+  return (
+    <div class="fixed inset-0 z-[400] bg-black flex flex-col">
+      <div
+        class="flex items-center justify-between px-4 pt-3"
+        style={{ paddingTop: "calc(12px + env(safe-area-inset-top))" }}
+      >
+        <span class="md-title-medium text-white">Scan a barcode</span>
+        <IconButton
+          name="x"
+          aria-label="Close scanner"
+          onClick={onClose}
+          class="text-white"
+        />
+      </div>
+      <div class="relative flex-1 min-h-0">
+        <video
+          ref={videoRef}
+          playsInline
+          muted
+          class="absolute inset-0 w-full h-full object-cover"
+        />
+        {/* Aiming frame */}
+        <div class="absolute inset-0 grid place-items-center pointer-events-none">
+          <div
+            class="border-2 border-white/80 rounded-[var(--md-shape-lg)]"
+            style={{ width: "70%", maxWidth: 320, aspectRatio: "1.6 / 1" }}
+          />
+        </div>
+      </div>
+      <div class="px-6 py-6 text-center">
+        <span class="md-body-medium text-white/80">
+          Point the camera at the loyalty card's barcode.
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/components/cards/palette.ts
+++ b/components/cards/palette.ts
@@ -1,0 +1,31 @@
+/**
+ * Preset accent colours for loyalty-card tiles. Cards store the `key`; the tile
+ * and present view read `bg`/`fg` from here. Decorative only — deliberately not
+ * tied to the MD3 token scheme so cards stay visually distinct from app chrome.
+ */
+export interface CardColor {
+  key: string;
+  bg: string;
+  fg: string;
+}
+
+export const CARD_COLORS: CardColor[] = [
+  { key: "teal", bg: "#0F766E", fg: "#FFFFFF" },
+  { key: "indigo", bg: "#4338CA", fg: "#FFFFFF" },
+  { key: "rose", bg: "#BE123C", fg: "#FFFFFF" },
+  { key: "amber", bg: "#B45309", fg: "#FFFFFF" },
+  { key: "green", bg: "#15803D", fg: "#FFFFFF" },
+  { key: "slate", bg: "#334155", fg: "#FFFFFF" },
+];
+
+export const DEFAULT_CARD_COLOR = CARD_COLORS[0].key;
+
+/** Resolve a stored colour key to its swatch, falling back to the default. */
+export function resolveColor(key?: string): CardColor {
+  return CARD_COLORS.find((c) => c.key === key) ?? CARD_COLORS[0];
+}
+
+/** Pick a rotating default so a fresh card differs from the previous one. */
+export function nextColor(index: number): string {
+  return CARD_COLORS[index % CARD_COLORS.length].key;
+}

--- a/components/md3/Barcode.test.tsx
+++ b/components/md3/Barcode.test.tsx
@@ -1,0 +1,22 @@
+import { assertStringIncludes } from "jsr:@std/assert@^1.0.19";
+import { render } from "npm:preact-render-to-string@^6.6.3";
+import { h } from "preact";
+import { Barcode } from "./Barcode.tsx";
+
+Deno.test("Barcode — renders an SVG image for a valid EAN-13", () => {
+  const html = render(h(Barcode, { value: "9520123456788", format: "ean13" }));
+  assertStringIncludes(html, "data:image/svg+xml");
+});
+
+Deno.test("Barcode — renders an SVG image for a QR code", () => {
+  const html = render(
+    h(Barcode, { value: "https://happie.app/card/42", format: "qrcode" }),
+  );
+  assertStringIncludes(html, "data:image/svg+xml");
+});
+
+Deno.test("Barcode — friendly fallback when the value can't be encoded", () => {
+  // A non-numeric value is invalid for EAN-13, so bwip-js throws.
+  const html = render(h(Barcode, { value: "not-a-barcode", format: "ean13" }));
+  assertStringIncludes(html, "render");
+});

--- a/components/md3/Barcode.tsx
+++ b/components/md3/Barcode.tsx
@@ -1,0 +1,71 @@
+import bwipjs from "@bwip-js/browser";
+import type { BarcodeFormat } from "@/models/index.ts";
+import { cn } from "@/components/md3/tokens.ts";
+
+interface BarcodeProps {
+  value: string;
+  format: BarcodeFormat;
+  /** Show the human-readable digits under a linear symbology (ignored for QR). */
+  includeText?: boolean;
+  class?: string;
+}
+
+/**
+ * Encode `value` as a crisp, self-scaling SVG barcode. bwip-js's `toSVG` is a
+ * pure function (no DOM), so this renders identically on the server and client
+ * — the barcode is visible before hydration with no hydration mismatch. The SVG
+ * is served as an `<img>` data URI (rather than injected HTML) so it scales as a
+ * vector while keeping markup safe.
+ */
+function toSvg(
+  value: string,
+  format: BarcodeFormat,
+  includeText: boolean,
+): string {
+  const isQr = format === "qrcode";
+  return bwipjs.toSVG({
+    bcid: format,
+    text: value,
+    scale: isQr ? 4 : 3,
+    ...(isQr ? {} : {
+      height: 14,
+      includetext: includeText,
+      textxalign: "center",
+    }),
+  });
+}
+
+export function Barcode(
+  { value, format, includeText = true, class: cls }: BarcodeProps,
+) {
+  let svg: string | null = null;
+  try {
+    svg = toSvg(value, format, includeText);
+  } catch {
+    svg = null;
+  }
+
+  if (!svg) {
+    return (
+      <div
+        class={cn(
+          "grid place-items-center text-center md-body-small text-on-surface-variant p-4",
+          cls,
+        )}
+        role="img"
+        aria-label="Barcode could not be rendered"
+      >
+        Couldn't render this barcode — check the number.
+      </div>
+    );
+  }
+
+  const src = `data:image/svg+xml,${encodeURIComponent(svg)}`;
+  return (
+    <img
+      src={src}
+      alt={`${format} barcode`}
+      class={cn("block w-full h-auto", cls)}
+    />
+  );
+}

--- a/database/index.ts
+++ b/database/index.ts
@@ -8,3 +8,4 @@ export * from "./household.repo.ts";
 export * from "./category.repo.ts";
 export * from "./dish.repo.ts";
 export * from "./dish-tag-group.repo.ts";
+export * from "./loyalty-card.repo.ts";

--- a/database/loyalty-card.repo.test.ts
+++ b/database/loyalty-card.repo.test.ts
@@ -1,0 +1,129 @@
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import { LoyaltyCardRepo } from "@/database/loyalty-card.repo.ts";
+import { getKv } from "@/database/db.ts";
+
+// Isolated in-memory KV for this test process (see shopping-list-item.repo.test.ts).
+Deno.env.set("KV_PATH", ":memory:");
+
+async function clearCards() {
+  const kv = await getKv();
+  for await (const e of kv.list({ prefix: ["loyalty_cards"] })) {
+    await kv.delete(e.key);
+  }
+}
+
+const H1 = "house-1";
+const H2 = "house-2";
+
+Deno.test({
+  name: "create + getById — round-trips fields and assigns id + createdAt",
+  sanitizeResources: false,
+  async fn() {
+    await clearCards();
+    const created = await LoyaltyCardRepo.create({
+      householdId: H1,
+      label: "Delhaize",
+      value: "5400141000000",
+      format: "ean13",
+      color: "teal",
+      createdBy: "u1",
+    });
+    assertEquals(typeof created.id, "string");
+    assertEquals(typeof created.createdAt, "string");
+    const fetched = await LoyaltyCardRepo.getById(H1, created.id);
+    assertEquals(fetched?.label, "Delhaize");
+    assertEquals(fetched?.value, "5400141000000");
+    assertEquals(fetched?.format, "ean13");
+    assertEquals(fetched?.color, "teal");
+  },
+});
+
+Deno.test({
+  name: "getAll — returns only the requesting household's cards",
+  sanitizeResources: false,
+  async fn() {
+    await clearCards();
+    await LoyaltyCardRepo.create({
+      householdId: H1,
+      label: "Ours",
+      value: "111",
+      format: "code128",
+    });
+    await LoyaltyCardRepo.create({
+      householdId: H2,
+      label: "Theirs",
+      value: "222",
+      format: "code128",
+    });
+    const mine = await LoyaltyCardRepo.getAll(H1);
+    assertEquals(mine.map((c) => c.label), ["Ours"]);
+  },
+});
+
+Deno.test({
+  name: "getById — does not leak across households",
+  sanitizeResources: false,
+  async fn() {
+    await clearCards();
+    const theirs = await LoyaltyCardRepo.create({
+      householdId: H2,
+      label: "Theirs",
+      value: "222",
+      format: "code128",
+    });
+    // Asking as H1 for a card owned by H2 must return null.
+    assertEquals(await LoyaltyCardRepo.getById(H1, theirs.id), null);
+  },
+});
+
+Deno.test({
+  name: "update — partial patch does not clobber omitted fields",
+  sanitizeResources: false,
+  async fn() {
+    await clearCards();
+    const c = await LoyaltyCardRepo.create({
+      householdId: H1,
+      label: "Old",
+      value: "999",
+      format: "code128",
+      color: "teal",
+    });
+    const updated = await LoyaltyCardRepo.update(H1, c.id, { label: "New" });
+    assertEquals(updated?.label, "New");
+    assertEquals(updated?.value, "999"); // untouched
+    assertEquals(updated?.color, "teal"); // untouched
+  },
+});
+
+Deno.test({
+  name: "update — returns null for a missing card",
+  sanitizeResources: false,
+  async fn() {
+    await clearCards();
+    assertEquals(
+      await LoyaltyCardRepo.update(H1, "nope", { label: "x" }),
+      null,
+    );
+  },
+});
+
+Deno.test({
+  name: "delete — removes only within the owning household",
+  sanitizeResources: false,
+  async fn() {
+    await clearCards();
+    const c = await LoyaltyCardRepo.create({
+      householdId: H1,
+      label: "Gone",
+      value: "1",
+      format: "code128",
+    });
+    // A delete scoped to the wrong household is a no-op.
+    await LoyaltyCardRepo.delete(H2, c.id);
+    assertEquals((await LoyaltyCardRepo.getById(H1, c.id))?.label, "Gone");
+    // The owning household can delete it.
+    await LoyaltyCardRepo.delete(H1, c.id);
+    assertEquals(await LoyaltyCardRepo.getById(H1, c.id), null);
+    assertEquals(await LoyaltyCardRepo.getAll(H1), []);
+  },
+});

--- a/database/loyalty-card.repo.ts
+++ b/database/loyalty-card.repo.ts
@@ -1,0 +1,69 @@
+import {
+  CreateLoyaltyCardDto,
+  LoyaltyCardInterface,
+  UpdateLoyaltyCardDto,
+} from "@/models/index.ts";
+import { getKv } from "./db.ts";
+import { mergeDefinedPatch } from "./merge-patch.ts";
+
+/**
+ * Loyalty cards are shared within a household. Keys are scoped by household so a
+ * member only ever reads or writes their own household's cards
+ * (`["loyalty_cards", householdId, id]`), mirroring `ShoppingListRepo`.
+ */
+export class LoyaltyCardRepo {
+  static async create(
+    data: CreateLoyaltyCardDto,
+  ): Promise<LoyaltyCardInterface> {
+    const kv = await getKv();
+    const id = crypto.randomUUID();
+    const card: LoyaltyCardInterface = {
+      ...data,
+      id,
+      createdAt: data.createdAt ?? new Date().toISOString(),
+    };
+    await kv.set(["loyalty_cards", data.householdId, id], card);
+    return card;
+  }
+
+  static async getAll(householdId: string): Promise<LoyaltyCardInterface[]> {
+    const kv = await getKv();
+    const iter = kv.list<LoyaltyCardInterface>({
+      prefix: ["loyalty_cards", householdId],
+    });
+    const cards: LoyaltyCardInterface[] = [];
+    for await (const { value } of iter) cards.push(value);
+    return cards;
+  }
+
+  static async getById(
+    householdId: string,
+    id: string,
+  ): Promise<LoyaltyCardInterface | null> {
+    const kv = await getKv();
+    const result = await kv.get<LoyaltyCardInterface>([
+      "loyalty_cards",
+      householdId,
+      id,
+    ]);
+    return result.value;
+  }
+
+  static async update(
+    householdId: string,
+    id: string,
+    patch: UpdateLoyaltyCardDto,
+  ): Promise<LoyaltyCardInterface | null> {
+    const kv = await getKv();
+    const existing = await this.getById(householdId, id);
+    if (!existing) return null;
+    const updated = mergeDefinedPatch<LoyaltyCardInterface>(existing, patch);
+    await kv.set(["loyalty_cards", householdId, id], updated);
+    return updated;
+  }
+
+  static async delete(householdId: string, id: string): Promise<void> {
+    const kv = await getKv();
+    await kv.delete(["loyalty_cards", householdId, id]);
+  }
+}

--- a/deno.json
+++ b/deno.json
@@ -29,6 +29,7 @@
     "fresh": "jsr:@fresh/core@^2.2.0",
     "preact": "npm:preact@^10.27.2",
     "@preact/signals": "npm:@preact/signals@^2.5.0",
+    "@bwip-js/browser": "npm:@bwip-js/browser@^4.11.2",
     "@fresh/plugin-vite": "jsr:@fresh/plugin-vite@^1.0.8",
     "usehooks-ts": "npm:usehooks-ts@^3.1.1",
     "vite": "npm:vite@^7.1.3",

--- a/deno.lock
+++ b/deno.lock
@@ -34,6 +34,7 @@
     "jsr:@std/uuid@^1.0.9": "1.0.9",
     "npm:@babel/core@^7.28.0": "7.28.5",
     "npm:@babel/preset-react@^7.27.1": "7.28.5_@babel+core@7.28.5",
+    "npm:@bwip-js/browser@^4.11.2": "4.11.2",
     "npm:@mjackson/node-fetch-server@0.7": "0.7.0",
     "npm:@opentelemetry/api@^1.9.0": "1.9.0",
     "npm:@preact/signals@^2.2.1": "2.5.1_preact@10.28.0",
@@ -371,6 +372,9 @@
         "@babel/helper-string-parser",
         "@babel/helper-validator-identifier"
       ]
+    },
+    "@bwip-js/browser@4.11.2": {
+      "integrity": "sha512-+6wZZY218c0Q6e9xjpESAs851ezWp8pZp2vS7WSjwX0GBOeGoT04NbvgHWPvtg4NIWXEIxoOgSBPnhmkFXhyNg=="
     },
     "@esbuild/aix-ppc64@0.25.7": {
       "integrity": "sha512-uD0kKFHh6ETr8TqEtaAcV+dn/2qnYbH/+8wGEdY70Qf7l1l/jmBUbrmQqwiPKAQE6cOQ7dTj6Xr0HzQDGHyceQ==",
@@ -1328,6 +1332,7 @@
     "dependencies": [
       "jsr:@fresh/core@^2.2.0",
       "jsr:@fresh/plugin-vite@^1.0.8",
+      "npm:@bwip-js/browser@^4.11.2",
       "npm:@preact/signals@^2.5.0",
       "npm:@tailwindcss/vite@^4.1.12",
       "npm:preact@^10.27.2",

--- a/docs/ui-ux-patterns.md
+++ b/docs/ui-ux-patterns.md
@@ -358,6 +358,46 @@ and must feel native on a phone.
 
 ---
 
+## 11. Progressive enhancement for capability-gated features
+
+**Rule:** When a feature relies on a browser capability that isn't universally
+available (camera `BarcodeDetector`, Web Share, notifications…), **feature-detect
+on the client and degrade gracefully.** The core flow must always work without
+it; the capability is purely additive.
+
+**Why:** The app is a mobile-first PWA spanning Android/Chrome and iOS Safari,
+whose capabilities differ. Loyalty cards must be addable by **typing** a number
+on every device; camera scanning is a shortcut offered only where it exists.
+Assuming a capability breaks the whole screen on browsers that lack it.
+
+**How:**
+
+- Initialise a `useSignal(false)` and flip it to `true` inside a mount
+  `useEffect` **only** when the capability is present — so SSR and the first
+  client render agree (no hydration mismatch), then the enhanced control appears
+  after hydration.
+- Conditionally render the enhanced affordance on that signal; the fallback path
+  (manual entry) is always present.
+- Wrap the capability's async calls in `try/catch` and surface failures via a
+  **Snackbar** (see §3) rather than letting them throw.
+
+```ts
+const available = useSignal(false);
+useEffect(() => {
+  if (scannerSupported()) available.value = true; // client-only probe
+}, []);
+// …
+{available.value && <button onClick={openScanner}>Scan</button>}
+```
+
+**See:** `components/cards/ScannerOverlay.tsx` (`scannerSupported()` +
+`getUserMedia`/`BarcodeDetector` in a guarded effect), `islands/cards/LoyaltyWallet.tsx`
+(`scannerAvailable`). Barcodes themselves render from a pure library call
+(`bwip-js` `toSVG`) served as an `<img>` data URI — see
+`components/md3/Barcode.tsx`.
+
+---
+
 ## Review checklist for user-facing changes
 
 Before merging anything the user sees, tick these (section refs in parens):

--- a/hooks/useLoyaltyCards.test.ts
+++ b/hooks/useLoyaltyCards.test.ts
@@ -1,0 +1,91 @@
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import { stub } from "jsr:@std/testing@^1.0.18/mock";
+import { api } from "@/services/api.ts";
+import { useLoyaltyCards } from "@/hooks/useLoyaltyCards.ts";
+import type { LoyaltyCardInterface } from "@/models/index.ts";
+
+const card = (
+  id: string,
+  label: string,
+  value = "9520123456788",
+): LoyaltyCardInterface => ({
+  id,
+  householdId: "h1",
+  label,
+  value,
+  format: "ean13",
+});
+
+Deno.test("sorted — alphabetical by label (case-insensitive)", () => {
+  const hook = useLoyaltyCards([
+    card("1", "delhaize"),
+    card("2", "Aldi"),
+    card("3", "Carrefour"),
+  ]);
+  assertEquals(hook.sorted.value.map((c) => c.label), [
+    "Aldi",
+    "Carrefour",
+    "delhaize",
+  ]);
+});
+
+Deno.test("addCard — pessimistic: appends only the server-returned card", async () => {
+  const created = card("new", "Colruyt");
+  const create = stub(api.cards, "create", () => Promise.resolve(created));
+  const hook = useLoyaltyCards([card("1", "Aldi")]);
+  try {
+    const result = await hook.addCard({
+      label: "Colruyt",
+      value: "9520123456788",
+      format: "ean13",
+    });
+    assertEquals(result, created);
+    assertEquals(hook.cards.value.map((c) => c.id), ["1", "new"]);
+    assertEquals(create.calls.length, 1);
+  } finally {
+    create.restore();
+  }
+});
+
+Deno.test("addCard — on failure, returns null and does not add", async () => {
+  const create = stub(api.cards, "create", () => Promise.resolve(null));
+  const hook = useLoyaltyCards([card("1", "Aldi")]);
+  try {
+    const result = await hook.addCard({
+      label: "Broken",
+      value: "bad",
+      format: "ean13",
+    });
+    assertEquals(result, null);
+    assertEquals(hook.cards.value.map((c) => c.id), ["1"]);
+  } finally {
+    create.restore();
+  }
+});
+
+Deno.test("removeCard — optimistically removes and calls the API", async () => {
+  const del = stub(api.cards, "delete", () => Promise.resolve());
+  const hook = useLoyaltyCards([card("1", "Aldi"), card("2", "Lidl")]);
+  try {
+    await hook.removeCard("1");
+    assertEquals(hook.cards.value.map((c) => c.id), ["2"]);
+    assertEquals(del.calls.length, 1);
+  } finally {
+    del.restore();
+  }
+});
+
+Deno.test("refresh — re-pulls cards from the API", async () => {
+  const hook = useLoyaltyCards([card("1", "Old")]);
+  const getAll = stub(
+    api.cards,
+    "getAll",
+    () => Promise.resolve([card("2", "Fresh"), card("3", "New")]),
+  );
+  try {
+    await hook.refresh();
+  } finally {
+    getAll.restore();
+  }
+  assertEquals(hook.cards.value.map((c) => c.label), ["Fresh", "New"]);
+});

--- a/hooks/useLoyaltyCards.ts
+++ b/hooks/useLoyaltyCards.ts
@@ -1,0 +1,67 @@
+import { computed, signal } from "@preact/signals";
+import type { LoyaltyCardInput, LoyaltyCardInterface } from "@/models/index.ts";
+import { api } from "@/services/api.ts";
+import { beginBusy, endBusy } from "@/utils/loading.ts";
+
+/**
+ * Reactive store for a household's loyalty cards. Follows the app's mutation
+ * conventions: creates are **pessimistic** (server mints the id, so we wait for
+ * the returned card), deletes are **optimistic** (removed locally immediately).
+ * The `api` boundary never throws — `addCard` returns `null` on failure so the
+ * island can surface a snackbar.
+ */
+export function useLoyaltyCards(initialCards: LoyaltyCardInterface[]) {
+  const cards = signal<LoyaltyCardInterface[]>(initialCards ?? []);
+  const pendingCount = signal(0);
+
+  const startPending = () => {
+    pendingCount.value++;
+    beginBusy();
+  };
+  const endPending = () => {
+    pendingCount.value--;
+    endBusy();
+  };
+
+  const sorted = computed<LoyaltyCardInterface[]>(() =>
+    [...cards.value].sort((a, b) =>
+      a.label.toLowerCase().localeCompare(b.label.toLowerCase())
+    )
+  );
+
+  const addCard = async (
+    input: LoyaltyCardInput,
+  ): Promise<LoyaltyCardInterface | null> => {
+    startPending();
+    try {
+      const created = await api.cards.create(input);
+      if (created) cards.value = [...cards.value, created];
+      return created;
+    } finally {
+      endPending();
+    }
+  };
+
+  const removeCard = async (id: string): Promise<void> => {
+    cards.value = cards.value.filter((c) => c.id !== id);
+    startPending();
+    try {
+      await api.cards.delete(id);
+    } finally {
+      endPending();
+    }
+  };
+
+  const refresh = async (): Promise<void> => {
+    // Pull-to-refresh renders its own spinner, so this intentionally tracks
+    // pendingCount without driving the global loading bar (beginBusy/endBusy).
+    pendingCount.value++;
+    try {
+      cards.value = await api.cards.getAll();
+    } finally {
+      pendingCount.value--;
+    }
+  };
+
+  return { cards, pendingCount, sorted, addCard, removeCard, refresh };
+}

--- a/islands/cards/LoyaltyWallet.tsx
+++ b/islands/cards/LoyaltyWallet.tsx
@@ -1,0 +1,215 @@
+import { useMemo } from "preact/hooks";
+import { useEffect } from "preact/hooks";
+import { useSignal } from "@preact/signals";
+import type { BarcodeFormat, LoyaltyCardInterface } from "@/models/index.ts";
+import { useLoyaltyCards } from "@/hooks/useLoyaltyCards.ts";
+import { formatLabel } from "@/utils/barcode.ts";
+import { PullToRefresh } from "@/components/md3/PullToRefresh.tsx";
+import { Sheet } from "@/components/md3/Sheet.tsx";
+import { Snackbar } from "@/components/md3/Snackbar.tsx";
+import { Icon } from "@/components/md3/Icon.tsx";
+import { Pressable } from "@/components/md3/Pressable.tsx";
+import { Button } from "@/components/md3/Button.tsx";
+import Fab from "@/islands/shell/Fab.tsx";
+import { CardForm } from "@/components/cards/CardForm.tsx";
+import { CardPresent } from "@/components/cards/CardPresent.tsx";
+import {
+  ScannerOverlay,
+  scannerSupported,
+} from "@/components/cards/ScannerOverlay.tsx";
+import {
+  DEFAULT_CARD_COLOR,
+  nextColor,
+  resolveColor,
+} from "@/components/cards/palette.ts";
+
+interface Props {
+  initialCards: LoyaltyCardInterface[];
+}
+
+/** `•••• 1234` for longer numbers; the raw value for short ones. */
+function maskValue(value: string): string {
+  const v = value.trim();
+  if (v.length <= 4) return v;
+  return `•••• ${v.slice(-4)}`;
+}
+
+export default function LoyaltyWallet({ initialCards }: Props) {
+  // useMemo([]) so the hook's signals are created once from SSR props.
+  const { sorted, cards, addCard, removeCard, refresh } = useMemo(
+    () => useLoyaltyCards(initialCards),
+    [],
+  );
+
+  const addOpen = useSignal(false);
+  const scannerOpen = useSignal(false);
+  const present = useSignal<LoyaltyCardInterface | null>(null);
+  const saving = useSignal(false);
+  const scannerAvailable = useSignal(false);
+  const snack = useSignal<{ msg: string } | null>(null);
+
+  const form = {
+    label: useSignal(""),
+    value: useSignal(""),
+    format: useSignal<BarcodeFormat>("code128"),
+    color: useSignal(DEFAULT_CARD_COLOR),
+    manualFormat: useSignal(false),
+  };
+
+  // Feature-detect the camera scanner on the client only (avoids SSR mismatch).
+  useEffect(() => {
+    if (scannerSupported()) scannerAvailable.value = true;
+  }, []);
+
+  const toast = (msg: string) => {
+    snack.value = { msg };
+    setTimeout(() => (snack.value = null), 2400);
+  };
+
+  const openAdd = () => {
+    form.label.value = "";
+    form.value.value = "";
+    form.format.value = "code128";
+    form.color.value = nextColor(cards.value.length);
+    form.manualFormat.value = false;
+    addOpen.value = true;
+  };
+
+  const onScanDetect = (value: string, format: BarcodeFormat) => {
+    form.value.value = value;
+    form.format.value = format;
+    form.manualFormat.value = true;
+    scannerOpen.value = false;
+  };
+
+  const handleSave = async () => {
+    saving.value = true;
+    const created = await addCard({
+      label: form.label.value.trim(),
+      value: form.value.value.trim(),
+      format: form.format.value,
+      color: form.color.value,
+    });
+    saving.value = false;
+    if (!created) {
+      toast("Couldn't save that card — try again.");
+      return;
+    }
+    addOpen.value = false;
+  };
+
+  const handleDelete = (id: string) => {
+    present.value = null;
+    removeCard(id);
+    toast("Card removed.");
+  };
+
+  const list = sorted.value;
+
+  return (
+    <PullToRefresh onRefresh={refresh}>
+      <div class="px-4 pt-4 pb-[calc(96px+env(safe-area-inset-bottom))] flex flex-col gap-4">
+        <div class="flex flex-col gap-1">
+          <h1 class="md-title-large text-on-surface">Loyalty cards</h1>
+          <p class="md-body-medium text-on-surface-variant">
+            Your household's cards, ready to scan at the till.
+          </p>
+        </div>
+
+        {list.length === 0
+          ? (
+            <div class="px-2 pt-8 text-center flex flex-col items-center gap-4">
+              <span
+                class="grid place-items-center bg-primary-container text-on-primary-container rounded-full"
+                style={{ width: 64, height: 64 }}
+              >
+                <Icon name="card" size={30} />
+              </span>
+              <div class="md-title-medium text-on-surface">No cards yet</div>
+              <p class="md-body-medium text-on-surface-variant max-w-xs">
+                Add your first loyalty card and Happie will show its barcode
+                whenever you shop.
+              </p>
+              <Button variant="tonal" icon="plus" onClick={openAdd}>
+                Add a card
+              </Button>
+            </div>
+          )
+          : (
+            <div class="flex flex-col gap-3">
+              {list.map((c) => {
+                const color = resolveColor(c.color);
+                return (
+                  <Pressable
+                    key={c.id}
+                    onClick={() => (present.value = c)}
+                    aria-label={`Show ${c.label} barcode`}
+                    class="flex flex-col justify-between text-left rounded-[var(--md-shape-lg)] px-5 py-4 md-elevation-1"
+                    style={{
+                      background: color.bg,
+                      color: color.fg,
+                      minHeight: 96,
+                    }}
+                  >
+                    <div class="flex items-start justify-between gap-3">
+                      <span class="md-title-medium truncate">{c.label}</span>
+                      <Icon name="card" size={22} />
+                    </div>
+                    <span class="md-body-small" style={{ opacity: 0.85 }}>
+                      {formatLabel(c.format)} · {maskValue(c.value)}
+                    </span>
+                  </Pressable>
+                );
+              })}
+            </div>
+          )}
+      </div>
+
+      {/* Add-card FAB — shared component, fixed below the nav chrome */}
+      <div
+        class="fixed right-4 z-30"
+        style={{ bottom: "calc(96px + env(safe-area-inset-bottom))" }}
+      >
+        <Fab
+          icon="plus"
+          label="Add card"
+          aria-label="Add card"
+          onClick={openAdd}
+        />
+      </div>
+
+      <Sheet
+        open={addOpen.value}
+        onClose={() => (addOpen.value = false)}
+        title="Add a card"
+      >
+        <CardForm
+          form={form}
+          scannerAvailable={scannerAvailable.value}
+          saving={saving.value}
+          onScan={() => (scannerOpen.value = true)}
+          onSubmit={handleSave}
+          onCancel={() => (addOpen.value = false)}
+        />
+      </Sheet>
+
+      {scannerOpen.value && (
+        <ScannerOverlay
+          onDetect={onScanDetect}
+          onClose={() => (scannerOpen.value = false)}
+          onError={(msg) => toast(msg)}
+        />
+      )}
+
+      {present.value && (
+        <CardPresent
+          card={present.value}
+          onClose={() => (present.value = null)}
+          onDelete={handleDelete}
+        />
+      )}
+
+      <Snackbar data={snack.value} />
+    </PullToRefresh>
+  );
+}

--- a/islands/shell/MoreSheet.tsx
+++ b/islands/shell/MoreSheet.tsx
@@ -59,7 +59,10 @@ export default function MoreSheet({ open, onClose }: MoreSheetProps) {
           leading={badge("card")}
           headline="Loyalty cards"
           trailing={chevron()}
-          onClick={() => soon("Loyalty cards")}
+          onClick={() => {
+            onClose();
+            navigateTo("/cards");
+          }}
         />
         <div
           class="md-label-medium text-on-surface-variant uppercase tracking-wide"

--- a/models/index.ts
+++ b/models/index.ts
@@ -5,3 +5,4 @@ export * from "./shopping-list/index.ts";
 export * from "./category/index.ts";
 export * from "./household/index.ts";
 export * from "./dish/index.ts";
+export * from "./loyalty-card/index.ts";

--- a/models/loyalty-card/index.ts
+++ b/models/loyalty-card/index.ts
@@ -1,0 +1,1 @@
+export * from "./loyalty-card.interface.ts";

--- a/models/loyalty-card/loyalty-card.interface.ts
+++ b/models/loyalty-card/loyalty-card.interface.ts
@@ -1,0 +1,39 @@
+/**
+ * The barcode symbologies we support for loyalty cards. Values map directly to
+ * bwip-js `bcid` names (see `utils/barcode.ts`). Linear numeric formats cover
+ * the overwhelming majority of retail loyalty cards; `qrcode` covers app-style
+ * cards; `code128` is the flexible alphanumeric fallback.
+ */
+export type BarcodeFormat = "ean13" | "ean8" | "upca" | "code128" | "qrcode";
+
+export interface LoyaltyCardInterface {
+  id: string;
+  householdId: string;
+  /** Human label for identification, e.g. "Delhaize", "Air Miles". */
+  label: string;
+  /** The card number / barcode payload that gets encoded. */
+  value: string;
+  format: BarcodeFormat;
+  /** Optional accent colour for the wallet tile (a preset token key). */
+  color?: string;
+  createdAt?: string;
+  createdBy?: string;
+}
+
+// Derived type for creation (no ID — the server mints it).
+export type CreateLoyaltyCardDto = Omit<LoyaltyCardInterface, "id">;
+
+/**
+ * What the client sends to create a card. The server fills in `householdId`,
+ * `createdBy`, `createdAt` and `id` from the session — the client never sends
+ * (and cannot spoof) the household.
+ */
+export type LoyaltyCardInput = Pick<
+  LoyaltyCardInterface,
+  "label" | "value" | "format" | "color"
+>;
+
+// Derived type for patch/update: never the id or householdId, everything else optional.
+export type UpdateLoyaltyCardDto = Partial<
+  Omit<LoyaltyCardInterface, "id" | "householdId">
+>;

--- a/routes/api/cards/index.test.ts
+++ b/routes/api/cards/index.test.ts
@@ -1,0 +1,157 @@
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import { type Context } from "fresh";
+import { handler } from "@/routes/api/cards/index.ts";
+import { getKv } from "@/database/db.ts";
+
+Deno.env.set("KV_PATH", ":memory:");
+
+interface State {
+  userId?: string;
+  householdId?: string;
+}
+
+function ctx(req: Request, state: State = {}): Context<State> {
+  return { req, state } as unknown as Context<State>;
+}
+
+async function clearCards() {
+  const kv = await getKv();
+  for await (const e of kv.list({ prefix: ["loyalty_cards"] })) {
+    await kv.delete(e.key);
+  }
+}
+
+const AUTH: State = { userId: "u1", householdId: "h1" };
+
+const post = (body: unknown) =>
+  new Request("http://x/api/cards", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+const del = (body: unknown) =>
+  new Request("http://x/api/cards", {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+const validCard = {
+  label: "Delhaize",
+  value: "9520123456788",
+  format: "ean13",
+  color: "teal",
+};
+
+Deno.test({
+  name: "POST creates (201), GET lists it for the household",
+  sanitizeResources: false,
+  async fn() {
+    await clearCards();
+    const createRes = await handler.POST(ctx(post(validCard), AUTH));
+    assertEquals(createRes.status, 201);
+    const created = await createRes.json();
+    assertEquals(created.label, "Delhaize");
+    assertEquals(created.householdId, "h1");
+    assertEquals(created.createdBy, "u1");
+
+    const listRes = await handler.GET(
+      ctx(new Request("http://x/api/cards"), AUTH),
+    );
+    assertEquals(listRes.status, 200);
+    const list = await listRes.json();
+    assertEquals(list.map((c: { label: string }) => c.label), ["Delhaize"]);
+  },
+});
+
+Deno.test({
+  name: "GET / POST / DELETE require a household (401)",
+  sanitizeResources: false,
+  async fn() {
+    await clearCards();
+    assertEquals(
+      (await handler.GET(ctx(new Request("http://x/api/cards")))).status,
+      401,
+    );
+    assertEquals((await handler.POST(ctx(post(validCard)))).status, 401);
+    assertEquals(
+      (await handler.DELETE(ctx(del({ id: "x" })))).status,
+      401,
+    );
+  },
+});
+
+Deno.test({
+  name: "GET does not leak other households' cards",
+  sanitizeResources: false,
+  async fn() {
+    await clearCards();
+    await handler.POST(
+      ctx(post(validCard), { userId: "u2", householdId: "h2" }),
+    );
+    const listRes = await handler.GET(
+      ctx(new Request("http://x/api/cards"), AUTH),
+    );
+    assertEquals(await listRes.json(), []);
+  },
+});
+
+Deno.test({
+  name: "POST rejects missing label (400)",
+  sanitizeResources: false,
+  async fn() {
+    await clearCards();
+    const res = await handler.POST(
+      ctx(post({ ...validCard, label: "  " }), AUTH),
+    );
+    assertEquals(res.status, 400);
+  },
+});
+
+Deno.test({
+  name: "POST rejects an unknown format (400)",
+  sanitizeResources: false,
+  async fn() {
+    await clearCards();
+    const res = await handler.POST(
+      ctx(post({ ...validCard, format: "bogus" }), AUTH),
+    );
+    assertEquals(res.status, 400);
+  },
+});
+
+Deno.test({
+  name: "POST rejects a value that fails its symbology's validation (400)",
+  sanitizeResources: false,
+  async fn() {
+    await clearCards();
+    // Wrong EAN-13 check digit.
+    const res = await handler.POST(
+      ctx(post({ ...validCard, value: "9520123456789" }), AUTH),
+    );
+    assertEquals(res.status, 400);
+  },
+});
+
+Deno.test({
+  name: "DELETE removes a card (204); missing id is 400",
+  sanitizeResources: false,
+  async fn() {
+    await clearCards();
+    const created = await (await handler.POST(ctx(post(validCard), AUTH)))
+      .json();
+    assertEquals(
+      (await handler.DELETE(ctx(del({ id: created.id }), AUTH))).status,
+      204,
+    );
+    assertEquals(
+      (await handler.DELETE(ctx(del({}), AUTH))).status,
+      400,
+    );
+    const list = await (await handler.GET(
+      ctx(new Request("http://x/api/cards"), AUTH),
+    )).json();
+    assertEquals(list, []);
+  },
+});

--- a/routes/api/cards/index.ts
+++ b/routes/api/cards/index.ts
@@ -1,0 +1,66 @@
+import { define } from "@/utils/index.ts";
+import { LoyaltyCardRepo } from "@/database/index.ts";
+import type { BarcodeFormat } from "@/models/index.ts";
+import { validateBarcode } from "@/utils/barcode.ts";
+
+const FORMATS = new Set<BarcodeFormat>([
+  "ean13",
+  "ean8",
+  "upca",
+  "code128",
+  "qrcode",
+]);
+
+const json = (data: unknown, status: number) =>
+  new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+export const handler = define.handlers({
+  async GET(ctx) {
+    const householdId = ctx.state.householdId;
+    if (!householdId) return new Response("Unauthorized", { status: 401 });
+    const cards = await LoyaltyCardRepo.getAll(householdId);
+    return json(cards, 200);
+  },
+
+  async POST(ctx) {
+    const { userId, householdId } = ctx.state;
+    if (!userId || !householdId) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+    const body = await ctx.req.json();
+    const label = String(body.label ?? "").trim();
+    const value = String(body.value ?? "").trim();
+    const format = body.format as BarcodeFormat;
+    const color = body.color ? String(body.color) : undefined;
+
+    if (!label) return new Response("label required", { status: 400 });
+    if (!FORMATS.has(format)) {
+      return new Response("invalid format", { status: 400 });
+    }
+    const check = validateBarcode(value, format);
+    if (!check.ok) return new Response(check.message, { status: 400 });
+
+    const card = await LoyaltyCardRepo.create({
+      householdId,
+      label,
+      value,
+      format,
+      color,
+      createdBy: userId,
+      createdAt: new Date().toISOString(),
+    });
+    return json(card, 201);
+  },
+
+  async DELETE(ctx) {
+    const householdId = ctx.state.householdId;
+    if (!householdId) return new Response("Unauthorized", { status: 401 });
+    const { id } = await ctx.req.json();
+    if (!id) return new Response("ID is required", { status: 400 });
+    await LoyaltyCardRepo.delete(householdId, id);
+    return new Response(null, { status: 204 });
+  },
+});

--- a/routes/cards/index.tsx
+++ b/routes/cards/index.tsx
@@ -1,0 +1,20 @@
+import { page } from "fresh";
+import { LoyaltyCardRepo } from "@/database/index.ts";
+import LoyaltyWallet from "@/islands/cards/LoyaltyWallet.tsx";
+import { define } from "@/utils/index.ts";
+
+export const handler = define.handlers({
+  async GET(ctx) {
+    const householdId = ctx.state.householdId;
+    const cards = householdId ? await LoyaltyCardRepo.getAll(householdId) : [];
+    return page({ cards });
+  },
+});
+
+export default define.page<typeof handler>(function CardsPage({ data }) {
+  return (
+    <main class="max-w-md mx-auto">
+      <LoyaltyWallet initialCards={data.cards} />
+    </main>
+  );
+});

--- a/services/api.ts
+++ b/services/api.ts
@@ -11,6 +11,7 @@ import {
   DishTagGroupInterface,
   DishTagValueInterface,
 } from "@/models/index.ts";
+import { LoyaltyCardInput, LoyaltyCardInterface } from "@/models/index.ts";
 
 export const api = {
   items: {
@@ -200,6 +201,31 @@ export const api = {
     },
     delete: async (id: string): Promise<void> => {
       await fetch("/api/menu/dishes", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id }),
+      });
+    },
+  },
+  cards: {
+    getAll: async (): Promise<LoyaltyCardInterface[]> => {
+      const res = await fetch("/api/cards");
+      if (!res.ok) return [];
+      return res.json();
+    },
+    create: async (
+      card: LoyaltyCardInput,
+    ): Promise<LoyaltyCardInterface | null> => {
+      const res = await fetch("/api/cards", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(card),
+      });
+      if (!res.ok) return null;
+      return res.json();
+    },
+    delete: async (id: string): Promise<void> => {
+      await fetch("/api/cards", {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ id }),

--- a/utils/barcode.test.ts
+++ b/utils/barcode.test.ts
@@ -1,0 +1,84 @@
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import {
+  detectFormat,
+  formatLabel,
+  SUPPORTED_FORMATS,
+  validateBarcode,
+} from "@/utils/barcode.ts";
+
+Deno.test("detectFormat — 13 digits → ean13", () => {
+  assertEquals(detectFormat("9520123456788"), "ean13");
+});
+
+Deno.test("detectFormat — 12 digits → upca", () => {
+  assertEquals(detectFormat("012345000058"), "upca");
+});
+
+Deno.test("detectFormat — 8 digits → ean8", () => {
+  assertEquals(detectFormat("95200002"), "ean8");
+});
+
+Deno.test("detectFormat — other digit lengths → code128", () => {
+  assertEquals(detectFormat("1234567"), "code128");
+  assertEquals(detectFormat("123456789012345"), "code128");
+});
+
+Deno.test("detectFormat — non-numeric → code128 (never auto-picks qr)", () => {
+  assertEquals(detectFormat("ABC-123"), "code128");
+});
+
+Deno.test("detectFormat — ignores surrounding whitespace", () => {
+  assertEquals(detectFormat("  9520123456788 "), "ean13");
+});
+
+Deno.test("validateBarcode — accepts a valid EAN-13 check digit", () => {
+  assertEquals(validateBarcode("9520123456788", "ean13").ok, true);
+});
+
+Deno.test("validateBarcode — rejects a wrong EAN-13 check digit", () => {
+  assertEquals(validateBarcode("9520123456789", "ean13").ok, false);
+});
+
+Deno.test("validateBarcode — rejects wrong-length EAN-13", () => {
+  assertEquals(validateBarcode("952012345678", "ean13").ok, false);
+});
+
+Deno.test("validateBarcode — rejects non-digit EAN-13", () => {
+  assertEquals(validateBarcode("95201234567AB", "ean13").ok, false);
+});
+
+Deno.test("validateBarcode — accepts a valid EAN-8", () => {
+  assertEquals(validateBarcode("95200002", "ean8").ok, true);
+});
+
+Deno.test("validateBarcode — accepts a valid UPC-A", () => {
+  assertEquals(validateBarcode("012345000058", "upca").ok, true);
+});
+
+Deno.test("validateBarcode — code128 accepts printable ASCII, rejects empty", () => {
+  assertEquals(validateBarcode("ABC-123", "code128").ok, true);
+  assertEquals(validateBarcode("   ", "code128").ok, false);
+});
+
+Deno.test("validateBarcode — qrcode accepts arbitrary non-empty text", () => {
+  assertEquals(
+    validateBarcode("https://happie.app/card/42", "qrcode").ok,
+    true,
+  );
+  assertEquals(validateBarcode("", "qrcode").ok, false);
+});
+
+Deno.test("formatLabel — human-readable names", () => {
+  assertEquals(formatLabel("ean13"), "EAN-13");
+  assertEquals(formatLabel("qrcode"), "QR code");
+});
+
+Deno.test("SUPPORTED_FORMATS — covers every supported symbology once", () => {
+  assertEquals(SUPPORTED_FORMATS.map((f) => f.format), [
+    "ean13",
+    "ean8",
+    "upca",
+    "code128",
+    "qrcode",
+  ]);
+});

--- a/utils/barcode.ts
+++ b/utils/barcode.ts
@@ -1,0 +1,104 @@
+import type { BarcodeFormat } from "@/models/index.ts";
+
+export type { BarcodeFormat };
+
+export type ValidationResult =
+  | { ok: true }
+  | { ok: false; message: string };
+
+/** Supported symbologies in picker order, with human labels. */
+export const SUPPORTED_FORMATS: { format: BarcodeFormat; label: string }[] = [
+  { format: "ean13", label: "EAN-13" },
+  { format: "ean8", label: "EAN-8" },
+  { format: "upca", label: "UPC-A" },
+  { format: "code128", label: "Code 128" },
+  { format: "qrcode", label: "QR code" },
+];
+
+const LABELS: Record<BarcodeFormat, string> = Object.fromEntries(
+  SUPPORTED_FORMATS.map((f) => [f.format, f.label]),
+) as Record<BarcodeFormat, string>;
+
+/** Fixed digit lengths for the numeric retail symbologies (incl. check digit). */
+const FIXED_LENGTHS: Partial<Record<BarcodeFormat, number>> = {
+  ean13: 13,
+  ean8: 8,
+  upca: 12,
+};
+
+export function formatLabel(format: BarcodeFormat): string {
+  return LABELS[format] ?? format;
+}
+
+/**
+ * Best-guess symbology from a raw value, used to preselect the format in the
+ * add-card form. Pure digit strings map to their fixed-length retail formats;
+ * anything else falls back to Code 128. We never auto-pick `qrcode` — QR is an
+ * explicit user choice, since numeric/URL payloads are ambiguous.
+ */
+export function detectFormat(value: string): BarcodeFormat {
+  const v = value.trim();
+  if (/^\d+$/.test(v)) {
+    if (v.length === 13) return "ean13";
+    if (v.length === 12) return "upca";
+    if (v.length === 8) return "ean8";
+  }
+  return "code128";
+}
+
+/**
+ * GS1 mod-10 check digit for a numeric string that already includes its check
+ * digit as the last character. Weights alternate 3,1 from the rightmost data
+ * digit — the single algorithm behind EAN-13, EAN-8 and UPC-A.
+ */
+function hasValidCheckDigit(digits: string): boolean {
+  const data = digits.slice(0, -1);
+  const check = Number(digits[digits.length - 1]);
+  let sum = 0;
+  for (let i = 0; i < data.length; i++) {
+    // Weight the rightmost data digit by 3, then alternate.
+    const weight = (data.length - 1 - i) % 2 === 0 ? 3 : 1;
+    sum += Number(data[i]) * weight;
+  }
+  return (10 - (sum % 10)) % 10 === check;
+}
+
+/**
+ * Validate a value against a chosen symbology before we store or render it, so
+ * typos surface in the form rather than as a broken barcode. Numeric formats
+ * must be the right length and pass the check digit; Code 128 accepts printable
+ * ASCII; QR accepts any non-empty text.
+ */
+export function validateBarcode(
+  value: string,
+  format: BarcodeFormat,
+): ValidationResult {
+  const v = value.trim();
+  if (!v) return { ok: false, message: "Enter a barcode value." };
+
+  const fixed = FIXED_LENGTHS[format];
+  if (fixed !== undefined) {
+    const label = formatLabel(format);
+    if (!/^\d+$/.test(v)) {
+      return { ok: false, message: `${label} must be digits only.` };
+    }
+    if (v.length !== fixed) {
+      return { ok: false, message: `${label} must be ${fixed} digits.` };
+    }
+    if (!hasValidCheckDigit(v)) {
+      return { ok: false, message: `That ${label} number looks incorrect.` };
+    }
+    return { ok: true };
+  }
+
+  if (format === "code128") {
+    // Code 128 covers the printable ASCII range (0x20–0x7E).
+    if (!/^[\x20-\x7E]+$/.test(v)) {
+      return { ok: false, message: "Use letters, digits and basic symbols." };
+    }
+    return { ok: true };
+  }
+
+  // qrcode — encodes essentially anything; just guard against empty.
+  return { ok: true };
+}


### PR DESCRIPTION
Closes #16

## What

A new household-shared **Loyalty cards** module at `/cards`. Members can add, view and remove loyalty cards and display the generated barcode full-screen to scan at the till. Reached from the existing "Loyalty cards" entry in the More menu (previously a "coming soon" stub).

## Features

- **Add cards** via a bottom sheet: name, barcode number, **auto-detected format** with manual override (EAN-13 / EAN-8 / UPC-A / Code 128 / QR), a preset **colour accent**, and a **live barcode preview**.
- **Scan** the number with the phone camera where the browser supports `BarcodeDetector` (Android/Chrome); manual entry always works where it doesn't (e.g. iOS Safari) — progressive enhancement, never a hard dependency.
- **Barcode generation** via `bwip-js` (`toSVG`), rendered as a crisp SVG `<img>` data URI so it renders identically on server and client with no hydration mismatch.
- **Present view**: full-screen, high-contrast barcode on white for reliable in-store scanning, with a confirm-guarded delete.
- **Wallet list**: coloured card tiles with masked numbers (`•••• 1234`), empty state, FAB, pull-to-refresh.

## Architecture

- `models/loyalty-card/` + `database/loyalty-card.repo.ts` — **household-scoped** KV (`["loyalty_cards", householdId, id]`), mirroring `ShoppingListRepo`.
- `routes/api/cards/index.ts` — `GET`/`POST`/`DELETE`; `householdId` derived from the session (`ctx.state`), 401 without it, server-side symbology + GS1 check-digit validation. The client payload can't set `householdId`.
- `utils/barcode.ts` — pure format detection + validation (length-agnostic GS1 mod-10 check digit).
- `hooks/useLoyaltyCards.ts` — pessimistic create, optimistic delete, via the never-throwing `api` boundary.
- `islands/cards/LoyaltyWallet.tsx` + `components/cards/*` + `components/md3/Barcode.tsx`.
- Documented the capability-gated progressive-enhancement pattern in `docs/ui-ux-patterns.md`.

## Security

Cards are household-scoped and auth-gated; `householdId` comes from the session, never the client. Numbers travel in request bodies (never URLs), aren't logged, and are masked in the list view. (Loyalty numbers must stay reproducible to scan, so they're stored plaintext in KV — as with other household data — rather than encrypted at rest.)

## Testing

TDD throughout — **37 new tests**, full suite **196 passing**, `deno task check` green. Repo (household isolation), API (validation/auth/scoping), hook (optimistic/pessimistic), barcode utils (check-digit edge cases incl. canonical real-world barcodes), and Barcode component render.

Live-verified in the browser: add (EAN-13 + QR) → live preview → save → present view → confirm-delete, plus SSR reload and the More-menu entry point.

## Review

A code review pass flagged one substantive issue — a camera stream that could leak if the scanner was closed during the permission prompt — which is fixed here (guard released the stream after `getUserMedia` resolves); the detect loop was also throttled from ~60fps to ~200ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)