### PR TITLE
feat(Pressable): make non-button hosts keyboard-activatable

### DIFF
--- a/components/md3/Pressable.test.tsx
+++ b/components/md3/Pressable.test.tsx
@@ -1,11 +1,81 @@
-import { assertStringIncludes } from "jsr:@std/assert@^1.0.19";
+import {
+  assert,
+  assertEquals,
+  assertStringIncludes,
+} from "jsr:@std/assert@^1.0.19";
 import { render } from "npm:preact-render-to-string@^6.6.3";
 import { h } from "preact";
-import { Pressable } from "./Pressable.tsx";
+import { activateOnKey, Pressable } from "./Pressable.tsx";
 
 Deno.test("Pressable — renders md-press host and a state-layer span", () => {
   const html = render(h(Pressable, { class: "x" }, "Tap"));
   assertStringIncludes(html, "md-press");
   assertStringIncludes(html, "md-state");
   assertStringIncludes(html, "Tap");
+});
+
+Deno.test("Pressable — non-button with onClick is keyboard-reachable", () => {
+  const html = render(h(Pressable, { as: "div", onClick: () => {} }, "Tap"));
+  assertStringIncludes(html, 'role="button"');
+  assertStringIncludes(html, 'tabindex="0"');
+});
+
+Deno.test("Pressable — native button keeps native semantics (no role/tabindex)", () => {
+  const html = render(h(Pressable, { onClick: () => {} }, "Tap"));
+  assert(!html.includes('role="button"'));
+  assert(!html.includes("tabindex"));
+});
+
+Deno.test("Pressable — non-button without onClick stays non-interactive", () => {
+  const html = render(h(Pressable, { as: "div" }, "Static"));
+  assert(!html.includes('role="button"'));
+  assert(!html.includes("tabindex"));
+});
+
+Deno.test("Pressable — disabled non-button is announced but not tab-focusable", () => {
+  const html = render(
+    h(Pressable, { as: "div", onClick: () => {}, disabled: true }, "Tap"),
+  );
+  assertStringIncludes(html, 'role="button"');
+  assertStringIncludes(html, 'tabindex="-1"');
+  assertStringIncludes(html, 'aria-disabled="true"');
+  assert(!html.includes('tabindex="0"'));
+});
+
+Deno.test("Pressable — caller can override role/tabindex via rest props", () => {
+  const html = render(
+    h(
+      Pressable,
+      { as: "div", onClick: () => {}, role: "menuitem", tabIndex: -1 },
+      "x",
+    ),
+  );
+  assertStringIncludes(html, 'role="menuitem"');
+  assertStringIncludes(html, 'tabindex="-1"');
+  assert(!html.includes('role="button"'));
+});
+
+Deno.test("activateOnKey — Enter and Space activate and prevent default", () => {
+  let clicks = 0;
+  let prevented = 0;
+  const activate = () => clicks++;
+  const key = (k: string) => ({ key: k, preventDefault: () => prevented++ });
+
+  activateOnKey(key("Enter"), activate);
+  activateOnKey(key(" "), activate);
+
+  assertEquals(clicks, 2);
+  assertEquals(prevented, 2); // Space (and Enter) must preventDefault — Space would scroll
+});
+
+Deno.test("activateOnKey — non-activation keys are ignored", () => {
+  let clicks = 0;
+  let prevented = 0;
+  const activate = () => clicks++;
+
+  activateOnKey({ key: "a", preventDefault: () => prevented++ }, activate);
+  activateOnKey({ key: "Tab", preventDefault: () => prevented++ }, activate);
+
+  assertEquals(clicks, 0);
+  assertEquals(prevented, 0);
 });

--- a/components/md3/Pressable.tsx
+++ b/components/md3/Pressable.tsx
@@ -36,7 +36,28 @@ interface PressableProps {
   stop?: boolean; // stopPropagation on click
   type?: string;
   "aria-label"?: string;
+  // Escape hatches: callers can override the button-role a11y defaults added
+  // for non-<button> hosts (spread last, so these win over the defaults).
+  role?: string;
+  tabIndex?: number;
+  onKeyDown?: (e: KeyboardEvent) => void;
   children?: ComponentChildren;
+}
+
+/**
+ * Activate a synthetic button on the keyboard, the way a native <button> does:
+ * Enter and Space fire the click handler, and both prevent the default (Space
+ * would otherwise scroll the page). Exported so the behavior is unit-testable
+ * without a DOM.
+ */
+export function activateOnKey(
+  e: Pick<KeyboardEvent, "key" | "preventDefault">,
+  activate: (e: Event) => void,
+) {
+  if (e.key === "Enter" || e.key === " " || e.key === "Spacebar") {
+    e.preventDefault();
+    activate(e as unknown as Event);
+  }
 }
 
 export function Pressable(
@@ -55,16 +76,30 @@ export function Pressable(
   const { rips, add } = useRipple();
   // deno-lint-ignore no-explicit-any
   const Tag = as as any;
+
+  const isButton = as === "button";
+  // A non-<button> host with an onClick is a synthetic button: give it the
+  // button role, keyboard focus, and Enter/Space activation a native button
+  // would have for free. Native <button> keeps its own semantics untouched.
+  const synthetic = !isButton && !!onClick;
+  const activate = disabled ? undefined : (e: Event) => {
+    if (stop) e.stopPropagation();
+    onClick?.(e);
+  };
+
   return (
     <Tag
       class={cn("md-press", cls)}
-      disabled={as === "button" ? disabled : undefined}
-      type={as === "button" ? (rest.type ?? "button") : undefined}
+      disabled={isButton ? disabled : undefined}
+      type={isButton ? (rest.type ?? "button") : undefined}
+      role={synthetic ? "button" : undefined}
+      tabIndex={synthetic ? (disabled ? -1 : 0) : undefined}
+      aria-disabled={synthetic && disabled ? "true" : undefined}
       onPointerDown={disabled ? undefined : add}
-      onClick={disabled ? undefined : (e: Event) => {
-        if (stop) e.stopPropagation();
-        onClick?.(e);
-      }}
+      onClick={activate}
+      onKeyDown={synthetic && activate
+        ? (e: KeyboardEvent) => activateOnKey(e, activate)
+        : undefined}
       style={{
         cursor: disabled ? "default" : "pointer",
         ...style,


### PR DESCRIPTION
## Summary

`components/md3/Pressable.tsx` rendered a plain `<div>` when `as="div"` with an `onClick` — no `role`, `tabIndex`, or keyboard handler. That made div-based click targets **mouse-only** for keyboard and screen-reader users. Since `Pressable` backs shared components used app-wide (`Card`, `ListItem`, `islands/items.tsx` rows, dish/menu tiles, `DishCatalogue`), the gap was widespread.

This adds **opt-in, automatic** accessibility when `Pressable` renders a non-`<button>` host with an `onClick`:

- `role="button"` + `tabIndex={0}` so it's announced as a button and reachable via Tab.
- `onKeyDown` that activates on **Enter/Space** (Space calls `preventDefault` so the page doesn't scroll) — the same activation a native `<button>` gets for free.
- **Disabled** → `tabIndex={-1}` + `aria-disabled="true"` (announced but not tab-focusable), no keyboard activation.
- Native `<button>` usage is **unchanged** (no role/tabindex/keydown added).
- The a11y defaults are placed before `{...rest}`, and `role`/`tabIndex`/`onKeyDown` were added to `PressableProps`, so callers can override them (e.g. `role="menuitem"`).

The click path is behaviorally identical (same `stop` + `onClick`, now named `activate`). The Enter/Space logic is extracted into an exported pure `activateOnKey(e, activate)` helper so it's unit-testable without a DOM.

Flagged as a Minor, out-of-scope finding during the weekly-menu (#41) review — a shared-component a11y improvement, not specific to that feature.

## Testing

- `deno task check` — passes (fmt + lint + type-check).
- `deno task test` — **166 passed / 0 failed**, including 8 `Pressable` tests (SSR role/tabindex for div+onClick; native button untouched; div-without-onClick stays inert; disabled handling; caller override; `activateOnKey` Enter/Space + `preventDefault`).
- Live browser check (seeded DB, logged in): after hydration, shopping-list cards rendered as `role="button" tabindex="0"` while native `<button>`s got none; **Enter** on a focused card navigated to the list; a dispatched **Space** keydown reported `defaultPrevented: true`; console clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)