### PR TITLE
Fix KV migration for the new Deno Deploy console (v2 URL + Variable id)

### DIFF
--- a/.github/workflows/migrate-prod-kv.yml
+++ b/.github/workflows/migrate-prod-kv.yml
@@ -9,12 +9,14 @@ name: Migrate production KV
 #
 # Required configuration (Settings → Secrets and variables → Actions, ideally
 # scoped to a "production" Environment — see the `environment:` note below):
-#   secrets.DENO_KV_DATABASE_ID   the production KV database id
-#                                 (Deno Deploy dashboard → project → KV)
-#   secrets.DENO_KV_ACCESS_TOKEN  a Deno Deploy access token
+#   vars.DENO_KV_DATABASE_ID      the production KV database id — a plain
+#                                 Variable (not sensitive on its own; useless
+#                                 without the access token). Deno Deploy
+#                                 dashboard → project → KV.
+#   secrets.DENO_KV_ACCESS_TOKEN  a Deno Deploy access token — a Secret
 #                                 (dashboard → account settings → Access Tokens)
 #   secrets.SEED_PASSWORD         the shared legacy password used to rehash
-#                                 pre-PBKDF2 users
+#                                 pre-PBKDF2 users — a Secret
 #
 # NOTE: the "Run workflow" button only appears once this file is on the default
 # branch (main), so merge it first, then trigger it from the Actions tab.
@@ -68,7 +70,7 @@ jobs:
         env:
           # Locally (isDeploy=false) getKv() honors KV_PATH; an https:// value
           # connects to the remote production KV via KV Connect.
-          KV_PATH: "https://api.deno.com/databases/${{ secrets.DENO_KV_DATABASE_ID }}/connect"
+          KV_PATH: "https://api.deno.com/databases/${{ vars.DENO_KV_DATABASE_ID }}/connect"
           DENO_KV_ACCESS_TOKEN: ${{ secrets.DENO_KV_ACCESS_TOKEN }}
           SEED_PASSWORD: ${{ secrets.SEED_PASSWORD }}
           # Which household inherits the previously-global catalogue. Required in

--- a/.github/workflows/migrate-prod-kv.yml
+++ b/.github/workflows/migrate-prod-kv.yml
@@ -11,10 +11,11 @@ name: Migrate production KV
 # scoped to a "production" Environment — see the `environment:` note below):
 #   vars.DENO_KV_DATABASE_ID      the production KV database id — a plain
 #                                 Variable (not sensitive on its own; useless
-#                                 without the access token). Deno Deploy
-#                                 dashboard → project → KV.
-#   secrets.DENO_KV_ACCESS_TOKEN  a Deno Deploy access token — a Secret
-#                                 (dashboard → account settings → Access Tokens)
+#                                 without the access token). Deno Deploy console
+#                                 → Databases → your database.
+#   secrets.DENO_KV_ACCESS_TOKEN  a Deno Deploy organization access token
+#                                 (ddo_…) — a Secret. Create it on your org's
+#                                 settings page in the Deno Deploy console.
 #   secrets.SEED_PASSWORD         the shared legacy password used to rehash
 #                                 pre-PBKDF2 users — a Secret
 #
@@ -70,7 +71,7 @@ jobs:
         env:
           # Locally (isDeploy=false) getKv() honors KV_PATH; an https:// value
           # connects to the remote production KV via KV Connect.
-          KV_PATH: "https://api.deno.com/databases/${{ vars.DENO_KV_DATABASE_ID }}/connect"
+          KV_PATH: "https://api.deno.com/v2/databases/${{ vars.DENO_KV_DATABASE_ID }}/connect"
           DENO_KV_ACCESS_TOKEN: ${{ secrets.DENO_KV_ACCESS_TOKEN }}
           SEED_PASSWORD: ${{ secrets.SEED_PASSWORD }}
           # Which household inherits the previously-global catalogue. Required in

--- a/docs/running-migrations.md
+++ b/docs/running-migrations.md
@@ -42,8 +42,8 @@ as a **Variable**:
 
 | Name | Kind | Where to get it |
 |------|------|-----------------|
-| `DENO_KV_DATABASE_ID` | **Variable** | Deno Deploy dashboard → project → **KV** → database id. Not sensitive on its own (useless without the token). |
-| `DENO_KV_ACCESS_TOKEN` | **Secret** | dashboard → account settings → **Access Tokens** |
+| `DENO_KV_DATABASE_ID` | **Variable** | Deno Deploy console → **Databases** → your database (the id in the Databases table). Not sensitive on its own (useless without the token). |
+| `DENO_KV_ACCESS_TOKEN` | **Secret** | Deno Deploy console → your **organization's settings** → an **organization access token** (`ddo_…`) |
 | `SEED_PASSWORD` | **Secret** | the shared legacy password |
 
 The workflow reads the id from `vars.DENO_KV_DATABASE_ID` and the two
@@ -59,8 +59,8 @@ To run: **Actions → Migrate production KV → Run workflow**, enter
 ## Running against production — locally via KV Connect
 
 ```bash
-KV_PATH="https://api.deno.com/databases/<DB_ID>/connect" \
-DENO_KV_ACCESS_TOKEN="<deno-deploy-access-token>" \
+KV_PATH="https://api.deno.com/v2/databases/<DB_ID>/connect" \
+DENO_KV_ACCESS_TOKEN="<deno-deploy-org-access-token>" \
 PRIMARY_USERNAME="<username whose household owns the catalogue>" \
 SEED_PASSWORD="<shared legacy password>" \
 deno task db:migrate

--- a/docs/running-migrations.md
+++ b/docs/running-migrations.md
@@ -37,11 +37,18 @@ push/PR triggers).
 
 One-time setup — add these under **Settings → Secrets and variables → Actions**
 (ideally scoped to a `production` **Environment**, where you can also require a
-reviewer's approval):
+reviewer's approval). Store credentials as **Secrets** and the non-sensitive id
+as a **Variable**:
 
-- `DENO_KV_DATABASE_ID` — Deno Deploy dashboard → project → **KV** → database id
-- `DENO_KV_ACCESS_TOKEN` — dashboard → account settings → **Access Tokens**
-- `SEED_PASSWORD`
+| Name | Kind | Where to get it |
+|------|------|-----------------|
+| `DENO_KV_DATABASE_ID` | **Variable** | Deno Deploy dashboard → project → **KV** → database id. Not sensitive on its own (useless without the token). |
+| `DENO_KV_ACCESS_TOKEN` | **Secret** | dashboard → account settings → **Access Tokens** |
+| `SEED_PASSWORD` | **Secret** | the shared legacy password |
+
+The workflow reads the id from `vars.DENO_KV_DATABASE_ID` and the two
+credentials from `secrets.*`, so store each on the matching side — a value put
+on the wrong side reads back empty.
 
 To run: **Actions → Migrate production KV → Run workflow**, enter
 `primary_username`, and type `MIGRATE` in the confirm field.


### PR DESCRIPTION
Follow-up to #57 (already merged). Two commits landed on the branch **after** #57 merged, so they never made it into `main`. This PR carries them:

- **Target the new Deno Deploy console.** The KV Connect URL becomes `https://api.deno.com/v2/databases/<id>/connect` (the `/v2/` form), and the docs/workflow now point to the new console's **organization access token** (`ddo_…`) and the **Databases** table for the id. Without this the workflow used the classic URL and wouldn't connect.
- **Read the database id from a Variable.** `DENO_KV_DATABASE_ID` is read via `vars.` (it's a non-sensitive identifier), while `DENO_KV_ACCESS_TOKEN` and `SEED_PASSWORD` stay `secrets.`. This makes the workflow reference match where each value is stored.

Only two files change: `.github/workflows/migrate-prod-kv.yml` and `docs/running-migrations.md`. No app or migration-logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)