### PR TITLE
fix(migrate): fail loudly when pointed at the wrong database

### DIFF
--- a/.github/workflows/migrate-prod-kv.yml
+++ b/.github/workflows/migrate-prod-kv.yml
@@ -30,7 +30,7 @@ on:
         required: true
         type: string
       confirm:
-        description: 'Type MIGRATE to confirm you are mutating PRODUCTION data'
+        description: "Type MIGRATE to confirm you are mutating PRODUCTION data"
         required: true
         type: string
 

--- a/scripts/migrate.test.ts
+++ b/scripts/migrate.test.ts
@@ -263,3 +263,27 @@ Deno.test({
     });
   },
 });
+
+Deno.test({
+  name:
+    "assertPrimaryHouseholdResolvable — throws when PRIMARY_USERNAME is absent from this DB (wrong database)",
+  sanitizeResources: false,
+  async fn() {
+    const kv = await getKv();
+    // Empty DB: no users, no households, no catalogue — as if pointed at the
+    // wrong database. With a primary user named explicitly, this must fail
+    // loudly instead of silently no-opping.
+    await clearCatalogue();
+    await clearIdentity();
+    Deno.env.set("PRIMARY_USERNAME", "frozemaric");
+    try {
+      await assertRejects(
+        () => assertPrimaryHouseholdResolvable(kv),
+        Error,
+        "not found",
+      );
+    } finally {
+      Deno.env.delete("PRIMARY_USERNAME");
+    }
+  },
+});

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -124,20 +124,24 @@ async function hasGlobalCatalogue(kv: Deno.Kv): Promise<boolean> {
 /**
  * Fail-fast pre-check, run before migrate() mutates anything: verifies the
  * primary household will be resolvable, so a misconfigured run stops before it
- * half-applies. No-ops when there is no global catalogue left to scope, so a
- * re-run of an already-migrated DB never throws here.
+ * half-applies. Re-runs of an already-migrated DB are a no-op here.
  */
 export async function assertPrimaryHouseholdResolvable(
   kv: Deno.Kv,
 ): Promise<void> {
-  if (!(await hasGlobalCatalogue(kv))) return;
   const primaryUsername = Deno.env.get("PRIMARY_USERNAME");
-  if (primaryUsername) {
-    if (!(await UserRepo.findByUsername(primaryUsername))) {
-      throw new Error(`PRIMARY_USERNAME '${primaryUsername}' not found.`);
-    }
-    return; // its household will exist once the user loop has run
+  // When a primary user is named explicitly, it MUST exist in this database —
+  // checked even when there's nothing to scope. A missing user almost always
+  // means the migration is pointed at the wrong database, so fail loudly
+  // instead of silently no-opping against the wrong (or an empty) KV.
+  if (primaryUsername && !(await UserRepo.findByUsername(primaryUsername))) {
+    throw new Error(
+      `PRIMARY_USERNAME '${primaryUsername}' not found — are you pointed at ` +
+        `the right database?`,
+    );
   }
+  if (!(await hasGlobalCatalogue(kv))) return;
+  if (primaryUsername) return; // existence verified above; household follows
   // Unset: only safe when the run will yield exactly one household.
   let userCount = 0;
   for await (const _ of kv.list({ prefix: ["users"] })) userCount++;


### PR DESCRIPTION
## Why

A production run of the KV migration was accidentally pointed at the wrong database (a leftover from switching to the new Deno Deploy console). It found nothing to migrate and **reported success** — with no signal that it had hit the wrong DB — which looked like the catalogue had been wiped. (Nothing was actually deleted; the real DB was intact, just not the one migrated.)

The silent success came from the empty-DB short-circuit in `assertPrimaryHouseholdResolvable` running *before* the `PRIMARY_USERNAME` existence check — the same short-circuit that (correctly) lets preview deploys no-op on an empty KV.

## Change

When `PRIMARY_USERNAME` is set explicitly (as in a real production run), require that user to exist in the connected KV **before** the empty-DB short-circuit. If it's missing, throw:

> `PRIMARY_USERNAME 'frozemaric' not found — are you pointed at the right database?`

- **Production run, wrong DB:** the named user isn't there → fails immediately instead of a silent no-op. This is the regression the incident needed.
- **Preview deploy (`PRIMARY_USERNAME` unset):** unchanged — still a clean no-op on an empty KV.

Adds a regression test that reproduces the wrong-DB case (empty KV + `PRIMARY_USERNAME` set → rejects). Also normalizes one quote in the migration workflow so `deno task check` is green (a fmt nit that slipped in via #59, which was validated for YAML but not run through `deno task check`).

## Verification

- `deno task check` — clean.
- `deno task test` — 225 passed / 0 failed (includes the new regression test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)