### PR TITLE
feat(dev): HTTPS dev server for on-device PWA testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ kv.db-wal
 
 .superpowers/
 
+# Local HTTPS dev certificates for on-device testing (machine-specific)
+certs/
+
 # macOS Finder metadata
 .DS_Store
 

--- a/deno.json
+++ b/deno.json
@@ -4,6 +4,7 @@
     "check": "deno fmt --check && deno lint && deno check",
     "test": "deno test --unstable-kv -A",
     "dev": "deno run --env-file --unstable-kv -A vite",
+    "dev:mobile": "MOBILE_HTTPS=1 deno run --env-file --unstable-kv -A vite --host",
     "build": "vite build",
     "preview": "deno serve --env-file --unstable-kv -A _fresh/server.js",
     "db:seed": "deno run --env-file --unstable-kv -A scripts/seed.ts",

--- a/docs/mobile-testing.md
+++ b/docs/mobile-testing.md
@@ -1,0 +1,131 @@
+# Testing on a real mobile device
+
+The app is mobile-first and meant to run as a PWA, so some things can only be
+verified on an actual phone: touch gestures, the on-screen keyboard, safe-area
+insets, Add to Home Screen, and standalone-mode chrome.
+
+This guide sets up `deno task dev:mobile`, which serves the dev server over
+HTTPS on your local network so your phone can reach it.
+
+## Why HTTPS is required
+
+Two independent reasons — neither has a plain-HTTP workaround:
+
+1. **The session cookie is `Secure`** (`routes/login.tsx`). Browsers refuse to
+   store or send `Secure` cookies over `http://` on any origin other than
+   `localhost`. Over plain HTTP on the LAN you cannot log in at all.
+2. **PWA features need a secure context.** Service workers, installability and
+   push are unavailable outside one. `localhost` counts as secure by special
+   case; `http://192.168.x.x` does not.
+
+## One-time setup
+
+### 1. Install mkcert and its local CA
+
+```bash
+brew install mkcert
+```
+
+```bash
+mkcert -install
+```
+
+`mkcert -install` adds a local certificate authority to the macOS system trust
+store, so it will ask for your password.
+
+### 2. Generate the dev certificate
+
+Run this from the repository root. Substitute your own machine name and current
+LAN IP:
+
+```bash
+mkcert -cert-file certs/dev-cert.pem -key-file certs/dev-key.pem "$(scutil --get LocalHostName).local" localhost 127.0.0.1 "$(ipconfig getifaddr en0)"
+```
+
+`certs/` is gitignored — these certificates are machine-specific and must never
+be committed.
+
+Prefer the `.local` hostname over the raw IP when you connect: iOS resolves
+`.local` names over Bonjour with no configuration, and it survives DHCP lease
+changes. Re-run the command above if your LAN IP changes and you want the IP
+form to keep working.
+
+### 3. Trust the CA on the iPhone
+
+This is two separate steps in two different places in Settings. Doing only the
+first is the most common failure — Safari will still show a certificate warning,
+and it will refuse to register a service worker even if you tap through it.
+
+1. Find the root CA on your Mac:
+
+   ```bash
+   open "$(mkcert -CAROOT)"
+   ```
+
+2. AirDrop `rootCA.pem` to the iPhone and accept it.
+3. **Install the profile:** Settings → General → VPN & Device Management →
+   tap the downloaded profile → Install.
+4. **Enable full trust:** Settings → General → About → Certificate Trust
+   Settings → toggle on the `mkcert` root certificate.
+
+Step 4 is not optional and is not reachable from step 3.
+
+## Running it
+
+```bash
+deno task dev:mobile
+```
+
+Then on the phone, using your own machine name:
+
+```
+https://LM26011.local:5173
+```
+
+Both devices must be on the same network. Some routers and most corporate or
+guest Wi-Fi networks block client-to-client traffic ("AP isolation"); if the
+page never loads, that is the usual cause — a personal hotspot from the phone,
+with the Mac joined to it, is the quickest way around it.
+
+`deno task dev` is unaffected and still serves plain HTTP on `localhost`. The
+HTTPS behaviour is gated on the `MOBILE_HTTPS=1` environment variable that
+`dev:mobile` sets, not on the mere presence of `certs/`, so the normal dev flow
+and the Browser-pane preview config keep working without certificates.
+
+You need an account to log in with on the phone — see `deno task db:seed` and
+the `SEED_USERNAME` / `SEED_PASSWORD` variables in `.env`.
+
+## Troubleshooting
+
+**Login succeeds but immediately bounces back to `/login`.** The session cookie
+was rejected. This is what happens when the `Set-Cookie` `Domain` attribute does
+not match the host in the address bar. Check the response header:
+
+```bash
+curl -sk -i -X POST https://YOUR-HOST:5173/login -d "username=U&password=P" | grep -i set-cookie
+```
+
+There should be **no** `Domain=` attribute — the cookie is deliberately
+host-only so it works unchanged on `localhost`, a `.local` name, a LAN IP, and
+production. Do not reintroduce `domain: ctx.url.hostname` in `routes/login.tsx`:
+behind the Fresh Vite plugin the inner request URL is always `localhost`, so
+that pins the cookie to `Domain=localhost` and every non-localhost origin
+silently fails to store it.
+
+**Certificate warning that will not go away.** You almost certainly did step 3
+but not step 4 of the trust setup above. Full trust is a separate toggle.
+
+**The page never loads at all.** AP isolation on the network — see above.
+
+## What you can and cannot test today
+
+Working now: the web manifest, Add to Home Screen, app icons, standalone
+chrome, `viewport-fit=cover` safe-area insets, real touch and scroll behaviour,
+and the on-screen keyboard.
+
+Not working yet: **offline, caching and the update prompt.** `static/pwa-sw.js`
+and `static/pwa-sw-register.ts` exist but nothing imports them, so no service
+worker is registered. `routes/_app.tsx` links the manifest only.
+
+Also note the manifest requests `"display": "fullscreen"`, which iOS does not
+implement; it falls back to standalone.

--- a/routes/login.tsx
+++ b/routes/login.tsx
@@ -40,7 +40,11 @@ export const handler = define.handlers<Data>({
       value: session.id,
       maxAge: 60 * 60 * 24, // 24 hours
       sameSite: "Lax",
-      domain: ctx.url.hostname,
+      // No `domain`: a host-only cookie is scoped to whatever host served it,
+      // which is what we want. Pinning it to `ctx.url.hostname` broke on-device
+      // testing — behind the Fresh Vite plugin the inner request URL is always
+      // localhost, so a phone hitting the LAN address got `Domain=localhost`
+      // and the browser silently rejected the cookie (endless login loop).
       path: "/",
       secure: true,
     });

--- a/routes/logout.ts
+++ b/routes/logout.ts
@@ -12,7 +12,9 @@ export const handler: Handlers = {
     }
 
     const headers = new Headers();
-    deleteCookie(headers, "sessionId", { path: "/", domain: ctx.url.hostname });
+    // Must mirror the attributes used in routes/login.tsx — a host-only cookie
+    // is only cleared by a host-only delete, so no `domain` here either.
+    deleteCookie(headers, "sessionId", { path: "/" });
     headers.set("location", "/login");
 
     return new Response(null, {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,12 +2,48 @@ import { defineConfig } from "vite";
 import { fresh } from "@fresh/plugin-vite";
 import tailwindcss from "@tailwindcss/vite";
 
+const CERT_FILE = "certs/dev-cert.pem";
+const KEY_FILE = "certs/dev-key.pem";
+
+/**
+ * Opt-in HTTPS for on-device testing (`deno task dev:mobile`).
+ *
+ * PWA features need a secure context, and the session cookie is `Secure`
+ * (see routes/login.tsx), so plain HTTP over the LAN cannot even log in.
+ * Gated behind an env var rather than "certs happen to exist" so that plain
+ * `deno task dev` stays on http://localhost and keeps working without certs.
+ *
+ * See docs/mobile-testing.md for the mkcert setup.
+ */
+function mobileHttps() {
+  if (Deno.env.get("MOBILE_HTTPS") !== "1") return undefined;
+
+  try {
+    return {
+      key: Deno.readTextFileSync(KEY_FILE),
+      cert: Deno.readTextFileSync(CERT_FILE),
+    };
+  } catch (cause) {
+    throw new Error(
+      `MOBILE_HTTPS=1 but no dev certificate found at ${CERT_FILE} / ${KEY_FILE}.\n` +
+        `Generate one with mkcert — see docs/mobile-testing.md.`,
+      { cause },
+    );
+  }
+}
+
+const https = mobileHttps();
+
 export default defineConfig({
   plugins: [
     fresh(),
     tailwindcss(),
   ],
   server: {
+    // Both only take effect for `deno task dev:mobile`; `undefined` leaves
+    // Vite's defaults (localhost, HTTP) untouched for the normal dev flow.
+    https,
+    host: https ? true : undefined,
     watch: {
       // Prevent full-page reloads when Deno KV writes to local files
       ignored: [


### PR DESCRIPTION
Adds `deno task dev:mobile`, which serves the dev server over TLS on the local network so the app can be opened on a real phone — and fixes a session-cookie bug that made any non-localhost origin impossible to log in to.

## Why

Testing the PWA on a real device needs a secure context: service workers and installability are unavailable outside one, and the session cookie is `Secure`, so a plain-HTTP LAN origin cannot even complete a login.

## The cookie fix

`routes/login.tsx` pinned the cookie to `domain: ctx.url.hostname`. Behind the Fresh Vite plugin the inner request URL is always `localhost`, so the response carried `Domain=localhost` no matter which host the client actually used. Any other origin — a phone on the LAN address, a `.local` name — had the cookie **silently rejected**: login returned its `303 → /shopping`, then bounced straight back to `/login` with no error surfaced anywhere.

Verified with a real cookie jar before the fix:

```
--- cookies stored: ---
  (EMPTY — cookie was REJECTED)
GET /shopping -> status=303 redirected_to=.../login
```

Omitting `domain` makes the cookie host-only, which is correct on `localhost`, a `.local` name, a LAN IP and production alike. `routes/logout.ts` needed the same change, as a host-only cookie is only cleared by a host-only delete — otherwise logout would fail to clear the session.

This bug predates this branch and affects any non-localhost dev origin, which is why it is a separate commit.

## Design notes

- HTTPS is gated on `MOBILE_HTTPS=1`, **not** on the presence of `certs/`. Otherwise generating certs would silently flip plain `deno task dev` to https and break tooling pointed at the HTTP origin.
- Certificates live in a gitignored `certs/` directory — machine-specific, never committed.
- Vite skips its `allowedHosts` check when HTTPS is enabled, so no host allowlisting is required.
- Missing certs produce a pointed error naming the expected paths and the docs.
- `docs/mobile-testing.md` covers the mkcert setup, the two-part iOS trust dance (the "enable full trust" toggle lives in a different Settings screen from the profile install and is the step most often missed), and troubleshooting.

## Verification

- `deno task check` clean; `deno task test` → 225 passed, 0 failed.
- HTTPS serves over HTTP/2 on `localhost`, the `.local` name and the LAN IP; manifest returns `200 application/manifest+json`.
- Login → `/shopping` `200` → logout → bounce to `/login`, all over HTTPS on the LAN address, using a cookie jar that enforces browser domain-matching rules.
- Plain `deno task dev` unchanged: HTTP, localhost-only, not exposed on the LAN.
- Tested with a throwaway self-signed cert, since trusting a CA requires the developer's own machine and device.

## Scope

Deliberately excluded: no service worker is registered (`static/pwa-sw.js` and `static/pwa-sw-register.ts` exist but are unimported), so **offline, caching and the update prompt remain untestable**. The manifest, Add to Home Screen, icons, standalone chrome, safe-area insets and real touch behaviour all are — which unblocks the pending on-device checks for #34 and #45. Wiring up the service worker is follow-up work.

Also noted while reading the manifest: it requests `"display": "fullscreen"`, which iOS does not implement and falls back to standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)