### PR TITLE
feat(todos): shared household to-do backlog (iteration 1)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,6 +6,13 @@
       "runtimeExecutable": "/Users/frederic.gryspeerdt/.deno/bin/deno",
       "runtimeArgs": ["task", "dev"],
       "port": 5173
+    },
+    {
+      "name": "dev-wt",
+      "runtimeExecutable": "/Users/frederic.gryspeerdt/.deno/bin/deno",
+      "runtimeArgs": ["task", "dev", "--port", "5178"],
+      "port": 5178,
+      "autoPort": false
     }
   ]
 }

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,6 +4,14 @@ This is a **Fresh** project (Deno-based full-stack framework) for a shopping
 list application. It uses **Deno KV** for data storage and **Tailwind CSS v4**
 for styling.
 
+# Domain Language
+
+**Before naming anything user-facing or domain-level, read
+[`CONTEXT.md`](../CONTEXT.md).** It is the project's domain glossary — the
+ubiquitous language for core concepts like "household," "to-do," and "backlog,"
+and what to avoid instead. Keep it updated when you introduce a new domain
+concept.
+
 # UI/UX Patterns
 
 **Before building or changing anything the user sees, read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,9 @@ Deno KV + Tailwind v4). The shopping list is the first of many planned modules.
 
 - **General project guidance** — stack, architecture, data flow, commands,
   coding conventions: see [`CLAUDE.md`](CLAUDE.md).
+- **Domain language** — read [`CONTEXT.md`](CONTEXT.md) **before naming anything
+  user-facing or domain-level.** It's the project's domain glossary (ubiquitous
+  language) — what to call things, and what to avoid instead.
 - **UI/UX patterns** — read [`docs/ui-ux-patterns.md`](docs/ui-ux-patterns.md)
   **before building or changing anything the user sees.** It captures the
   established front-end conventions (optimistic vs. pessimistic mutations, the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,14 @@ but must also work well on desktop. Mobile is the priority because much of the
 functionality is meant to be used on the go — e.g. checking off items while
 shopping, or quickly adding something to a list from wherever you are.
 
+## Domain Language
+
+**Before naming anything user-facing or domain-level, read
+[`CONTEXT.md`](CONTEXT.md).** It is the project's domain glossary — the
+ubiquitous language for core concepts like "household," "to-do," and "backlog,"
+and what to avoid instead (e.g. "task," "list," "account"). Keep it updated when
+you introduce a new domain concept.
+
 ## UI/UX Patterns
 
 **Before building or changing anything the user sees, read

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,38 @@
+# Happie
+
+Happie is a household manager: a shared platform for the daily ins and outs of
+living together. Its language is deliberately domestic rather than
+productivity-tool — the people using it are a family, including children, not
+knowledge workers.
+
+## Language
+
+### Household
+
+**Household**: The group of people who live together and share everything in
+Happie. Every piece of data in the app belongs to exactly one household.
+_Avoid_: family, account, group, tenant
+
+### To-dos
+
+**To-do**: Something the household needs to get done. It carries its own freely
+typed title — there is nothing to pick it from. It covers both the one-off
+("book the venue") and the routine ("take out the bins"); a routine to-do is not
+a separate kind of thing, only one that comes back. _Avoid_: task, chore, item,
+action item, ticket
+
+**Backlog**: The single collection of every to-do a household has. A household
+has exactly one, and it is never divided into sub-lists — a to-do is found by
+filtering the backlog, not by opening the container it was filed in. _Avoid_:
+to-do list, list, inbox
+
+**Done**: A to-do the household actually carried out. Being done is a point in
+time, not a flag: a done to-do knows the moment it happened. It stays in the
+backlog once done — finishing something is worth seeing. _Avoid_: checked,
+completed, closed, finished, archived
+
+**Not needed**: The other way a to-do leaves the backlog: the household decided
+it never had to happen at all. Unlike being done, this is not a state a to-do
+can be in — the to-do is simply gone, leaving no trace. Never conflate the two;
+"we did it" and "we dropped it" are opposite outcomes. _Avoid_: cancelled,
+dropped, dismissed, abandoned, archived

--- a/database/index.ts
+++ b/database/index.ts
@@ -9,3 +9,4 @@ export * from "./category.repo.ts";
 export * from "./dish.repo.ts";
 export * from "./dish-tag-group.repo.ts";
 export * from "./loyalty-card.repo.ts";
+export * from "./todo.repo.ts";

--- a/database/todo.repo.test.ts
+++ b/database/todo.repo.test.ts
@@ -1,0 +1,182 @@
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import { TodoRepo } from "@/database/todo.repo.ts";
+import type { CreateTodoDto } from "@/models/index.ts";
+
+// Isolated in-memory KV for this test process. getKv() reads KV_PATH lazily on
+// first use (inside a repo method), and no repo method is called until a test
+// body runs — so setting it here at module load is early enough. Each test uses
+// a distinct householdId because the process-wide KV singleton is shared.
+Deno.env.set("KV_PATH", ":memory:");
+
+// sanitizeResources is disabled because getKv() opens a module-level KV
+// singleton lazily on first use and never closes it (by design — it's meant
+// to live for the process's lifetime, same as in production). Deno's default
+// resource sanitizer would otherwise flag that singleton as "leaked" from
+// whichever test happens to open it first.
+
+function draft(
+  householdId: string,
+  title: string,
+  overrides: Partial<CreateTodoDto> = {},
+): CreateTodoDto {
+  return {
+    householdId,
+    title,
+    createdBy: "user-1",
+    createdAt: new Date().toISOString(),
+    completedAt: null,
+    ...overrides,
+  };
+}
+
+Deno.test({
+  name: "create — mints an id and stores the to-do open",
+  sanitizeResources: false,
+  async fn() {
+    const todo = await TodoRepo.create(draft("hh-create", "Take out the bins"));
+
+    assertEquals(todo.title, "Take out the bins");
+    assertEquals(todo.completedAt, null);
+    assertEquals(typeof todo.id, "string");
+    assertEquals(todo.id.length > 0, true);
+
+    const found = await TodoRepo.getById("hh-create", todo.id);
+    assertEquals(found?.id, todo.id);
+  },
+});
+
+Deno.test({
+  name: "getAll — open to-dos come first, newest first",
+  sanitizeResources: false,
+  async fn() {
+    const hh = "hh-order-open";
+    await TodoRepo.create(draft(hh, "oldest", {
+      createdAt: "2026-08-01T10:00:00.000Z",
+    }));
+    await TodoRepo.create(draft(hh, "newest", {
+      createdAt: "2026-08-03T10:00:00.000Z",
+    }));
+    await TodoRepo.create(draft(hh, "middle", {
+      createdAt: "2026-08-02T10:00:00.000Z",
+    }));
+
+    const all = await TodoRepo.getAll(hh);
+
+    assertEquals(all.map((t) => t.title), ["newest", "middle", "oldest"]);
+  },
+});
+
+Deno.test({
+  name: "getAll — done to-dos sort after open ones, most recently done first",
+  sanitizeResources: false,
+  async fn() {
+    const hh = "hh-order-done";
+    await TodoRepo.create(draft(hh, "still open", {
+      createdAt: "2026-08-01T10:00:00.000Z",
+    }));
+    await TodoRepo.create(draft(hh, "done earlier", {
+      createdAt: "2026-08-02T10:00:00.000Z",
+      completedAt: "2026-08-02T12:00:00.000Z",
+    }));
+    await TodoRepo.create(draft(hh, "done later", {
+      createdAt: "2026-08-03T10:00:00.000Z",
+      completedAt: "2026-08-03T12:00:00.000Z",
+    }));
+
+    const all = await TodoRepo.getAll(hh);
+
+    assertEquals(all.map((t) => t.title), [
+      "still open",
+      "done later",
+      "done earlier",
+    ]);
+  },
+});
+
+Deno.test({
+  name: "getById — returns null for an unknown id",
+  sanitizeResources: false,
+  async fn() {
+    assertEquals(await TodoRepo.getById("hh-missing", "nope"), null);
+  },
+});
+
+Deno.test({
+  name: "update — a partial patch does not clobber omitted fields",
+  sanitizeResources: false,
+  async fn() {
+    const hh = "hh-update";
+    const todo = await TodoRepo.create(
+      draft(hh, "Call the dentist", { notes: "09 123 45 67" }),
+    );
+
+    const updated = await TodoRepo.update(hh, todo.id, {
+      completedAt: "2026-08-03T09:00:00.000Z",
+    });
+
+    assertEquals(updated?.completedAt, "2026-08-03T09:00:00.000Z");
+    assertEquals(updated?.title, "Call the dentist");
+    assertEquals(updated?.notes, "09 123 45 67");
+    assertEquals(updated?.createdBy, "user-1");
+  },
+});
+
+Deno.test({
+  name: "update — un-ticking writes completedAt back to null",
+  sanitizeResources: false,
+  async fn() {
+    const hh = "hh-untick";
+    const todo = await TodoRepo.create(
+      draft(hh, "Pay the water bill", {
+        completedAt: "2026-08-03T09:00:00.000Z",
+      }),
+    );
+
+    const updated = await TodoRepo.update(hh, todo.id, { completedAt: null });
+
+    assertEquals(updated?.completedAt, null);
+  },
+});
+
+Deno.test({
+  name: "update — returns null for an unknown id",
+  sanitizeResources: false,
+  async fn() {
+    assertEquals(
+      await TodoRepo.update("hh-update-missing", "nope", { title: "x" }),
+      null,
+    );
+  },
+});
+
+Deno.test({
+  name: "delete — removes the to-do",
+  sanitizeResources: false,
+  async fn() {
+    const hh = "hh-delete";
+    const todo = await TodoRepo.create(draft(hh, "Cancel the newspaper"));
+
+    await TodoRepo.delete(hh, todo.id);
+
+    assertEquals(await TodoRepo.getById(hh, todo.id), null);
+    assertEquals(await TodoRepo.getAll(hh), []);
+  },
+});
+
+Deno.test({
+  name: "households are isolated — one never reads another's to-dos",
+  sanitizeResources: false,
+  async fn() {
+    const mine = await TodoRepo.create(draft("hh-mine", "Mine"));
+    await TodoRepo.create(draft("hh-theirs", "Theirs"));
+
+    assertEquals((await TodoRepo.getAll("hh-mine")).map((t) => t.title), [
+      "Mine",
+    ]);
+    assertEquals(await TodoRepo.getById("hh-theirs", mine.id), null);
+    assertEquals(
+      await TodoRepo.update("hh-theirs", mine.id, { title: "x" }),
+      null,
+    );
+  },
+});

--- a/database/todo.repo.test.ts
+++ b/database/todo.repo.test.ts
@@ -94,6 +94,30 @@ Deno.test({
 });
 
 Deno.test({
+  name: "getAll — ties on identical createdAt break by id for a stable order",
+  sanitizeResources: false,
+  async fn() {
+    const hh = "hh-order-tie";
+    const sameInstant = "2026-08-03T10:00:00.000Z";
+    const t1 = await TodoRepo.create(
+      draft(hh, "captured first", { createdAt: sameInstant }),
+    );
+    const t2 = await TodoRepo.create(
+      draft(hh, "captured second", { createdAt: sameInstant }),
+    );
+
+    const expectedIds = [t1.id, t2.id].sort((a, b) => a.localeCompare(b));
+
+    // Fetching repeatedly must always agree on the same order (not KV
+    // iteration order, which could otherwise vary run to run).
+    const first = await TodoRepo.getAll(hh);
+    const second = await TodoRepo.getAll(hh);
+    assertEquals(first.map((t) => t.id), expectedIds);
+    assertEquals(second.map((t) => t.id), expectedIds);
+  },
+});
+
+Deno.test({
   name: "getById — returns null for an unknown id",
   sanitizeResources: false,
   async fn() {

--- a/database/todo.repo.ts
+++ b/database/todo.repo.ts
@@ -1,0 +1,71 @@
+import type {
+  CreateTodoDto,
+  TodoInterface,
+  UpdateTodoDto,
+} from "@/models/index.ts";
+import { getKv } from "./db.ts";
+import { mergeDefinedPatch } from "./merge-patch.ts";
+
+/**
+ * To-dos are shared within a household. Keys are scoped by household so a
+ * member only ever reads or writes their own household's to-dos
+ * (`["todos", householdId, id]`), mirroring `LoyaltyCardRepo`. A household has
+ * exactly one backlog — there is no to-do list aggregate (see docs/adr/0001).
+ */
+export class TodoRepo {
+  static async create(data: CreateTodoDto): Promise<TodoInterface> {
+    const kv = await getKv();
+    const id = crypto.randomUUID();
+    const todo: TodoInterface = { ...data, id };
+    await kv.set(["todos", data.householdId, id], todo);
+    return todo;
+  }
+
+  /**
+   * Every consumer gets the same order, so the SSR render and the hydrated view
+   * agree and the island only has to find the partition point: open to-dos
+   * first (newest created first), then done ones (most recently done first).
+   */
+  static async getAll(householdId: string): Promise<TodoInterface[]> {
+    const kv = await getKv();
+    const iter = kv.list<TodoInterface>({ prefix: ["todos", householdId] });
+    const todos: TodoInterface[] = [];
+    for await (const { value } of iter) todos.push(value);
+
+    return todos.sort((a, b) => {
+      if (a.completedAt === null && b.completedAt === null) {
+        return b.createdAt.localeCompare(a.createdAt);
+      }
+      if (a.completedAt === null) return -1;
+      if (b.completedAt === null) return 1;
+      return b.completedAt.localeCompare(a.completedAt);
+    });
+  }
+
+  static async getById(
+    householdId: string,
+    id: string,
+  ): Promise<TodoInterface | null> {
+    const kv = await getKv();
+    const result = await kv.get<TodoInterface>(["todos", householdId, id]);
+    return result.value;
+  }
+
+  static async update(
+    householdId: string,
+    id: string,
+    patch: UpdateTodoDto,
+  ): Promise<TodoInterface | null> {
+    const kv = await getKv();
+    const existing = await this.getById(householdId, id);
+    if (!existing) return null;
+    const updated = mergeDefinedPatch<TodoInterface>(existing, patch);
+    await kv.set(["todos", householdId, id], updated);
+    return updated;
+  }
+
+  static async delete(householdId: string, id: string): Promise<void> {
+    const kv = await getKv();
+    await kv.delete(["todos", householdId, id]);
+  }
+}

--- a/database/todo.repo.ts
+++ b/database/todo.repo.ts
@@ -34,11 +34,22 @@ export class TodoRepo {
 
     return todos.sort((a, b) => {
       if (a.completedAt === null && b.completedAt === null) {
-        return b.createdAt.localeCompare(a.createdAt);
+        // Plain string comparison, not localeCompare: two to-dos captured in
+        // the same rapid-capture burst can share a millisecond-precision
+        // createdAt, so ties are broken by id for a total, stable order —
+        // otherwise they'd fall back to KV iteration order and could swap
+        // places relative to the optimistic prepend on reload.
+        if (a.createdAt !== b.createdAt) {
+          return a.createdAt < b.createdAt ? 1 : -1;
+        }
+        return a.id.localeCompare(b.id);
       }
       if (a.completedAt === null) return -1;
       if (b.completedAt === null) return 1;
-      return b.completedAt.localeCompare(a.completedAt);
+      if (a.completedAt !== b.completedAt) {
+        return a.completedAt < b.completedAt ? 1 : -1;
+      }
+      return a.id.localeCompare(b.id);
     });
   }
 

--- a/docs/adr/0001-one-household-backlog-no-todo-lists.md
+++ b/docs/adr/0001-one-household-backlog-no-todo-lists.md
@@ -1,0 +1,42 @@
+# One household backlog, no to-do lists
+
+The shopping module divides items across multiple named lists
+(`ShoppingListInterface`, keys `["shopping_list_items", listId, id]`). To-dos
+deliberately do **not** work this way: a household has exactly one backlog, and
+a to-do is found by filtering it rather than by opening the container it was
+filed in. Keys are `["todos", householdId, id]` — there is no `TodoList`
+aggregate, and none is planned.
+
+## Why
+
+Slicing a to-do backlog happens along several axes at once — who it's for,
+whether it's done, when it's due, what it's part of — and a single parent
+hierarchy can only express one of them. "Order the cake" is legitimately part of
+the birthday party *and* something to buy *and* assigned to one person. Filters
+and labels compose; lists force the to-do to pick one home.
+
+Requiring a container choice before capture is also friction on the app's most
+common action. Shopping tolerates it honestly, because you genuinely do know
+which trip you are shopping for; "take out the bins" has no natural home, and
+list-first to-do apps reliably end up with a junk *General* list holding most of
+the items — the hierarchy is paid for and a flat list is what you get.
+
+## Considered options
+
+- **Mirror `ShoppingListRepo`** — multiple named to-do lists. Rejected: solves
+  grouping, and none of recurrence, which is what most real household examples
+  (monthly bills, weekly bins, yearly appointments) actually need. A list is a
+  container, not a schedule.
+- **A nullable `listId` on each to-do**, to switch multiplicity on later.
+  Rejected: a field that is always `null` taxes every read and still leaves the
+  UI unbuilt, so the work happens twice. This codebase already carries unused
+  DTOs of that kind.
+
+## Consequences
+
+Genuine multiple to-do lists would require a KV migration from length-3 to
+length-4 keys. This is an accepted bet.
+
+Grouping arrives as **labels**, not lists — composable with filters and with
+assignment, and there is an existing pattern to follow in
+`DishTagGroupInterface`.

--- a/docs/adr/0002-completion-is-a-timestamp-not-needed-is-a-deletion.md
+++ b/docs/adr/0002-completion-is-a-timestamp-not-needed-is-a-deletion.md
@@ -1,0 +1,42 @@
+# Completion is a timestamp; "not needed" is a deletion
+
+A to-do leaves the backlog two ways, and they are opposites. **Done** means the
+household carried it out, recorded as `completedAt: string | null` — the
+timestamp *is* the state, and the to-do stays in the backlog. **Not needed**
+means it never had to happen, and is a hard delete leaving no trace. There is
+deliberately no bulk "clear done" action, and no third `dropped` state.
+
+## Why
+
+This departs from the shopping module twice over, so both halves are worth
+recording.
+
+`ShoppingListItemInterface.checked` is a bare `boolean` with no `checkedAt` or
+`checkedBy`. That is fine for a shopping list — one person is in the shop, and
+nobody cares at 7pm who ticked off the milk. Household chores are the opposite
+case: *when* something was done is the information that prevents duplicated work,
+and it is the only way to answer "has anyone taken the bins out since Tuesday?",
+which is what recurrence will need. A nullable timestamp as the single state
+carrier also avoids the drift bug that a `done` boolean beside a `completedAt`
+invites, where one write path updates one and not the other.
+
+Shopping's bulk `clearChecked` is a hard delete, and copying it would apply the
+*"this was never needed"* action to precisely the to-dos that **were** needed and
+**were** done — destroying the record `completedAt` exists to keep. For a
+shopping list that is harmless; a milk carton's job ends at the till. For
+household work, "what we got done" is the point.
+
+## Consequences
+
+Done to-dos accumulate indefinitely. This is a **render** problem, not a
+deletion problem: the fix is to show a window (done today / this week) once due
+dates arrive, never to destroy rows.
+
+`completedBy` is deliberately absent for now. A household currently holds exactly
+one user, so it would carry no information — and the thing that will eventually
+complete a to-do is a **member** (see issue #17), not a user, so storing a userId
+today would only buy a migration.
+
+Deleting an individual done to-do stays possible, as an escape hatch for a
+mistyped or accidentally ticked to-do. It is an escape hatch, not a workflow, and
+gets no separate concept.

--- a/docs/superpowers/plans/2026-08-03-household-shared-todos.md
+++ b/docs/superpowers/plans/2026-08-03-household-shared-todos.md
@@ -56,6 +56,8 @@ failure to your own work.
 | Modify `database/index.ts` | Add the repo. |
 | Create `routes/api/todos/index.ts` | `GET` list, `POST` create. |
 | Create `routes/api/todos/[id].ts` | `PATCH` update, `DELETE` remove. |
+| Create `routes/api/todos/index.test.ts` | Handler tests: create, list, validation, 401, household isolation. |
+| Create `routes/api/todos/[id].test.ts` | Handler tests: patch, tick/un-tick, 400/404, cross-household refusal. |
 | Modify `services/api.ts` | Add the `todos` namespace. |
 | Create `hooks/useTodos.ts` | Signals store + all four mutations. |
 | Create `hooks/useTodos.test.ts` | Mutation behaviour, rollback, exit timing, blank-title guard. |
@@ -585,6 +587,8 @@ git commit -m "feat(todos): add household-scoped TodoRepo"
 **Files:**
 - Create: `routes/api/todos/index.ts`
 - Create: `routes/api/todos/[id].ts`
+- Create: `routes/api/todos/index.test.ts`
+- Create: `routes/api/todos/[id].test.ts`
 
 **Interfaces:**
 - Consumes: `TodoRepo` from `@/database/index.ts` (Task 3); `json`, `noContent`, `badRequest`, `notFound` from `@/utils/index.ts` (Task 2); `define` from `@/utils/index.ts`.
@@ -596,9 +600,340 @@ git commit -m "feat(todos): add household-scoped TodoRepo"
 
 Unauthenticated `/api/*` requests already 401 in middleware (`routes/_middleware.ts:44`), so handlers do not repeat that. They **do** guard on `ctx.state.householdId` being present, because the type is optional.
 
-There is no automated test in this task — the repo covers persistence and the island covers rendering, and the codebase has no HTTP-handler test harness. Step 6 is a manual smoke test against the dev server.
+**Handler tests are a house pattern.** `routes/api/cards/index.test.ts` calls the exported `handler.GET` / `handler.POST` directly with a hand-built fake `Context` and an in-memory KV. Follow it exactly. For the `[id]` route the fake context must also carry `params`, since the handler reads `ctx.params.id`.
 
-- [ ] **Step 1: Write the collection route**
+- [ ] **Step 1: Write the failing tests**
+
+Create `routes/api/todos/index.test.ts`:
+
+```ts
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import { type Context } from "fresh";
+import { handler } from "@/routes/api/todos/index.ts";
+import { getKv } from "@/database/db.ts";
+
+Deno.env.set("KV_PATH", ":memory:");
+
+interface State {
+  userId?: string;
+  householdId?: string;
+}
+
+function ctx(req: Request, state: State = {}): Context<State> {
+  return { req, state } as unknown as Context<State>;
+}
+
+async function clearTodos() {
+  const kv = await getKv();
+  for await (const e of kv.list({ prefix: ["todos"] })) {
+    await kv.delete(e.key);
+  }
+}
+
+const AUTH: State = { userId: "u1", householdId: "h1" };
+
+const post = (body: unknown) =>
+  new Request("http://x/api/todos", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+Deno.test({
+  name: "POST creates an open to-do (201); GET lists it for the household",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const createRes = await handler.POST(
+      ctx(post({ title: "Take out the bins" }), AUTH),
+    );
+    assertEquals(createRes.status, 201);
+    const created = await createRes.json();
+    assertEquals(created.title, "Take out the bins");
+    assertEquals(created.householdId, "h1");
+    assertEquals(created.createdBy, "u1");
+    assertEquals(created.completedAt, null);
+
+    const listRes = await handler.GET(
+      ctx(new Request("http://x/api/todos"), AUTH),
+    );
+    assertEquals(listRes.status, 200);
+    const list = await listRes.json();
+    assertEquals(list.map((t: { title: string }) => t.title), [
+      "Take out the bins",
+    ]);
+  },
+});
+
+Deno.test({
+  name: "POST trims the title and omits blank notes",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const created = await (await handler.POST(
+      ctx(post({ title: "  Call the dentist  ", notes: "   " }), AUTH),
+    )).json();
+    assertEquals(created.title, "Call the dentist");
+    assertEquals(created.notes, undefined);
+  },
+});
+
+Deno.test({
+  name: "POST keeps notes when given",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const created = await (await handler.POST(
+      ctx(post({ title: "Call the dentist", notes: "09 123 45 67" }), AUTH),
+    )).json();
+    assertEquals(created.notes, "09 123 45 67");
+  },
+});
+
+Deno.test({
+  name: "POST rejects a blank title (400)",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    assertEquals(
+      (await handler.POST(ctx(post({ title: "   " }), AUTH))).status,
+      400,
+    );
+    assertEquals((await handler.POST(ctx(post({}), AUTH))).status, 400);
+  },
+});
+
+Deno.test({
+  name: "GET and POST require a household (401)",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    assertEquals(
+      (await handler.GET(ctx(new Request("http://x/api/todos")))).status,
+      401,
+    );
+    assertEquals(
+      (await handler.POST(ctx(post({ title: "x" })))).status,
+      401,
+    );
+  },
+});
+
+Deno.test({
+  name: "GET does not leak another household's to-dos",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    await handler.POST(
+      ctx(post({ title: "Theirs" }), { userId: "u2", householdId: "h2" }),
+    );
+    const list = await (await handler.GET(
+      ctx(new Request("http://x/api/todos"), AUTH),
+    )).json();
+    assertEquals(list, []);
+  },
+});
+```
+
+Create `routes/api/todos/[id].test.ts`:
+
+```ts
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import { type Context } from "fresh";
+import { handler } from "@/routes/api/todos/[id].ts";
+import { TodoRepo } from "@/database/todo.repo.ts";
+import { getKv } from "@/database/db.ts";
+
+Deno.env.set("KV_PATH", ":memory:");
+
+interface State {
+  userId?: string;
+  householdId?: string;
+}
+
+function ctx(req: Request, id: string, state: State = {}): Context<State> {
+  return { req, state, params: { id } } as unknown as Context<State>;
+}
+
+async function clearTodos() {
+  const kv = await getKv();
+  for await (const e of kv.list({ prefix: ["todos"] })) {
+    await kv.delete(e.key);
+  }
+}
+
+const AUTH: State = { userId: "u1", householdId: "h1" };
+
+const patch = (body: unknown) =>
+  new Request("http://x/api/todos/x", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+const del = () => new Request("http://x/api/todos/x", { method: "DELETE" });
+
+function seed(householdId = "h1", title = "Take out the bins") {
+  return TodoRepo.create({
+    householdId,
+    title,
+    createdBy: "u1",
+    createdAt: "2026-08-03T10:00:00.000Z",
+    completedAt: null,
+  });
+}
+
+Deno.test({
+  name: "PATCH updates the title",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const todo = await seed();
+    const res = await handler.PATCH(
+      ctx(patch({ title: "  Take out the recycling  " }), todo.id, AUTH),
+    );
+    assertEquals(res.status, 200);
+    assertEquals((await res.json()).title, "Take out the recycling");
+  },
+});
+
+Deno.test({
+  name: "PATCH ticks off and un-ticks via completedAt",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const todo = await seed();
+
+    const ticked = await (await handler.PATCH(
+      ctx(patch({ completedAt: "2026-08-03T12:00:00.000Z" }), todo.id, AUTH),
+    )).json();
+    assertEquals(ticked.completedAt, "2026-08-03T12:00:00.000Z");
+
+    const reopened = await (await handler.PATCH(
+      ctx(patch({ completedAt: null }), todo.id, AUTH),
+    )).json();
+    assertEquals(reopened.completedAt, null);
+  },
+});
+
+Deno.test({
+  name: "PATCH can clear notes",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const todo = await TodoRepo.create({
+      householdId: "h1",
+      title: "Call the dentist",
+      notes: "09 123 45 67",
+      createdBy: "u1",
+      createdAt: "2026-08-03T10:00:00.000Z",
+      completedAt: null,
+    });
+
+    const cleared = await (await handler.PATCH(
+      ctx(patch({ notes: "" }), todo.id, AUTH),
+    )).json();
+    assertEquals(cleared.notes, "");
+  },
+});
+
+Deno.test({
+  name: "PATCH rejects a blank title (400) and leaves the to-do alone",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const todo = await seed();
+    assertEquals(
+      (await handler.PATCH(ctx(patch({ title: "  " }), todo.id, AUTH))).status,
+      400,
+    );
+    const still = await TodoRepo.getById("h1", todo.id);
+    assertEquals(still?.title, "Take out the bins");
+  },
+});
+
+Deno.test({
+  name: "PATCH ignores client-supplied createdBy and createdAt",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const todo = await seed();
+    const updated = await (await handler.PATCH(
+      ctx(
+        patch({ createdBy: "hacker", createdAt: "1999-01-01T00:00:00.000Z" }),
+        todo.id,
+        AUTH,
+      ),
+    )).json();
+    assertEquals(updated.createdBy, "u1");
+    assertEquals(updated.createdAt, "2026-08-03T10:00:00.000Z");
+  },
+});
+
+Deno.test({
+  name: "PATCH on an unknown id is 404",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    assertEquals(
+      (await handler.PATCH(ctx(patch({ title: "x" }), "nope", AUTH))).status,
+      404,
+    );
+  },
+});
+
+Deno.test({
+  name: "DELETE removes the to-do (204), then 404",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const todo = await seed();
+    assertEquals((await handler.DELETE(ctx(del(), todo.id, AUTH))).status, 204);
+    assertEquals((await handler.DELETE(ctx(del(), todo.id, AUTH))).status, 404);
+    assertEquals(await TodoRepo.getById("h1", todo.id), null);
+  },
+});
+
+Deno.test({
+  name: "another household cannot patch or delete your to-do",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const todo = await seed();
+    const theirs: State = { userId: "u2", householdId: "h2" };
+
+    assertEquals(
+      (await handler.PATCH(ctx(patch({ title: "x" }), todo.id, theirs))).status,
+      404,
+    );
+    assertEquals(
+      (await handler.DELETE(ctx(del(), todo.id, theirs))).status,
+      404,
+    );
+    assertEquals((await TodoRepo.getById("h1", todo.id))?.title, "Take out the bins");
+  },
+});
+
+Deno.test({
+  name: "PATCH and DELETE require a household (401)",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    assertEquals(
+      (await handler.PATCH(ctx(patch({ title: "x" }), "any"))).status,
+      401,
+    );
+    assertEquals((await handler.DELETE(ctx(del(), "any"))).status, 401);
+  },
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `deno test --unstable-kv -A routes/api/todos/`
+Expected: FAIL — module not found for `routes/api/todos/index.ts` and `routes/api/todos/[id].ts`.
+
+- [ ] **Step 3: Write the collection route**
 
 Create `routes/api/todos/index.ts`:
 
@@ -637,7 +972,7 @@ export const handler = define.handlers({
 });
 ```
 
-- [ ] **Step 2: Write the item route**
+- [ ] **Step 4: Write the item route**
 
 Create `routes/api/todos/[id].ts`. The `PATCH` handler picks only the three client-writable fields off the body, so a client cannot patch `createdBy` or `createdAt` even though `UpdateTodoDto` permits them:
 
@@ -660,7 +995,10 @@ export const handler = define.handlers({
       patch.title = title;
     }
     if (body.notes !== undefined) {
-      patch.notes = String(body.notes).trim() || undefined;
+      // Empty string, not undefined: mergeDefinedPatch skips undefined, so
+      // `undefined` here would silently leave an existing note in place and
+      // clearing notes in the UI would appear to fail.
+      patch.notes = String(body.notes).trim();
     }
     if (body.completedAt !== undefined) {
       patch.completedAt = body.completedAt === null
@@ -688,56 +1026,17 @@ export const handler = define.handlers({
 
 Note `DELETE` reads before deleting so a wrong or other-household id returns `404` rather than a misleading `204` — `kv.delete` on a missing key succeeds silently.
 
-Note also the `notes` handling: an empty string is stored as `undefined` (field cleared) rather than `""`. `mergeDefinedPatch` skips `undefined`, so clearing notes via `PATCH` will **not** remove an existing value — it leaves it unchanged. That is a known limitation of the shared merge helper and is acceptable for iteration 1; do not work around it by bypassing `mergeDefinedPatch`.
+- [ ] **Step 5: Run tests to verify they pass**
 
-- [ ] **Step 3: Verify check passes**
+Run: `deno test --unstable-kv -A routes/api/todos/`
+Expected: PASS, 15 passed (6 in `index.test.ts`, 9 in `[id].test.ts`).
 
-Run: `deno task check`
-Expected: PASS.
+- [ ] **Step 6: Verify the whole suite and check**
 
-- [ ] **Step 4: Start the dev server**
+Run: `deno task check && deno task test`
+Expected: both PASS.
 
-Run: `deno task dev`
-Expected: Vite starts and prints a localhost URL. Local dev auto-authenticates (see the dev auto-login middleware), so a session cookie is not needed manually.
-
-- [ ] **Step 5: Smoke-test the four endpoints**
-
-In a second terminal, replacing `<PORT>` with the dev server's port:
-
-```bash
-curl -s -X POST localhost:<PORT>/api/todos -H 'Content-Type: application/json' -d '{"title":"Take out the bins","notes":"Tuesday"}'
-```
-
-Expected: `201` and a JSON to-do with an `id`, `completedAt: null`, and a `householdId`.
-
-```bash
-curl -s localhost:<PORT>/api/todos
-```
-
-Expected: a JSON array containing that to-do.
-
-```bash
-curl -s -o /dev/null -w '%{http_code}\n' -X POST localhost:<PORT>/api/todos -H 'Content-Type: application/json' -d '{"title":"   "}'
-```
-
-Expected: `400`.
-
-Then, substituting the `id` from the create response:
-
-```bash
-curl -s -X PATCH localhost:<PORT>/api/todos/<ID> -H 'Content-Type: application/json' -d '{"completedAt":"2026-08-03T09:00:00.000Z"}'
-```
-
-Expected: `200` and the to-do with that `completedAt`.
-
-```bash
-curl -s -o /dev/null -w '%{http_code}\n' -X DELETE localhost:<PORT>/api/todos/<ID>
-curl -s -o /dev/null -w '%{http_code}\n' -X DELETE localhost:<PORT>/api/todos/<ID>
-```
-
-Expected: `204` then `404`.
-
-- [ ] **Step 6: Stop the dev server and commit**
+- [ ] **Step 7: Commit**
 
 ```bash
 git add routes/api/todos
@@ -1280,7 +1579,7 @@ Copy strings the test asserts on, so keep them exact: FAB label `"New to-do"`, c
 Create `islands/todos/TodoBacklog.test.tsx`:
 
 ```tsx
-import { assertStringIncludes } from "jsr:@std/assert@^1.0.19";
+import { assertFalse, assertStringIncludes } from "jsr:@std/assert@^1.0.19";
 import { render } from "npm:preact-render-to-string@^6.6.3";
 import { h } from "preact";
 import TodoBacklog from "./TodoBacklog.tsx";
@@ -1315,7 +1614,7 @@ Deno.test("TodoBacklog — renders open and done to-dos, and the FAB", () => {
   assertStringIncludes(html, "Call the dentist");
   assertStringIncludes(html, "09 123 45 67"); // notes hint on the row
   assertStringIncludes(html, "Pay the water bill");
-  assertStringIncludes(html, "Done"); // done section heading
+  assertStringIncludes(html, ">Done<"); // done section heading
   assertStringIncludes(html, "New to-do"); // FAB label
 });
 
@@ -1332,9 +1631,9 @@ Deno.test("TodoBacklog — no Done heading when nothing is done yet", () => {
   }));
 
   assertStringIncludes(html, "Take out the bins");
-  if (html.includes(">Done<")) {
-    throw new Error("Done section should be hidden when no to-do is done");
-  }
+  // The create sheet's body is gated on its open state, so nothing else in the
+  // SSR output says "Done" — this really is the section heading.
+  assertFalse(html.includes(">Done<"));
 });
 ```
 
@@ -1528,44 +1827,52 @@ export default function TodoBacklog({ initialTodos }: Props) {
         />
       </div>
 
-      {/* Create sheet — stays open between saves for rapid capture */}
+      {/* Create sheet — stays open between saves for rapid capture.
+          Body gated on createOpen: <Sheet> renders its children even when
+          closed (see islands/items.tsx:442), so an ungated `autofocus` would
+          steal focus and raise the mobile keyboard on page load. Gating also
+          means `autofocus` fires on mount, i.e. exactly when the sheet opens. */}
       <Sheet
         open={createOpen.value}
         onClose={() => (createOpen.value = false)}
         title="New to-do"
       >
-        <div class="flex flex-col gap-3 pb-1">
-          <input
-            autofocus
-            value={newTitle.value}
-            onInput={(e) => (newTitle.value = e.currentTarget.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                submitNew();
-              }
-            }}
-            placeholder="What needs doing?"
-            aria-label="What needs doing?"
-            class="w-full md-body-large text-on-surface bg-surface-chigh border-0 rounded-[var(--md-shape-lg)] py-3 px-4 outline-none"
-          />
-          <textarea
-            value={newNotes.value}
-            onInput={(e) => (newNotes.value = e.currentTarget.value)}
-            rows={2}
-            placeholder="Notes (optional)"
-            aria-label="Notes (optional)"
-            class="w-full md-body-large text-on-surface bg-surface-chigh border-0 rounded-[var(--md-shape-lg)] py-3 px-4 outline-none resize-none"
-          />
-          <Button variant="filled" full onClick={submitNew}>Add</Button>
-          <Button
-            variant="text"
-            full
-            onClick={() => (createOpen.value = false)}
-          >
-            Done
-          </Button>
-        </div>
+        {createOpen.value && (
+          <div class="flex flex-col gap-3 pb-1">
+            <input
+              autofocus
+              value={newTitle.value}
+              onInput={(e) => (newTitle.value = e.currentTarget.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  submitNew();
+                }
+              }}
+              placeholder="What needs doing?"
+              aria-label="What needs doing?"
+              class="w-full md-body-large text-on-surface bg-surface-chigh border-0 rounded-[var(--md-shape-lg)] py-3 px-4 outline-none"
+            />
+            <textarea
+              value={newNotes.value}
+              onInput={(e) => (newNotes.value = e.currentTarget.value)}
+              rows={2}
+              placeholder="Notes (optional)"
+              aria-label="Notes (optional)"
+              class="w-full md-body-large text-on-surface bg-surface-chigh border-0 rounded-[var(--md-shape-lg)] py-3 px-4 outline-none resize-none"
+            />
+            <Button variant="filled" full onClick={submitNew}>Add</Button>
+            {/* "Close", not "Done" — "Done" beside "Add" reads as a second
+                save, and the Done *section* heading must stay unambiguous. */}
+            <Button
+              variant="text"
+              full
+              onClick={() => (createOpen.value = false)}
+            >
+              Close
+            </Button>
+          </div>
+        )}
       </Sheet>
 
       {/* Edit sheet */}
@@ -1656,8 +1963,6 @@ export default function TodoBacklog({ initialTodos }: Props) {
 
 Run: `deno test --unstable-kv -A islands/todos/TodoBacklog.test.tsx`
 Expected: PASS, 3 passed.
-
-If the third test fails because `>Done<` appears in the create sheet's text button, that is a genuine collision — rename that button's label to `"Close"` in both the island and this plan's expectations, and re-run.
 
 - [ ] **Step 5: Verify the whole suite and check**
 
@@ -1834,7 +2139,7 @@ git commit -m "docs(todos): surface to-dos in the More sheet and document the ca
 ## Verification before calling this done
 
 - [ ] `deno task check` passes
-- [ ] `deno task test` passes, and includes the new `utils/http.test.ts`, `database/todo.repo.test.ts`, `hooks/useTodos.test.ts` and `islands/todos/TodoBacklog.test.tsx`
+- [ ] `deno task test` passes, and includes the new `utils/http.test.ts`, `database/todo.repo.test.ts`, `routes/api/todos/index.test.ts`, `routes/api/todos/[id].test.ts`, `hooks/useTodos.test.ts` and `islands/todos/TodoBacklog.test.tsx` — 196 baseline + 41 new = 237 passing
 - [ ] The full manual journey in Task 8 Step 4 has been walked, not assumed
 - [ ] `/todos` shows no "Coming soon" pill anywhere
 - [ ] No file outside the File Structure table was modified

--- a/docs/superpowers/plans/2026-08-03-household-shared-todos.md
+++ b/docs/superpowers/plans/2026-08-03-household-shared-todos.md
@@ -1,0 +1,1844 @@
+# Household Shared To-dos Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give a household one shared backlog of to-dos it can create, read, update, delete and tick off, replacing the `ComingSoon` placeholder at `/todos`.
+
+**Architecture:** A new household-scoped KV aggregate (`["todos", householdId, id]`) behind `TodoRepo`, four JSON API handlers, a signals-based store in `hooks/useTodos.ts`, and one island (`islands/todos/TodoBacklog.tsx`) rendering an Open section and a Done section. Layered exactly like the existing loyalty-cards module, with one addition: shared HTTP response helpers in `utils/http.ts`.
+
+**Tech Stack:** Deno, Fresh 2 (SSR + islands), Preact, `@preact/signals`, Deno KV, Tailwind CSS v4, `@std/assert` + `preact-render-to-string` for tests.
+
+**Spec:** [`docs/superpowers/specs/2026-08-03-household-shared-todos-design.md`](../specs/2026-08-03-household-shared-todos-design.md)
+**Decisions of record:** [ADR 0001](../../adr/0001-one-household-backlog-no-todo-lists.md), [ADR 0002](../../adr/0002-completion-is-a-timestamp-not-needed-is-a-deletion.md)
+
+## Before you start
+
+`deno.json` sets `"nodeModulesDir": "manual"`, so a fresh worktree has no
+`node_modules` and `deno check` fails on the npm imports (`@bwip-js/browser` in
+`components/md3/Barcode.tsx`) before you have written a line. Run this once:
+
+```bash
+deno install
+```
+
+Baseline after that, on the commit this plan was written against: `deno task
+check` passes and `deno task test` reports **196 passed, 0 failed**. If your
+baseline differs, find out why before starting — don't attribute a pre-existing
+failure to your own work.
+
+## Global Constraints
+
+- **Deno + Fresh 2.** Fresh is `jsr:@fresh/core@^2.2.0`. Routes and handlers use `define.handlers({...})` / `define.page<typeof handler>(...)` from `@/utils/index.ts`. Never `FreshContext` — the type is `Context` from `"fresh"`.
+- **Imports use the `@/` alias** for project root, e.g. `import { db } from "@/database/db.ts"`. Repos are re-exported from `@/database/index.ts`; models from `@/models/index.ts`.
+- **JSX is `precompile`** — write `class`, never `className`.
+- **Never call `Deno.openKv()` directly.** Always `getKv()` from `@/database/db.ts`.
+- **Signals in islands:** hooks create state with `signal()` at hook-body level, and the island calls the hook inside `useMemo(() => useTodos(...), [])` so the signals are created once. This is the established pattern — see `islands/dishes/DishCatalogue.tsx:21-31`. Do **not** call `signal()` directly in an island component body.
+- **KV keys** are `["todos", householdId, id]`. IDs via `crypto.randomUUID()`. Timestamps are ISO strings via `new Date().toISOString()`.
+- **Entity type suffix is `XxxInterface`.** Create DTO is `CreateXxxDto = Omit<XxxInterface, "id">`. Client-input DTO is `XxxInput`. Update DTO is `Partial<Omit<XxxInterface, "id" | "householdId">>`.
+- **Copy is English**, warm and readable by a child. Issue #13 converts the app to Dutch in one later pass — do not translate here.
+- **Commits follow Conventional Commits**: `<type>[scope]: <description>`.
+- **`deno task check`** (`deno fmt --check && deno lint && deno check`) and **`deno task test`** (`deno test --unstable-kv -A`) must both pass before each commit. `--unstable-kv` is required for KV-backed tests.
+- **Out of scope, do not build:** assignment, `completedBy`, filters, due dates, recurrence, labels, bulk "clear done", `createKvRepo<T>`, the `services/api/<entity>.ts` split, Dutch copy, home-screen counts, nav badges.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| Create `models/todo/todo.interface.ts` | `TodoInterface` + three DTOs. No behaviour. |
+| Create `models/todo/index.ts` | Barrel (`export *`). |
+| Modify `models/index.ts` | Add the todo barrel. |
+| Create `utils/http.ts` | Four JSON response helpers, shared. |
+| Modify `utils/index.ts` | Re-export `http.ts`. |
+| Create `database/todo.repo.ts` | KV persistence + the sort contract. |
+| Create `database/todo.repo.test.ts` | Repo behaviour, including household isolation. |
+| Modify `database/index.ts` | Add the repo. |
+| Create `routes/api/todos/index.ts` | `GET` list, `POST` create. |
+| Create `routes/api/todos/[id].ts` | `PATCH` update, `DELETE` remove. |
+| Modify `services/api.ts` | Add the `todos` namespace. |
+| Create `hooks/useTodos.ts` | Signals store + all four mutations. |
+| Create `hooks/useTodos.test.ts` | Mutation behaviour, rollback, exit timing, blank-title guard. |
+| Create `islands/todos/TodoBacklog.tsx` | The whole `/todos` UI. |
+| Create `islands/todos/TodoBacklog.test.tsx` | SSR render assertions. |
+| Modify `routes/todos/index.tsx` | Replace `ComingSoon` with loader + island. |
+
+Task order follows the dependency chain: types → helpers → persistence → API → client → UI. Each task ends green and committed.
+
+---
+
+### Task 1: Todo model and DTOs
+
+**Files:**
+- Create: `models/todo/todo.interface.ts`
+- Create: `models/todo/index.ts`
+- Modify: `models/index.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `TodoInterface`, `CreateTodoDto`, `TodoInput`, `UpdateTodoDto`, all importable from `@/models/index.ts`.
+
+There is no test in this task — it is types only, and `deno check` is the verification. `TodoInterface` is exercised by Task 3's tests.
+
+- [ ] **Step 1: Write the interface and DTOs**
+
+Create `models/todo/todo.interface.ts`:
+
+```ts
+export interface TodoInterface {
+  id: string;
+  householdId: string;
+  /** What needs doing, as the household typed it. */
+  title: string;
+  /** Optional detail — a phone number, a deadline someone mentioned. */
+  notes?: string;
+  /** userId of whoever added it. Creating requires a login, so this is a user. */
+  createdBy: string;
+  createdAt: string;
+  /**
+   * When the household actually did this, or null if it is still open. The
+   * timestamp *is* the state — there is no separate `done` boolean. See
+   * docs/adr/0002.
+   */
+  completedAt: string | null;
+}
+
+// Derived type for creation (no ID — the server mints it).
+export type CreateTodoDto = Omit<TodoInterface, "id">;
+
+/**
+ * What the client sends to create a to-do. The server fills in `householdId`,
+ * `createdBy`, `createdAt`, `completedAt` and `id` — the client never sends
+ * (and cannot spoof) the household.
+ */
+export type TodoInput = Pick<TodoInterface, "title" | "notes">;
+
+// Derived type for patch/update: never the id or householdId, everything else optional.
+export type UpdateTodoDto = Partial<Omit<TodoInterface, "id" | "householdId">>;
+```
+
+- [ ] **Step 2: Add the barrel**
+
+Create `models/todo/index.ts`:
+
+```ts
+export * from "./todo.interface.ts";
+```
+
+- [ ] **Step 3: Register in the models barrel**
+
+In `models/index.ts`, append one line after the existing exports:
+
+```ts
+export * from "./todo/index.ts";
+```
+
+- [ ] **Step 4: Verify it type-checks and formats**
+
+Run: `deno task check`
+Expected: PASS, no output beyond the fmt/lint/check summaries.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add models/todo models/index.ts
+git commit -m "feat(todos): add Todo model and DTOs"
+```
+
+---
+
+### Task 2: Shared HTTP response helpers
+
+**Files:**
+- Create: `utils/http.ts`
+- Create: `utils/http.test.ts`
+- Modify: `utils/index.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `json(data: unknown, status?: number): Response` — default status `200`, `Content-Type: application/json`
+  - `noContent(): Response` — `204`, null body
+  - `badRequest(message: string): Response` — `400`, plain text body
+  - `notFound(message?: string): Response` — `404`, plain text body, default message `"Not found"`
+
+These are the uncontroversial half of issue #51. `routes/api/cards/index.ts:14` currently defines a local `json` — leave it alone, this task does not refactor existing routes.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `utils/http.test.ts`:
+
+```ts
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import { badRequest, json, noContent, notFound } from "./http.ts";
+
+Deno.test("json — serialises the body with a JSON content type and default 200", async () => {
+  const res = json({ ok: true });
+  assertEquals(res.status, 200);
+  assertEquals(res.headers.get("Content-Type"), "application/json");
+  assertEquals(await res.json(), { ok: true });
+});
+
+Deno.test("json — honours an explicit status", async () => {
+  const res = json({ id: "a" }, 201);
+  assertEquals(res.status, 201);
+  assertEquals(await res.json(), { id: "a" });
+});
+
+Deno.test("noContent — 204 with an empty body", async () => {
+  const res = noContent();
+  assertEquals(res.status, 204);
+  assertEquals(await res.text(), "");
+});
+
+Deno.test("badRequest — 400 carrying the message", async () => {
+  const res = badRequest("title required");
+  assertEquals(res.status, 400);
+  assertEquals(await res.text(), "title required");
+});
+
+Deno.test("notFound — 404, with a default message", async () => {
+  assertEquals(notFound().status, 404);
+  assertEquals(await notFound().text(), "Not found");
+  assertEquals(await notFound("no such to-do").text(), "no such to-do");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `deno test --unstable-kv -A utils/http.test.ts`
+Expected: FAIL — module not found, `Module not found "file:///.../utils/http.ts"`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `utils/http.ts`:
+
+```ts
+/** JSON response helpers shared by the API routes, so handlers stop repeating
+ *  `new Response(JSON.stringify(x), { status, headers })`. See issue #51. */
+
+export function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export function noContent(): Response {
+  return new Response(null, { status: 204 });
+}
+
+export function badRequest(message: string): Response {
+  return new Response(message, { status: 400 });
+}
+
+export function notFound(message = "Not found"): Response {
+  return new Response(message, { status: 404 });
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `deno test --unstable-kv -A utils/http.test.ts`
+Expected: PASS, 5 passed.
+
+- [ ] **Step 5: Register in the utils barrel**
+
+In `utils/index.ts`, append:
+
+```ts
+export * from "./http.ts";
+```
+
+- [ ] **Step 6: Verify the whole suite and check still pass**
+
+Run: `deno task check && deno task test`
+Expected: both PASS. The barrel addition must not collide with an existing export name — if `deno check` reports a duplicate export, stop and report it rather than renaming a public helper.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add utils/http.ts utils/http.test.ts utils/index.ts
+git commit -m "feat(api): add shared JSON response helpers"
+```
+
+---
+
+### Task 3: TodoRepo
+
+**Files:**
+- Create: `database/todo.repo.ts`
+- Create: `database/todo.repo.test.ts`
+- Modify: `database/index.ts`
+
+**Interfaces:**
+- Consumes: `TodoInterface`, `CreateTodoDto`, `UpdateTodoDto` from `@/models/index.ts` (Task 1); `getKv` from `./db.ts`; `mergeDefinedPatch` from `./merge-patch.ts`.
+- Produces `TodoRepo` with static methods:
+  - `create(data: CreateTodoDto): Promise<TodoInterface>`
+  - `getAll(householdId: string): Promise<TodoInterface[]>` — **sorted**: open first by `createdAt` descending, then done by `completedAt` descending
+  - `getById(householdId: string, id: string): Promise<TodoInterface | null>`
+  - `update(householdId: string, id: string, patch: UpdateTodoDto): Promise<TodoInterface | null>`
+  - `delete(householdId: string, id: string): Promise<void>`
+
+Note `create` takes the DTO **alone** — `CreateTodoDto` already carries `householdId`, exactly as `LoyaltyCardRepo.create` does (`database/loyalty-card.repo.ts:15`). Every other method takes `householdId` first.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `database/todo.repo.test.ts`:
+
+```ts
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import { TodoRepo } from "@/database/todo.repo.ts";
+import type { CreateTodoDto } from "@/models/index.ts";
+
+// Isolated in-memory KV for this test process. getKv() reads KV_PATH lazily on
+// first use (inside a repo method), and no repo method is called until a test
+// body runs — so setting it here at module load is early enough. Each test uses
+// a distinct householdId because the process-wide KV singleton is shared.
+Deno.env.set("KV_PATH", ":memory:");
+
+// sanitizeResources is disabled because getKv() opens a module-level KV
+// singleton lazily on first use and never closes it (by design — it's meant
+// to live for the process's lifetime, same as in production). Deno's default
+// resource sanitizer would otherwise flag that singleton as "leaked" from
+// whichever test happens to open it first.
+
+function draft(
+  householdId: string,
+  title: string,
+  overrides: Partial<CreateTodoDto> = {},
+): CreateTodoDto {
+  return {
+    householdId,
+    title,
+    createdBy: "user-1",
+    createdAt: new Date().toISOString(),
+    completedAt: null,
+    ...overrides,
+  };
+}
+
+Deno.test({
+  name: "create — mints an id and stores the to-do open",
+  sanitizeResources: false,
+  async fn() {
+    const todo = await TodoRepo.create(draft("hh-create", "Take out the bins"));
+
+    assertEquals(todo.title, "Take out the bins");
+    assertEquals(todo.completedAt, null);
+    assertEquals(typeof todo.id, "string");
+    assertEquals(todo.id.length > 0, true);
+
+    const found = await TodoRepo.getById("hh-create", todo.id);
+    assertEquals(found?.id, todo.id);
+  },
+});
+
+Deno.test({
+  name: "getAll — open to-dos come first, newest first",
+  sanitizeResources: false,
+  async fn() {
+    const hh = "hh-order-open";
+    await TodoRepo.create(draft(hh, "oldest", {
+      createdAt: "2026-08-01T10:00:00.000Z",
+    }));
+    await TodoRepo.create(draft(hh, "newest", {
+      createdAt: "2026-08-03T10:00:00.000Z",
+    }));
+    await TodoRepo.create(draft(hh, "middle", {
+      createdAt: "2026-08-02T10:00:00.000Z",
+    }));
+
+    const all = await TodoRepo.getAll(hh);
+
+    assertEquals(all.map((t) => t.title), ["newest", "middle", "oldest"]);
+  },
+});
+
+Deno.test({
+  name: "getAll — done to-dos sort after open ones, most recently done first",
+  sanitizeResources: false,
+  async fn() {
+    const hh = "hh-order-done";
+    await TodoRepo.create(draft(hh, "still open", {
+      createdAt: "2026-08-01T10:00:00.000Z",
+    }));
+    await TodoRepo.create(draft(hh, "done earlier", {
+      createdAt: "2026-08-02T10:00:00.000Z",
+      completedAt: "2026-08-02T12:00:00.000Z",
+    }));
+    await TodoRepo.create(draft(hh, "done later", {
+      createdAt: "2026-08-03T10:00:00.000Z",
+      completedAt: "2026-08-03T12:00:00.000Z",
+    }));
+
+    const all = await TodoRepo.getAll(hh);
+
+    assertEquals(all.map((t) => t.title), [
+      "still open",
+      "done later",
+      "done earlier",
+    ]);
+  },
+});
+
+Deno.test({
+  name: "getById — returns null for an unknown id",
+  sanitizeResources: false,
+  async fn() {
+    assertEquals(await TodoRepo.getById("hh-missing", "nope"), null);
+  },
+});
+
+Deno.test({
+  name: "update — a partial patch does not clobber omitted fields",
+  sanitizeResources: false,
+  async fn() {
+    const hh = "hh-update";
+    const todo = await TodoRepo.create(
+      draft(hh, "Call the dentist", { notes: "09 123 45 67" }),
+    );
+
+    const updated = await TodoRepo.update(hh, todo.id, {
+      completedAt: "2026-08-03T09:00:00.000Z",
+    });
+
+    assertEquals(updated?.completedAt, "2026-08-03T09:00:00.000Z");
+    assertEquals(updated?.title, "Call the dentist");
+    assertEquals(updated?.notes, "09 123 45 67");
+    assertEquals(updated?.createdBy, "user-1");
+  },
+});
+
+Deno.test({
+  name: "update — un-ticking writes completedAt back to null",
+  sanitizeResources: false,
+  async fn() {
+    const hh = "hh-untick";
+    const todo = await TodoRepo.create(
+      draft(hh, "Pay the water bill", {
+        completedAt: "2026-08-03T09:00:00.000Z",
+      }),
+    );
+
+    const updated = await TodoRepo.update(hh, todo.id, { completedAt: null });
+
+    assertEquals(updated?.completedAt, null);
+  },
+});
+
+Deno.test({
+  name: "update — returns null for an unknown id",
+  sanitizeResources: false,
+  async fn() {
+    assertEquals(
+      await TodoRepo.update("hh-update-missing", "nope", { title: "x" }),
+      null,
+    );
+  },
+});
+
+Deno.test({
+  name: "delete — removes the to-do",
+  sanitizeResources: false,
+  async fn() {
+    const hh = "hh-delete";
+    const todo = await TodoRepo.create(draft(hh, "Cancel the newspaper"));
+
+    await TodoRepo.delete(hh, todo.id);
+
+    assertEquals(await TodoRepo.getById(hh, todo.id), null);
+    assertEquals(await TodoRepo.getAll(hh), []);
+  },
+});
+
+Deno.test({
+  name: "households are isolated — one never reads another's to-dos",
+  sanitizeResources: false,
+  async fn() {
+    const mine = await TodoRepo.create(draft("hh-mine", "Mine"));
+    await TodoRepo.create(draft("hh-theirs", "Theirs"));
+
+    assertEquals((await TodoRepo.getAll("hh-mine")).map((t) => t.title), [
+      "Mine",
+    ]);
+    assertEquals(await TodoRepo.getById("hh-theirs", mine.id), null);
+    assertEquals(await TodoRepo.update("hh-theirs", mine.id, { title: "x" }), null);
+  },
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `deno test --unstable-kv -A database/todo.repo.test.ts`
+Expected: FAIL — module not found, `Module not found "file:///.../database/todo.repo.ts"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `database/todo.repo.ts`:
+
+```ts
+import type {
+  CreateTodoDto,
+  TodoInterface,
+  UpdateTodoDto,
+} from "@/models/index.ts";
+import { getKv } from "./db.ts";
+import { mergeDefinedPatch } from "./merge-patch.ts";
+
+/**
+ * To-dos are shared within a household. Keys are scoped by household so a
+ * member only ever reads or writes their own household's to-dos
+ * (`["todos", householdId, id]`), mirroring `LoyaltyCardRepo`. A household has
+ * exactly one backlog — there is no to-do list aggregate (see docs/adr/0001).
+ */
+export class TodoRepo {
+  static async create(data: CreateTodoDto): Promise<TodoInterface> {
+    const kv = await getKv();
+    const id = crypto.randomUUID();
+    const todo: TodoInterface = { ...data, id };
+    await kv.set(["todos", data.householdId, id], todo);
+    return todo;
+  }
+
+  /**
+   * Every consumer gets the same order, so the SSR render and the hydrated view
+   * agree and the island only has to find the partition point: open to-dos
+   * first (newest created first), then done ones (most recently done first).
+   */
+  static async getAll(householdId: string): Promise<TodoInterface[]> {
+    const kv = await getKv();
+    const iter = kv.list<TodoInterface>({ prefix: ["todos", householdId] });
+    const todos: TodoInterface[] = [];
+    for await (const { value } of iter) todos.push(value);
+
+    return todos.sort((a, b) => {
+      if (a.completedAt === null && b.completedAt === null) {
+        return b.createdAt.localeCompare(a.createdAt);
+      }
+      if (a.completedAt === null) return -1;
+      if (b.completedAt === null) return 1;
+      return b.completedAt.localeCompare(a.completedAt);
+    });
+  }
+
+  static async getById(
+    householdId: string,
+    id: string,
+  ): Promise<TodoInterface | null> {
+    const kv = await getKv();
+    const result = await kv.get<TodoInterface>(["todos", householdId, id]);
+    return result.value;
+  }
+
+  static async update(
+    householdId: string,
+    id: string,
+    patch: UpdateTodoDto,
+  ): Promise<TodoInterface | null> {
+    const kv = await getKv();
+    const existing = await this.getById(householdId, id);
+    if (!existing) return null;
+    const updated = mergeDefinedPatch<TodoInterface>(existing, patch);
+    await kv.set(["todos", householdId, id], updated);
+    return updated;
+  }
+
+  static async delete(householdId: string, id: string): Promise<void> {
+    const kv = await getKv();
+    await kv.delete(["todos", householdId, id]);
+  }
+}
+```
+
+`mergeDefinedPatch` skips only `undefined`, not `null` (`database/merge-patch.ts:16`), which is exactly why `{ completedAt: null }` un-ticks correctly.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `deno test --unstable-kv -A database/todo.repo.test.ts`
+Expected: PASS, 9 passed.
+
+- [ ] **Step 5: Register in the database barrel**
+
+In `database/index.ts`, append:
+
+```ts
+export * from "./todo.repo.ts";
+```
+
+- [ ] **Step 6: Verify the whole suite and check**
+
+Run: `deno task check && deno task test`
+Expected: both PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add database/todo.repo.ts database/todo.repo.test.ts database/index.ts
+git commit -m "feat(todos): add household-scoped TodoRepo"
+```
+
+---
+
+### Task 4: API routes
+
+**Files:**
+- Create: `routes/api/todos/index.ts`
+- Create: `routes/api/todos/[id].ts`
+
+**Interfaces:**
+- Consumes: `TodoRepo` from `@/database/index.ts` (Task 3); `json`, `noContent`, `badRequest`, `notFound` from `@/utils/index.ts` (Task 2); `define` from `@/utils/index.ts`.
+- Produces the wire contract Task 5 consumes:
+  - `GET /api/todos` → `200` `TodoInterface[]`
+  - `POST /api/todos`, body `{ title, notes? }` → `201` `TodoInterface`; `400` when title is blank
+  - `PATCH /api/todos/:id`, body any subset of `{ title, notes, completedAt }` → `200` `TodoInterface`; `400` when title is present but blank; `404` when absent
+  - `DELETE /api/todos/:id` → `204`; `404` when absent
+
+Unauthenticated `/api/*` requests already 401 in middleware (`routes/_middleware.ts:44`), so handlers do not repeat that. They **do** guard on `ctx.state.householdId` being present, because the type is optional.
+
+There is no automated test in this task — the repo covers persistence and the island covers rendering, and the codebase has no HTTP-handler test harness. Step 6 is a manual smoke test against the dev server.
+
+- [ ] **Step 1: Write the collection route**
+
+Create `routes/api/todos/index.ts`:
+
+```ts
+import { badRequest, define, json } from "@/utils/index.ts";
+import { TodoRepo } from "@/database/index.ts";
+
+export const handler = define.handlers({
+  async GET(ctx) {
+    const householdId = ctx.state.householdId;
+    if (!householdId) return new Response("Unauthorized", { status: 401 });
+    return json(await TodoRepo.getAll(householdId));
+  },
+
+  async POST(ctx) {
+    const { userId, householdId } = ctx.state;
+    if (!userId || !householdId) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+
+    const body = await ctx.req.json();
+    const title = String(body.title ?? "").trim();
+    if (!title) return badRequest("title required");
+    const rawNotes = String(body.notes ?? "").trim();
+
+    const todo = await TodoRepo.create({
+      householdId,
+      title,
+      notes: rawNotes || undefined,
+      createdBy: userId,
+      createdAt: new Date().toISOString(),
+      completedAt: null,
+    });
+    return json(todo, 201);
+  },
+});
+```
+
+- [ ] **Step 2: Write the item route**
+
+Create `routes/api/todos/[id].ts`. The `PATCH` handler picks only the three client-writable fields off the body, so a client cannot patch `createdBy` or `createdAt` even though `UpdateTodoDto` permits them:
+
+```ts
+import { badRequest, define, json, noContent, notFound } from "@/utils/index.ts";
+import { TodoRepo } from "@/database/index.ts";
+import type { UpdateTodoDto } from "@/models/index.ts";
+
+export const handler = define.handlers({
+  async PATCH(ctx) {
+    const householdId = ctx.state.householdId;
+    if (!householdId) return new Response("Unauthorized", { status: 401 });
+
+    const body = await ctx.req.json();
+    const patch: UpdateTodoDto = {};
+
+    if (body.title !== undefined) {
+      const title = String(body.title).trim();
+      if (!title) return badRequest("title required");
+      patch.title = title;
+    }
+    if (body.notes !== undefined) {
+      patch.notes = String(body.notes).trim() || undefined;
+    }
+    if (body.completedAt !== undefined) {
+      patch.completedAt = body.completedAt === null
+        ? null
+        : String(body.completedAt);
+    }
+
+    const updated = await TodoRepo.update(householdId, ctx.params.id, patch);
+    if (!updated) return notFound("no such to-do");
+    return json(updated);
+  },
+
+  async DELETE(ctx) {
+    const householdId = ctx.state.householdId;
+    if (!householdId) return new Response("Unauthorized", { status: 401 });
+
+    const existing = await TodoRepo.getById(householdId, ctx.params.id);
+    if (!existing) return notFound("no such to-do");
+
+    await TodoRepo.delete(householdId, existing.id);
+    return noContent();
+  },
+});
+```
+
+Note `DELETE` reads before deleting so a wrong or other-household id returns `404` rather than a misleading `204` — `kv.delete` on a missing key succeeds silently.
+
+Note also the `notes` handling: an empty string is stored as `undefined` (field cleared) rather than `""`. `mergeDefinedPatch` skips `undefined`, so clearing notes via `PATCH` will **not** remove an existing value — it leaves it unchanged. That is a known limitation of the shared merge helper and is acceptable for iteration 1; do not work around it by bypassing `mergeDefinedPatch`.
+
+- [ ] **Step 3: Verify check passes**
+
+Run: `deno task check`
+Expected: PASS.
+
+- [ ] **Step 4: Start the dev server**
+
+Run: `deno task dev`
+Expected: Vite starts and prints a localhost URL. Local dev auto-authenticates (see the dev auto-login middleware), so a session cookie is not needed manually.
+
+- [ ] **Step 5: Smoke-test the four endpoints**
+
+In a second terminal, replacing `<PORT>` with the dev server's port:
+
+```bash
+curl -s -X POST localhost:<PORT>/api/todos -H 'Content-Type: application/json' -d '{"title":"Take out the bins","notes":"Tuesday"}'
+```
+
+Expected: `201` and a JSON to-do with an `id`, `completedAt: null`, and a `householdId`.
+
+```bash
+curl -s localhost:<PORT>/api/todos
+```
+
+Expected: a JSON array containing that to-do.
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' -X POST localhost:<PORT>/api/todos -H 'Content-Type: application/json' -d '{"title":"   "}'
+```
+
+Expected: `400`.
+
+Then, substituting the `id` from the create response:
+
+```bash
+curl -s -X PATCH localhost:<PORT>/api/todos/<ID> -H 'Content-Type: application/json' -d '{"completedAt":"2026-08-03T09:00:00.000Z"}'
+```
+
+Expected: `200` and the to-do with that `completedAt`.
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' -X DELETE localhost:<PORT>/api/todos/<ID>
+curl -s -o /dev/null -w '%{http_code}\n' -X DELETE localhost:<PORT>/api/todos/<ID>
+```
+
+Expected: `204` then `404`.
+
+- [ ] **Step 6: Stop the dev server and commit**
+
+```bash
+git add routes/api/todos
+git commit -m "feat(todos): add to-do API routes"
+```
+
+---
+
+### Task 5: API client namespace
+
+**Files:**
+- Modify: `services/api.ts`
+
+**Interfaces:**
+- Consumes: the wire contract from Task 4; `TodoInput`, `TodoInterface`, `UpdateTodoDto` from `@/models/index.ts`.
+- Produces `api.todos`:
+  - `getAll(): Promise<TodoInterface[]>` — `[]` on failure
+  - `create(input: TodoInput): Promise<TodoInterface | null>` — `null` on failure
+  - `update(id: string, patch: UpdateTodoDto): Promise<TodoInterface | null>` — `null` on failure
+  - `delete(id: string): Promise<boolean>` — `true` on success
+
+Every method follows the `api` error boundary: never throw, return `null` / `[]` / `false` so the caller can roll back and snackbar. `delete` returns a `boolean` rather than `void` (unlike `api.cards.delete`) because Task 6 needs to know whether to roll the optimistic removal back.
+
+Do **not** start the `services/api/<entity>.ts` split — that is issue #51, done all at once.
+
+- [ ] **Step 1: Add the types to the existing import**
+
+In `services/api.ts`, add a new import line beside the existing model imports at the top:
+
+```ts
+import { TodoInput, TodoInterface, UpdateTodoDto } from "@/models/index.ts";
+```
+
+- [ ] **Step 2: Add the namespace**
+
+In `services/api.ts`, add a `todos` namespace inside the `api` object, after the `cards` namespace and before `dishTagGroups`:
+
+```ts
+  todos: {
+    getAll: async (): Promise<TodoInterface[]> => {
+      const res = await fetch("/api/todos");
+      if (!res.ok) return [];
+      return res.json();
+    },
+    create: async (input: TodoInput): Promise<TodoInterface | null> => {
+      const res = await fetch("/api/todos", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(input),
+      });
+      if (!res.ok) return null;
+      return res.json();
+    },
+    update: async (
+      id: string,
+      patch: UpdateTodoDto,
+    ): Promise<TodoInterface | null> => {
+      const res = await fetch(`/api/todos/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(patch),
+      });
+      if (!res.ok) return null;
+      return res.json();
+    },
+    delete: async (id: string): Promise<boolean> => {
+      const res = await fetch(`/api/todos/${id}`, { method: "DELETE" });
+      return res.ok;
+    },
+  },
+```
+
+- [ ] **Step 3: Verify check passes**
+
+Run: `deno task check`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add services/api.ts
+git commit -m "feat(todos): add todos API client namespace"
+```
+
+---
+
+### Task 6: useTodos store
+
+**Files:**
+- Create: `hooks/useTodos.ts`
+- Create: `hooks/useTodos.test.ts`
+
+**Interfaces:**
+- Consumes: `api.todos` (Task 5); `TodoInterface`, `TodoInput` from `@/models/index.ts`; `createDebouncedMergeScheduler` from `@/utils/debounce-update.ts`; `beginBusy` / `endBusy` from `@/utils/loading.ts`.
+- Produces `useTodos(initialTodos: TodoInterface[])` returning:
+  - `openTodos: Signal<TodoInterface[]>`
+  - `doneTodos: Signal<TodoInterface[]>`
+  - `exitingIds: Signal<string[]>`
+  - `pendingCount: Signal<number>`
+  - `addTodo(input: TodoInput): Promise<TodoInterface | null>`
+  - `editTodo(id: string, patch: { title?: string; notes?: string }): void`
+  - `flushTodo(id: string): void`
+  - `tickOff(id: string): Promise<boolean>`
+  - `unTick(id: string): Promise<boolean>`
+  - `removeTodo(id: string): Promise<boolean>`
+  - `refresh(): Promise<void>`
+
+**Two things to know before writing this.**
+
+**§6 exit animations.** `docs/ui-ux-patterns.md` §6 requires that a row leaving a list is marked "exiting", waits ~300ms for the CSS transition, and *then* leaves state. `useShoppingList` implements exactly this in `removeListItem` (`hooks/useShoppingList.ts:129`) and `checkItem` (`:147`) via an `exitingItems` signal — and note `uncheckItem` (`:171`) deliberately has **no** animation. Mirror that asymmetry: `tickOff` and `removeTodo` animate, `unTick` does not.
+
+Be aware `useShoppingList` returns `exitingItems` but `islands/items.tsx` never consumes it, so there is **no existing CSS class** for an exiting row. Task 7 renders it with an inline transition; don't go hunting for a class.
+
+**Hook tests do exist.** `hooks/useShoppingList.test.ts` calls the hook directly and drives timers with `FakeTime` and `stub` from `jsr:@std/testing@^1.0.18`. Follow it.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `hooks/useTodos.test.ts`:
+
+```ts
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import { stub } from "jsr:@std/testing@^1.0.18/mock";
+import { FakeTime } from "jsr:@std/testing@^1.0.18/time";
+import { api } from "@/services/api.ts";
+import { useTodos } from "@/hooks/useTodos.ts";
+import type { TodoInterface } from "@/models/index.ts";
+
+function makeTodo(over: Partial<TodoInterface> = {}): TodoInterface {
+  return {
+    id: "t1",
+    householdId: "hh",
+    title: "Take out the bins",
+    createdBy: "u1",
+    createdAt: "2026-08-03T10:00:00.000Z",
+    completedAt: null,
+    ...over,
+  };
+}
+
+Deno.test("useTodos — splits the initial to-dos into open and done", () => {
+  const hook = useTodos([
+    makeTodo({ id: "t1" }),
+    makeTodo({ id: "t2", completedAt: "2026-08-02T12:00:00.000Z" }),
+  ]);
+
+  assertEquals(hook.openTodos.value.map((t) => t.id), ["t1"]);
+  assertEquals(hook.doneTodos.value.map((t) => t.id), ["t2"]);
+});
+
+Deno.test("tickOff — moves the to-do into done with a completedAt", async () => {
+  using _u = stub(
+    api.todos,
+    "update",
+    (_id: string, _patch: unknown) => Promise.resolve(makeTodo()),
+  );
+  const hook = useTodos([makeTodo({ id: "t1" })]);
+
+  using time = new FakeTime();
+  const promise = hook.tickOff("t1");
+  await time.tickAsync(300);
+  await promise;
+
+  assertEquals(hook.openTodos.value, []);
+  assertEquals(hook.doneTodos.value.length, 1);
+  assertEquals(hook.doneTodos.value[0].id, "t1");
+  assertEquals(hook.doneTodos.value[0].completedAt !== null, true);
+});
+
+Deno.test("tickOff — the to-do is in exitingIds during the 300ms animation", async () => {
+  using _u = stub(
+    api.todos,
+    "update",
+    (_id: string, _patch: unknown) => Promise.resolve(makeTodo()),
+  );
+  const hook = useTodos([makeTodo({ id: "t1" })]);
+
+  using time = new FakeTime();
+  const promise = hook.tickOff("t1");
+
+  assertEquals(hook.exitingIds.value.includes("t1"), true);
+
+  await time.tickAsync(300);
+  await promise;
+
+  assertEquals(hook.exitingIds.value.includes("t1"), false);
+});
+
+Deno.test("tickOff — rolls back and reports failure when the server rejects", async () => {
+  using _u = stub(
+    api.todos,
+    "update",
+    (_id: string, _patch: unknown) => Promise.resolve(null),
+  );
+  const hook = useTodos([makeTodo({ id: "t1" })]);
+
+  using time = new FakeTime();
+  const promise = hook.tickOff("t1");
+  await time.tickAsync(300);
+  const ok = await promise;
+
+  assertEquals(ok, false);
+  assertEquals(hook.openTodos.value.map((t) => t.id), ["t1"]);
+  assertEquals(hook.doneTodos.value, []);
+});
+
+Deno.test("unTick — moves the to-do back to open with a null completedAt", async () => {
+  using _u = stub(
+    api.todos,
+    "update",
+    (_id: string, _patch: unknown) => Promise.resolve(makeTodo()),
+  );
+  const hook = useTodos([
+    makeTodo({ id: "t1", completedAt: "2026-08-02T12:00:00.000Z" }),
+  ]);
+
+  const ok = await hook.unTick("t1");
+
+  assertEquals(ok, true);
+  assertEquals(hook.doneTodos.value, []);
+  assertEquals(hook.openTodos.value.length, 1);
+  assertEquals(hook.openTodos.value[0].completedAt, null);
+});
+
+Deno.test("removeTodo — removes the to-do and cancels a pending edit", async () => {
+  const patches: unknown[] = [];
+  using _u = stub(api.todos, "update", (_id: string, patch: unknown) => {
+    patches.push(patch);
+    return Promise.resolve(makeTodo());
+  });
+  using _d = stub(api.todos, "delete", (_id: string) => Promise.resolve(true));
+  const hook = useTodos([makeTodo({ id: "t1" })]);
+
+  using time = new FakeTime();
+  hook.editTodo("t1", { title: "Changed my mind" }); // schedules a 500ms write
+  const promise = hook.removeTodo("t1");
+  await time.tickAsync(300); // exit animation
+  const ok = await promise;
+  await time.tickAsync(1000); // the cancelled write must never fire
+
+  assertEquals(ok, true);
+  assertEquals(patches, []);
+  assertEquals(hook.openTodos.value, []);
+});
+
+Deno.test("removeTodo — restores the to-do when the delete fails", async () => {
+  using _d = stub(api.todos, "delete", (_id: string) => Promise.resolve(false));
+  const hook = useTodos([makeTodo({ id: "t1" })]);
+
+  using time = new FakeTime();
+  const promise = hook.removeTodo("t1");
+  await time.tickAsync(300);
+  const ok = await promise;
+
+  assertEquals(ok, false);
+  assertEquals(hook.openTodos.value.map((t) => t.id), ["t1"]);
+});
+
+Deno.test("editTodo — echoes locally but never persists a blank title", async () => {
+  const patches: unknown[] = [];
+  using _u = stub(api.todos, "update", (_id: string, patch: unknown) => {
+    patches.push(patch);
+    return Promise.resolve(makeTodo());
+  });
+  const hook = useTodos([makeTodo({ id: "t1" })]);
+
+  using time = new FakeTime();
+  hook.editTodo("t1", { title: "   " });
+  await time.tickAsync(600);
+
+  assertEquals(patches, []); // nothing written
+  assertEquals(hook.openTodos.value[0].title, "   "); // local echo only
+});
+
+Deno.test("editTodo — persists a non-blank title after the debounce", async () => {
+  const patches: unknown[] = [];
+  using _u = stub(api.todos, "update", (_id: string, patch: unknown) => {
+    patches.push(patch);
+    return Promise.resolve(makeTodo());
+  });
+  const hook = useTodos([makeTodo({ id: "t1" })]);
+
+  using time = new FakeTime();
+  hook.editTodo("t1", { title: "Take out the recycling" });
+  await time.tickAsync(600);
+
+  assertEquals(patches, [{ title: "Take out the recycling" }]);
+  assertEquals(hook.openTodos.value[0].title, "Take out the recycling");
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `deno test --unstable-kv -A hooks/useTodos.test.ts`
+Expected: FAIL — module not found, `Module not found "file:///.../hooks/useTodos.ts"`.
+
+- [ ] **Step 3: Write the hook**
+
+Create `hooks/useTodos.ts`:
+
+```ts
+import { signal } from "@preact/signals";
+import type { TodoInput, TodoInterface } from "@/models/index.ts";
+import { api } from "@/services/api.ts";
+import { createDebouncedMergeScheduler } from "@/utils/debounce-update.ts";
+import { beginBusy, endBusy } from "@/utils/loading.ts";
+
+type TodoEdit = { title?: string; notes?: string };
+
+/**
+ * Reactive store for a household's backlog. Follows the app's mutation
+ * conventions: creates are **pessimistic** (the server mints the id, so we wait
+ * for the returned to-do), edits are **optimistic and debounced**, and ticking
+ * off and deleting are **optimistic with rollback**. The `api` boundary never
+ * throws, so every mutation reports failure by return value and the island
+ * surfaces a snackbar.
+ *
+ * Call this inside `useMemo(() => useTodos(initial), [])` so the signals are
+ * created once — see `islands/todos/TodoBacklog.tsx`.
+ */
+export function useTodos(initialTodos: TodoInterface[]) {
+  const initial = initialTodos ?? [];
+  // TodoRepo.getAll already returns open before done, so this is a partition.
+  const openTodos = signal<TodoInterface[]>(
+    initial.filter((t) => t.completedAt === null),
+  );
+  const doneTodos = signal<TodoInterface[]>(
+    initial.filter((t) => t.completedAt !== null),
+  );
+  const pendingCount = signal(0);
+  /** Ids mid-exit-animation — the island fades these out (patterns doc §6). */
+  const exitingIds = signal<string[]>([]);
+
+  const EXIT_MS = 300; // keep in sync with the row transition in TodoBacklog.tsx
+
+  const startPending = () => {
+    pendingCount.value++;
+    beginBusy();
+  };
+  const endPending = () => {
+    pendingCount.value--;
+    endBusy();
+  };
+
+  const findAnywhere = (id: string): TodoInterface | undefined =>
+    openTodos.value.find((t) => t.id === id) ??
+      doneTodos.value.find((t) => t.id === id);
+
+  /** Debounced title/notes writes, merged per to-do (500ms default). */
+  const scheduler = createDebouncedMergeScheduler<TodoEdit>({
+    flush: async (id, patch) => {
+      // Never persist a blank title — the sheet's field can be emptied
+      // mid-typing, and the last non-empty value is what the user meant.
+      if (patch.title !== undefined && !patch.title.trim()) return;
+      startPending();
+      try {
+        await api.todos.update(id, patch);
+      } finally {
+        endPending();
+      }
+    },
+  });
+
+  const addTodo = async (input: TodoInput): Promise<TodoInterface | null> => {
+    startPending();
+    try {
+      const created = await api.todos.create(input);
+      if (created) openTodos.value = [created, ...openTodos.value];
+      return created;
+    } finally {
+      endPending();
+    }
+  };
+
+  /** Optimistic local edit; the write is debounced and merged. */
+  const editTodo = (id: string, patch: TodoEdit): void => {
+    const apply = (list: TodoInterface[]) =>
+      list.map((t) => (t.id === id ? { ...t, ...patch } : t));
+    if (openTodos.value.some((t) => t.id === id)) {
+      openTodos.value = apply(openTodos.value);
+    } else {
+      doneTodos.value = apply(doneTodos.value);
+    }
+    scheduler.schedule(id, patch);
+  };
+
+  /** Persist a pending edit immediately — call when the edit sheet closes. */
+  const flushTodo = (id: string): void => scheduler.flush(id);
+
+  const tickOff = async (id: string): Promise<boolean> => {
+    const todo = openTodos.value.find((t) => t.id === id);
+    if (!todo) return false;
+
+    // §6: keep the row on screen for the transition, then move it.
+    exitingIds.value = [...exitingIds.value, id];
+    await new Promise((resolve) => setTimeout(resolve, EXIT_MS));
+
+    // Snapshot after the wait — state may have changed during the animation.
+    const openSnapshot = openTodos.value;
+    const doneSnapshot = doneTodos.value;
+    const completedAt = new Date().toISOString();
+    const ticked = { ...todo, completedAt };
+
+    openTodos.value = openTodos.value.filter((t) => t.id !== id);
+    doneTodos.value = [ticked, ...doneTodos.value];
+    exitingIds.value = exitingIds.value.filter((x) => x !== id);
+
+    // Deliberately does NOT cancel pending edits, unlike useShoppingList's
+    // checkItem: a queued title patch still targets a live record, and both
+    // patches go through mergeDefinedPatch, so neither clobbers the other.
+    startPending();
+    try {
+      const saved = await api.todos.update(id, { completedAt });
+      if (!saved) {
+        openTodos.value = openSnapshot;
+        doneTodos.value = doneSnapshot;
+        return false;
+      }
+      return true;
+    } finally {
+      endPending();
+    }
+  };
+
+  const unTick = async (id: string): Promise<boolean> => {
+    const todo = doneTodos.value.find((t) => t.id === id);
+    if (!todo) return false;
+    const openSnapshot = openTodos.value;
+    const doneSnapshot = doneTodos.value;
+    const reopened = { ...todo, completedAt: null };
+
+    doneTodos.value = doneTodos.value.filter((t) => t.id !== id);
+    openTodos.value = [reopened, ...openTodos.value];
+
+    startPending();
+    try {
+      const saved = await api.todos.update(id, { completedAt: null });
+      if (!saved) {
+        openTodos.value = openSnapshot;
+        doneTodos.value = doneSnapshot;
+        return false;
+      }
+      return true;
+    } finally {
+      endPending();
+    }
+  };
+
+  const removeTodo = async (id: string): Promise<boolean> => {
+    if (!findAnywhere(id)) return false;
+
+    exitingIds.value = [...exitingIds.value, id];
+    await new Promise((resolve) => setTimeout(resolve, EXIT_MS));
+
+    const openSnapshot = openTodos.value;
+    const doneSnapshot = doneTodos.value;
+
+    // Drop any pending debounced edit first, or a late flush would PATCH a
+    // to-do we just deleted (the hazard clearCheckedItems guards against in
+    // hooks/useShoppingList.ts:195).
+    scheduler.cancel(id);
+    openTodos.value = openTodos.value.filter((t) => t.id !== id);
+    doneTodos.value = doneTodos.value.filter((t) => t.id !== id);
+    exitingIds.value = exitingIds.value.filter((x) => x !== id);
+
+    startPending();
+    try {
+      const ok = await api.todos.delete(id);
+      if (!ok) {
+        openTodos.value = openSnapshot;
+        doneTodos.value = doneSnapshot;
+      }
+      return ok;
+    } finally {
+      endPending();
+    }
+  };
+
+  const refresh = async (): Promise<void> => {
+    // Pull-to-refresh renders its own spinner, so this intentionally tracks
+    // pendingCount without driving the global loading bar (beginBusy/endBusy).
+    pendingCount.value++;
+    try {
+      const all = await api.todos.getAll();
+      openTodos.value = all.filter((t) => t.completedAt === null);
+      doneTodos.value = all.filter((t) => t.completedAt !== null);
+    } finally {
+      pendingCount.value--;
+    }
+  };
+
+  return {
+    openTodos,
+    doneTodos,
+    exitingIds,
+    pendingCount,
+    addTodo,
+    editTodo,
+    flushTodo,
+    tickOff,
+    unTick,
+    removeTodo,
+    refresh,
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `deno test --unstable-kv -A hooks/useTodos.test.ts`
+Expected: PASS, 9 passed.
+
+- [ ] **Step 5: Verify the whole suite and check**
+
+Run: `deno task check && deno task test`
+Expected: both PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add hooks/useTodos.ts hooks/useTodos.test.ts
+git commit -m "feat(todos): add useTodos store"
+```
+
+---
+
+### Task 7: TodoBacklog island
+
+**Files:**
+- Create: `islands/todos/TodoBacklog.tsx`
+- Create: `islands/todos/TodoBacklog.test.tsx`
+
+**Interfaces:**
+- Consumes: `useTodos` (Task 6); `TodoInterface` from `@/models/index.ts`; `Sheet`, `Button`, `RoundCheck`, `Icon`, `Snackbar`, `PullToRefresh`, `Pressable` from `@/components/md3/*`; `Fab` from `@/islands/shell/Fab.tsx`.
+- Produces: default-exported `TodoBacklog({ initialTodos }: { initialTodos: TodoInterface[] })`, consumed by Task 8.
+
+Copy strings the test asserts on, so keep them exact: FAB label `"New to-do"`, create sheet title `"New to-do"`, empty-state title `"Nothing to do"`, done heading `"Done"`, delete confirmation title `"Delete this to-do?"`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `islands/todos/TodoBacklog.test.tsx`:
+
+```tsx
+import { assertStringIncludes } from "jsr:@std/assert@^1.0.19";
+import { render } from "npm:preact-render-to-string@^6.6.3";
+import { h } from "preact";
+import TodoBacklog from "./TodoBacklog.tsx";
+import type { TodoInterface } from "@/models/index.ts";
+
+function todo(over: Partial<TodoInterface>): TodoInterface {
+  return {
+    id: "t1",
+    householdId: "hh",
+    title: "Take out the bins",
+    createdBy: "u1",
+    createdAt: "2026-08-03T10:00:00.000Z",
+    completedAt: null,
+    ...over,
+  };
+}
+
+Deno.test("TodoBacklog — renders open and done to-dos, and the FAB", () => {
+  const html = render(h(TodoBacklog, {
+    initialTodos: [
+      todo({ id: "t1", title: "Take out the bins" }),
+      todo({ id: "t2", title: "Call the dentist", notes: "09 123 45 67" }),
+      todo({
+        id: "t3",
+        title: "Pay the water bill",
+        completedAt: "2026-08-02T12:00:00.000Z",
+      }),
+    ],
+  }));
+
+  assertStringIncludes(html, "Take out the bins");
+  assertStringIncludes(html, "Call the dentist");
+  assertStringIncludes(html, "09 123 45 67"); // notes hint on the row
+  assertStringIncludes(html, "Pay the water bill");
+  assertStringIncludes(html, "Done"); // done section heading
+  assertStringIncludes(html, "New to-do"); // FAB label
+});
+
+Deno.test("TodoBacklog — empty state when the household has no to-dos", () => {
+  const html = render(h(TodoBacklog, { initialTodos: [] }));
+
+  assertStringIncludes(html, "Nothing to do");
+  assertStringIncludes(html, "New to-do"); // FAB is still offered
+});
+
+Deno.test("TodoBacklog — no Done heading when nothing is done yet", () => {
+  const html = render(h(TodoBacklog, {
+    initialTodos: [todo({ id: "t1", title: "Take out the bins" })],
+  }));
+
+  assertStringIncludes(html, "Take out the bins");
+  if (html.includes(">Done<")) {
+    throw new Error("Done section should be hidden when no to-do is done");
+  }
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `deno test --unstable-kv -A islands/todos/TodoBacklog.test.tsx`
+Expected: FAIL — module not found, `Module not found "file:///.../islands/todos/TodoBacklog.tsx"`.
+
+- [ ] **Step 3: Write the island**
+
+Create `islands/todos/TodoBacklog.tsx`:
+
+```tsx
+import { useMemo } from "preact/hooks";
+import { useSignal } from "@preact/signals";
+import type { TodoInterface } from "@/models/index.ts";
+import { useTodos } from "@/hooks/useTodos.ts";
+import { PullToRefresh } from "@/components/md3/PullToRefresh.tsx";
+import { Sheet } from "@/components/md3/Sheet.tsx";
+import { Button } from "@/components/md3/Button.tsx";
+import { RoundCheck } from "@/components/md3/RoundCheck.tsx";
+import { Icon } from "@/components/md3/Icon.tsx";
+import { Snackbar } from "@/components/md3/Snackbar.tsx";
+import { Pressable } from "@/components/md3/Pressable.tsx";
+import Fab from "@/islands/shell/Fab.tsx";
+
+interface Props {
+  initialTodos: TodoInterface[];
+}
+
+export default function TodoBacklog({ initialTodos }: Props) {
+  // useMemo([]) so the hook's signals are created once from SSR props.
+  const {
+    openTodos,
+    doneTodos,
+    exitingIds,
+    addTodo,
+    editTodo,
+    flushTodo,
+    tickOff,
+    unTick,
+    removeTodo,
+    refresh,
+  } = useMemo(() => useTodos(initialTodos), []);
+
+  const createOpen = useSignal(false);
+  const newTitle = useSignal("");
+  const newNotes = useSignal("");
+  const editingId = useSignal<string | null>(null);
+  const confirmingId = useSignal<string | null>(null);
+  const snack = useSignal<{ msg: string } | null>(null);
+
+  const open = openTodos.value;
+  const done = doneTodos.value;
+  const exiting = exitingIds.value;
+
+  const editing = () =>
+    open.find((t) => t.id === editingId.value) ??
+      done.find((t) => t.id === editingId.value);
+
+  const say = (msg: string) => {
+    snack.value = { msg };
+    setTimeout(() => (snack.value = null), 4000);
+  };
+
+  const submitNew = async () => {
+    const title = newTitle.value.trim();
+    if (!title) return;
+    const notes = newNotes.value.trim();
+    const created = await addTodo({ title, notes: notes || undefined });
+    if (!created) {
+      say("Couldn't add that to-do. Try again?");
+      return;
+    }
+    // Keep the sheet open and the field focused so several to-dos can be
+    // captured in a row without the mobile keyboard dismissing.
+    newTitle.value = "";
+    newNotes.value = "";
+  };
+
+  const closeEditor = () => {
+    const id = editingId.value;
+    if (id) flushTodo(id);
+    editingId.value = null;
+  };
+
+  // The 300ms here must match EXIT_MS in useTodos (patterns doc §6).
+  const row = (t: TodoInterface, isDone: boolean) => (
+    <div
+      key={t.id}
+      class="flex items-start gap-3 px-1 py-2.5"
+      style={{
+        opacity: exiting.includes(t.id) ? 0 : 1,
+        transform: exiting.includes(t.id)
+          ? "translateX(12px)"
+          : "translateX(0)",
+        transition:
+          "opacity .3s var(--md-emphasized), transform .3s var(--md-emphasized)",
+      }}
+    >
+      <Pressable
+        onClick={async () => {
+          const ok = isDone ? await unTick(t.id) : await tickOff(t.id);
+          if (!ok) say("That didn't save. Try again?");
+        }}
+        aria-label={isDone ? `Reopen ${t.title}` : `Tick off ${t.title}`}
+        class="pt-0.5"
+      >
+        <RoundCheck checked={isDone} />
+      </Pressable>
+      <Pressable
+        onClick={() => (editingId.value = t.id)}
+        class="flex-1 min-w-0 text-left"
+      >
+        <div
+          class={`md-body-large ${
+            isDone ? "text-on-surface-variant line-through" : "text-on-surface"
+          }`}
+        >
+          {t.title}
+        </div>
+        {t.notes && (
+          <div class="md-body-small text-on-surface-variant truncate">
+            📝 {t.notes}
+          </div>
+        )}
+      </Pressable>
+    </div>
+  );
+
+  return (
+    <PullToRefresh onRefresh={refresh}>
+      <div class="px-4 pt-4 pb-[calc(96px+env(safe-area-inset-bottom))] flex flex-col gap-4">
+        {open.length === 0 && done.length === 0
+          ? (
+            <div class="flex flex-col items-center text-center gap-4 pt-12 px-7">
+              <div
+                class="grid place-items-center bg-primary-container text-on-primary-container"
+                style={{
+                  width: 88,
+                  height: 88,
+                  borderRadius: "var(--md-shape-xl)",
+                }}
+              >
+                <Icon name="checklist" size={44} />
+              </div>
+              <div class="md-headline-small text-on-surface">Nothing to do</div>
+              <div
+                class="md-body-medium text-on-surface-variant"
+                style={{ maxWidth: 280 }}
+              >
+                When something needs doing around the house, add it here so
+                everyone can see it.
+              </div>
+            </div>
+          )
+          : (
+            <>
+              {open.length > 0 && (
+                <div class="flex flex-col">
+                  {open.map((t) => row(t, false))}
+                </div>
+              )}
+
+              {done.length > 0 && (
+                <div class="flex flex-col gap-1">
+                  <div class="md-label-medium uppercase text-on-surface-variant px-1 pt-2">
+                    Done
+                  </div>
+                  {done.map((t) => row(t, true))}
+                </div>
+              )}
+            </>
+          )}
+      </div>
+
+      {/* New-to-do FAB — shared component, fixed below the nav chrome */}
+      <div
+        class="fixed right-4 z-30"
+        style={{ bottom: "calc(96px + env(safe-area-inset-bottom))" }}
+      >
+        <Fab
+          icon="plus"
+          label="New to-do"
+          aria-label="New to-do"
+          onClick={() => {
+            newTitle.value = "";
+            newNotes.value = "";
+            createOpen.value = true;
+          }}
+        />
+      </div>
+
+      {/* Create sheet — stays open between saves for rapid capture */}
+      <Sheet
+        open={createOpen.value}
+        onClose={() => (createOpen.value = false)}
+        title="New to-do"
+      >
+        <div class="flex flex-col gap-3 pb-1">
+          <input
+            autofocus
+            value={newTitle.value}
+            onInput={(e) => (newTitle.value = e.currentTarget.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                submitNew();
+              }
+            }}
+            placeholder="What needs doing?"
+            aria-label="What needs doing?"
+            class="w-full md-body-large text-on-surface bg-surface-chigh border-0 rounded-[var(--md-shape-lg)] py-3 px-4 outline-none"
+          />
+          <textarea
+            value={newNotes.value}
+            onInput={(e) => (newNotes.value = e.currentTarget.value)}
+            rows={2}
+            placeholder="Notes (optional)"
+            aria-label="Notes (optional)"
+            class="w-full md-body-large text-on-surface bg-surface-chigh border-0 rounded-[var(--md-shape-lg)] py-3 px-4 outline-none resize-none"
+          />
+          <Button variant="filled" full onClick={submitNew}>Add</Button>
+          <Button
+            variant="text"
+            full
+            onClick={() => (createOpen.value = false)}
+          >
+            Done
+          </Button>
+        </div>
+      </Sheet>
+
+      {/* Edit sheet */}
+      <Sheet
+        open={editingId.value !== null}
+        onClose={closeEditor}
+        title="Edit to-do"
+      >
+        {(() => {
+          const t = editing();
+          if (!t) return null;
+          return (
+            <div class="flex flex-col gap-3 pb-1">
+              <input
+                value={t.title}
+                onInput={(e) =>
+                  editTodo(t.id, { title: e.currentTarget.value })}
+                aria-label="Title"
+                class="w-full md-body-large text-on-surface bg-surface-chigh border-0 rounded-[var(--md-shape-lg)] py-3 px-4 outline-none"
+              />
+              <textarea
+                value={t.notes ?? ""}
+                onInput={(e) =>
+                  editTodo(t.id, { notes: e.currentTarget.value })}
+                rows={2}
+                placeholder="Notes (optional)"
+                aria-label="Notes"
+                class="w-full md-body-large text-on-surface bg-surface-chigh border-0 rounded-[var(--md-shape-lg)] py-3 px-4 outline-none resize-none"
+              />
+              <Button variant="filled" full onClick={closeEditor}>Done</Button>
+              <Button
+                variant="error"
+                full
+                onClick={() => {
+                  const id = t.id;
+                  closeEditor();
+                  confirmingId.value = id;
+                }}
+              >
+                Delete
+              </Button>
+            </div>
+          );
+        })()}
+      </Sheet>
+
+      {/* Delete confirmation — the house pattern is a sheet, not a dialog */}
+      <Sheet
+        open={confirmingId.value !== null}
+        onClose={() => (confirmingId.value = null)}
+        title="Delete this to-do?"
+      >
+        <div class="flex flex-col gap-3 pb-1">
+          <div class="md-body-medium text-on-surface-variant">
+            This removes it for everyone. Use it when the to-do never needed
+            doing — ticking it off is how you say it's done.
+          </div>
+          <Button
+            variant="error"
+            full
+            onClick={async () => {
+              const id = confirmingId.value;
+              confirmingId.value = null;
+              if (!id) return;
+              const ok = await removeTodo(id);
+              if (!ok) say("Couldn't delete that. Try again?");
+            }}
+          >
+            Delete
+          </Button>
+          <Button
+            variant="text"
+            full
+            onClick={() => (confirmingId.value = null)}
+          >
+            Keep it
+          </Button>
+        </div>
+      </Sheet>
+
+      <Snackbar data={snack.value} />
+    </PullToRefresh>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `deno test --unstable-kv -A islands/todos/TodoBacklog.test.tsx`
+Expected: PASS, 3 passed.
+
+If the third test fails because `>Done<` appears in the create sheet's text button, that is a genuine collision — rename that button's label to `"Close"` in both the island and this plan's expectations, and re-run.
+
+- [ ] **Step 5: Verify the whole suite and check**
+
+Run: `deno task check && deno task test`
+Expected: both PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add islands/todos
+git commit -m "feat(todos): add TodoBacklog island"
+```
+
+---
+
+### Task 8: Wire up the /todos route
+
+**Files:**
+- Modify: `routes/todos/index.tsx` (replace the whole file — it is currently a 14-line `ComingSoon`)
+
+**Interfaces:**
+- Consumes: `TodoRepo` (Task 3), `TodoBacklog` (Task 7), `define` and `page`.
+- Produces: the working `/todos` page. Nothing downstream consumes this.
+
+`/todos` is a top-level nav tab, already registered at `config/navigation.ts:41`, so it takes the default section-title app bar and must **not** set `ctx.state.appBar`.
+
+- [ ] **Step 1: Replace the route**
+
+Overwrite `routes/todos/index.tsx`:
+
+```tsx
+import { page } from "fresh";
+import { TodoRepo } from "@/database/index.ts";
+import TodoBacklog from "@/islands/todos/TodoBacklog.tsx";
+import { define } from "@/utils/index.ts";
+
+export const handler = define.handlers({
+  async GET(ctx) {
+    const householdId = ctx.state.householdId!;
+    return page({ todos: await TodoRepo.getAll(householdId) });
+  },
+});
+
+export default define.page<typeof handler>(function Todos({ data }) {
+  return (
+    <main class="max-w-md mx-auto">
+      <TodoBacklog initialTodos={data.todos} />
+    </main>
+  );
+});
+```
+
+- [ ] **Step 2: Verify check and the whole suite pass**
+
+Run: `deno task check && deno task test`
+Expected: both PASS.
+
+- [ ] **Step 3: Start the dev server and open /todos**
+
+Run: `deno task dev`, then open `/todos` in the browser preview.
+Expected: the empty state — "Nothing to do" — and a "New to-do" FAB. No "Coming soon" pill.
+
+- [ ] **Step 4: Verify the full journey by hand**
+
+Walk each of these and confirm the stated result:
+
+1. Tap the FAB → sheet opens with the title field focused.
+2. Type "Take out the bins", press Enter → it appears at the top of the list; the sheet stays open with an empty, still-focused field.
+3. Type "Call the dentist", press Enter → it appears **above** "Take out the bins" (newest first). Close the sheet.
+4. Tap the round check on "Take out the bins" → it leaves the open list and appears under a **Done** heading, struck through.
+5. Tap its round check again → it returns to the open list.
+6. Tap the "Call the dentist" row → the edit sheet opens. Add a note, then tap Done → the note shows on the row with a 📝 prefix.
+7. Reload the page → both to-dos, the note, and any done state all survive (this proves SSR and persistence agree).
+8. Open a to-do, tap Delete → the confirmation sheet appears. Tap "Keep it" → nothing is deleted. Tap Delete again, then confirm → the to-do disappears.
+9. Reload → the deleted to-do is still gone.
+10. Select the whole title in the edit sheet and delete it, then close the sheet → reload and confirm the **old title is still there** (the blank-title guard held).
+
+- [ ] **Step 5: Confirm the empty state and the seed still work**
+
+Run: `deno task db:seed`
+Expected: completes without error. Then reload `/todos` — a seeded household has no to-dos, so the empty state shows. The seed script is not modified by this plan.
+
+- [ ] **Step 6: Stop the dev server and commit**
+
+```bash
+git add routes/todos/index.tsx
+git commit -m "feat(todos): replace the /todos placeholder with the backlog"
+```
+
+---
+
+### Task 9: Update the patterns doc and the More sheet
+
+**Files:**
+- Modify: `islands/shell/MoreSheet.tsx:37-66` (the To-dos module row currently says "coming soon")
+- Modify: `docs/ui-ux-patterns.md`
+
+**Interfaces:**
+- Consumes: the working `/todos` route (Task 8).
+- Produces: nothing consumed by code.
+
+CLAUDE.md requires `docs/ui-ux-patterns.md` to be kept updated when a new pattern is introduced. This feature introduces one: **a create sheet that stays open across saves for rapid capture**.
+
+- [ ] **Step 1: Point the More sheet at the live route**
+
+In `islands/shell/MoreSheet.tsx`, replace the To-dos row (currently at `:47-52`):
+
+```tsx
+        <ListItem
+          leading={badge("checklist")}
+          headline="To-dos"
+          trailing={chevron()}
+          onClick={() => soon("To-dos")}
+        />
+```
+
+with the navigating form, matching the Shopping row directly above it:
+
+```tsx
+        <ListItem
+          leading={badge("checklist")}
+          headline="To-dos"
+          trailing={chevron()}
+          onClick={() => {
+            onClose();
+            navigateTo("/todos");
+          }}
+        />
+```
+
+Leave the Menu planner row's `soon(...)` call alone. If `soon` becomes unused after this edit, `deno lint` will say so — in that case keep it, because Menu planner still uses it.
+
+- [ ] **Step 2: Document the persistent-create-sheet pattern**
+
+In `docs/ui-ux-patterns.md`, add a short subsection near the existing mutation and sheet guidance:
+
+```markdown
+### Create sheets that stay open for rapid capture
+
+Most create sheets close on save (New list, Add card, Add dish). Where a user
+plausibly adds several things in one sitting — the to-do backlog — the sheet
+**stays open** after a successful save, clearing its fields and keeping focus,
+and closes only via its own button or the scrim.
+
+**Why:** it removes two taps per item, and it stops the mobile soft keyboard
+dismissing and re-opening between entries — the class of problem behind the
+keyboard primer in `islands/items.tsx` and the autofocus regression in PR #45.
+
+**Don't** use this for creates that need a decision per item (choosing a
+category, a barcode format) — there the sheet closing *is* the confirmation.
+
+**See:** `islands/todos/TodoBacklog.tsx` — the create `Sheet` and `submitNew`.
+```
+
+- [ ] **Step 3: Verify check passes**
+
+Run: `deno task check`
+Expected: PASS. (`deno.json` excludes `docs/`, so the doc edit is not format-checked; the `MoreSheet.tsx` edit is.)
+
+- [ ] **Step 4: Verify the More sheet in the browser**
+
+Run `deno task dev`, open the More tab, tap To-dos.
+Expected: it navigates to `/todos` instead of showing a "coming soon" snackbar.
+
+- [ ] **Step 5: Stop the dev server and commit**
+
+```bash
+git add islands/shell/MoreSheet.tsx docs/ui-ux-patterns.md
+git commit -m "docs(todos): surface to-dos in the More sheet and document the capture-sheet pattern"
+```
+
+---
+
+## Verification before calling this done
+
+- [ ] `deno task check` passes
+- [ ] `deno task test` passes, and includes the new `utils/http.test.ts`, `database/todo.repo.test.ts`, `hooks/useTodos.test.ts` and `islands/todos/TodoBacklog.test.tsx`
+- [ ] The full manual journey in Task 8 Step 4 has been walked, not assumed
+- [ ] `/todos` shows no "Coming soon" pill anywhere
+- [ ] No file outside the File Structure table was modified
+
+## Deliberately not built
+
+Re-read this before adding anything: assignment, `completedBy`, filters, due dates, recurrence, labels, bulk "clear done", `createKvRepo<T>`, the `services/api/<entity>.ts` split, Dutch copy, home-screen counts, nav badges. Each is scoped to a later iteration in the spec, and assignment is hard-blocked on issue #17.

--- a/docs/superpowers/plans/2026-08-03-household-shared-todos.md
+++ b/docs/superpowers/plans/2026-08-03-household-shared-todos.md
@@ -1358,7 +1358,9 @@ type TodoEdit = { title?: string; notes?: string };
  */
 export function useTodos(initialTodos: TodoInterface[]) {
   const initial = initialTodos ?? [];
-  // TodoRepo.getAll already returns open before done, so this is a partition.
+  // Two independent filters splitting on completedAt === null; getAll's
+  // ordering (newest-created first, then most-recently-done first) is what
+  // keeps each resulting list correctly ordered without sorting here.
   const openTodos = signal<TodoInterface[]>(
     initial.filter((t) => t.completedAt === null),
   );
@@ -1426,14 +1428,25 @@ export function useTodos(initialTodos: TodoInterface[]) {
   const flushTodo = (id: string): void => scheduler.flush(id);
 
   const tickOff = async (id: string): Promise<boolean> => {
-    const todo = openTodos.value.find((t) => t.id === id);
-    if (!todo) return false;
+    // Cheap non-capturing check, so an unknown id returns without waiting 300ms.
+    if (!openTodos.value.some((t) => t.id === id)) return false;
 
     // §6: keep the row on screen for the transition, then move it.
     exitingIds.value = [...exitingIds.value, id];
     await new Promise((resolve) => setTimeout(resolve, EXIT_MS));
 
-    // Snapshot after the wait — state may have changed during the animation.
+    // Re-read after the wait — state may have changed during the animation
+    // (an edit, or a refresh() replacing the list). Building `ticked` from a
+    // pre-wait capture would silently drop a concurrent edit, and because
+    // tickOff does not cancel pending writes the server would still persist
+    // it — leaving local and server state diverged. Mirrors
+    // hooks/useShoppingList.ts:151, which re-reads for the same reason.
+    const todo = openTodos.value.find((t) => t.id === id);
+    if (!todo) {
+      exitingIds.value = exitingIds.value.filter((x) => x !== id);
+      return false;
+    }
+
     const openSnapshot = openTodos.value;
     const doneSnapshot = doneTodos.value;
     const completedAt = new Date().toISOString();

--- a/docs/superpowers/specs/2026-08-03-household-shared-todos-design.md
+++ b/docs/superpowers/specs/2026-08-03-household-shared-todos-design.md
@@ -1,0 +1,289 @@
+# Household shared to-dos — iteration 1
+
+**Status:** approved, ready for an implementation plan
+**Date:** 2026-08-03
+**Module:** To-dos (`/todos`)
+
+## Summary
+
+The to-dos module gives a household one shared backlog of things that need doing.
+Iteration 1 is deliberately a plain CRUD slice: create, read, update, delete, and
+tick off. Ticking off means *we did this*; deleting means *this never needed to
+happen*. Nothing is assigned to anyone yet, nothing is due, nothing recurs.
+
+The nav tab and route already exist as a placeholder — `todos` is a live tab
+(`config/navigation.ts:41`) and `routes/todos/index.tsx` renders `ComingSoon`.
+This work replaces that placeholder.
+
+## Domain language
+
+Defined in [`CONTEXT.md`](../../../CONTEXT.md): **Household**, **To-do**,
+**Backlog**, **Done**, **Not needed**. The spec uses those terms exactly; in
+particular a to-do is never called a task, chore or item, and the backlog is
+never called a list.
+
+## Decisions of record
+
+Two decisions deviate from the shopping module sitting next to them and are
+written up as ADRs:
+
+- [ADR 0001](../../adr/0001-one-household-backlog-no-todo-lists.md) — one
+  household backlog, no to-do lists
+- [ADR 0002](../../adr/0002-completion-is-a-timestamp-not-needed-is-a-deletion.md)
+  — completion is a timestamp; "not needed" is a deletion
+
+Decisions **not** given an ADR, and why: household scoping matches
+`LoyaltyCardRepo` and had no real alternative; the module's layering choices
+(below) are cheap to reverse and issue #51 owns them.
+
+## Scope
+
+### In iteration 1
+
+- `/todos` replaces the `ComingSoon` placeholder: SSR loader plus
+  `islands/todos/TodoBacklog.tsx`, mirroring `routes/shopping/index.tsx` → island
+- Create via the FAB → a sheet that **stays open** between saves for rapid capture
+- Read: an Open section and a Done section
+- Update title and notes via the row → the same sheet in edit mode
+- Delete, guarded by a confirmation bottom sheet
+- Tick off and un-tick
+- `TodoRepo`, the API routes, the `todos` API-client namespace, `hooks/useTodos.ts`
+- Repo tests and an island SSR test
+- An empty state for a household with no to-dos
+
+### Out of iteration 1
+
+| Iteration | Deferred work | Why it waits |
+| --- | --- | --- |
+| 2 | Assignment to members, `completedBy`, filters (title, assignee, not-done) | Hard-blocked on issue #17 — a household cannot yet hold more than one member, so there is nothing to assign to |
+| 3 | Due dates, today/overdue views, windowing the Done section | A due date is not one field; it brings sorting, overdue styling and views with it |
+| 4 | Recurrence | What monthly bills, the weekly bins and yearly appointments actually need |
+| 5 | Labels | The "plan a birthday party" grouping case |
+| — | Dutch copy | English now; issue #13 converts the app in one pass |
+| — | Home-screen counts, nav badges, activity log | Not asked for |
+| — | `createKvRepo<T>` | Issue #51, app-wide |
+
+### The membership caveat
+
+A household currently contains exactly one user. `UserInterface` carries a single
+`householdId` FK and `UserRepo.create` always mints a brand-new household
+(`database/user.repo.ts:24`), so it cannot place a user into an existing one;
+there is no signup route and `UserRepo.create` has no callers in app code.
+
+Iteration 1 is therefore **architecturally** shared but **observably**
+single-user. Scoping by `householdId` from the start costs nothing today —
+`ctx.state.householdId` is already resolved for every authenticated request
+(`routes/_middleware.ts:38`) — and avoids the migration that issue #42 is
+currently paying for on the catalogue.
+
+## Data model
+
+New: `models/todo/todo.interface.ts`, barrelled through `models/todo/index.ts` and
+`models/index.ts`, following the existing `XxxInterface` + DTO conventions.
+
+```ts
+export interface TodoInterface {
+  id: string;
+  householdId: string;
+  title: string;
+  notes?: string;
+  createdBy: string;          // userId
+  createdAt: string;          // ISO
+  completedAt: string | null; // null = not done
+}
+
+// Derived type for creation (No ID)
+export type CreateTodoDto = Omit<TodoInterface, "id">;
+
+// What the client may send. Excludes householdId/createdBy/createdAt so the
+// client cannot spoof ownership — mirrors LoyaltyCardInput.
+export type TodoInput = Pick<TodoInterface, "title" | "notes">;
+
+export type UpdateTodoDto = Partial<Omit<TodoInterface, "id" | "householdId">>;
+```
+
+Notes on the shape:
+
+- `completedAt` is a **required key with a nullable value**, not an optional
+  field. Every write path must state which it is; optional-and-absent makes "not
+  done" indistinguishable from "this record predates the field".
+- `createdBy` is required, matching `ShoppingListInterface` (dishes, categories
+  and cards all make it optional, which is the weaker choice). It stays a userId
+  permanently and correctly, because creating a to-do requires a login. It is
+  *completing* and *assignment* that will point at members.
+- `UpdateTodoDto` uses the newer of the two update-DTO shapes in the codebase —
+  `Partial<Omit<I, "id">>` with the id passed as a separate argument, as
+  `dish` and `loyalty-card` do — not the older `Pick<I,"id"> & Partial<...>`.
+
+## Persistence
+
+New: `database/todo.repo.ts`. Hand-rolled, copying `database/loyalty-card.repo.ts`
+— the cleanest household-scoped repo in the codebase. Static methods, `getKv()`
+at the top of each, `householdId` as the first parameter of every method.
+
+Key: `["todos", householdId, id]`
+
+| Method | Behaviour |
+| --- | --- |
+| `create(householdId, dto: CreateTodoDto)` | mints `crypto.randomUUID()`, `kv.set`, returns the to-do |
+| `getAll(householdId)` | prefix scan, **sorted** (below) |
+| `getById(householdId, id)` | returns `null` when absent |
+| `update(householdId, id, patch: UpdateTodoDto)` | `mergeDefinedPatch`, then re-read via `getById`; returns `null` when absent |
+| `delete(householdId, id)` | hard delete |
+
+**`getAll` sorts; callers never do.** Open to-dos first, newest `createdAt`
+first; then done to-dos, most recent `completedAt` first. One stable order means
+the SSR render and the hydrated view agree, and the island only has to find the
+partition point. This is a deliberate fix, not a copy:
+`ShoppingListItemRepo.getAll` does a bare prefix scan
+(`database/shopping-list-item.repo.ts:23`), so with random UUID keys shopping
+items come back in effectively arbitrary order.
+
+`update` uses `mergeDefinedPatch` (`database/merge-patch.ts:10`) so a partial
+patch cannot clobber omitted fields. Like every repo here except
+`WeeklyMenuRepo`, `update` is a non-atomic read-modify-write; that matches the
+established pattern and is acceptable while a household has one user. It is worth
+revisiting when #17 makes concurrent writers real.
+
+## API
+
+New response helpers at `utils/http.ts`, re-exported from `utils/index.ts`:
+`json(data, status)`, `noContent()`, `badRequest(msg)`, `notFound(msg)` — exactly
+the set issue #51 proposes, no more. A `201` is `json(todo, 201)`; there is no
+separate `created` helper. These are the uncontroversial half of #51 — additive,
+they touch no existing code, and they remove the repeated
+`new Response(JSON.stringify(...))` from four new handlers instead of adding a
+ninth copy of it.
+
+| Route | Method | Body | Response |
+| --- | --- | --- | --- |
+| `/api/todos` | `GET` | — | `200` `TodoInterface[]` |
+| `/api/todos` | `POST` | `TodoInput` | `201` `TodoInterface`, `400` on blank title |
+| `/api/todos/[id]` | `PATCH` | `UpdateTodoDto` | `200` `TodoInterface`, `404` |
+| `/api/todos/[id]` | `DELETE` | — | `204`, `404` |
+
+Every handler reads `householdId` from `ctx.state` and passes it to the repo. The
+client never sends a `householdId`; `POST` composes the `CreateTodoDto` from the
+`TodoInput` plus `householdId`, `createdBy` (the session user) and `createdAt`
+server-side.
+
+`UpdateTodoDto` is the **repo's** patch type and is deliberately wider than the
+wire contract. The `PATCH` handler picks only `title`, `notes` and `completedAt`
+off the parsed body and discards everything else, so a client cannot patch
+`createdBy` or `createdAt` even though the repo type permits it.
+
+Unauthenticated `/api/*` requests already 401 in middleware
+(`routes/_middleware.ts:44`), so handlers do not repeat that check.
+
+## Client and state
+
+- `services/api.ts` gains a `todos` namespace beside the existing seven.
+  The `services/api/<entity>.ts` split from issue #51 is **not** started here —
+  it is cheap and safe done all at once, and confusing done one-eighth of the way.
+- `hooks/useTodos.ts` holds two signals, `openTodos` and `doneTodos`, splitting
+  the sorted array from the server on `completedAt === null`. Because `getAll`
+  already returns open to-dos before done ones, this is a partition, not a
+  re-sort. Mirrors `hooks/useShoppingList.ts:18`.
+
+### Mutation strategy
+
+Per §1 of `docs/ui-ux-patterns.md`:
+
+| Action | Strategy |
+| --- | --- |
+| Create | **Pessimistic** — await the server, adopt the returned to-do. The server mints the id. |
+| Edit title/notes | **Optimistic**, debounced and merged via `utils/debounce-update.ts`, flushed when the sheet closes |
+| Tick off / un-tick | **Optimistic**, immediate `PATCH { completedAt }` — a discrete toggle, not debounced |
+| Delete | **Optimistic**, after the confirmation sheet |
+
+Every optimistic path snapshots, rolls back on failure, and surfaces a `Snackbar`
+(§3). Ticking off uses the optimistic exit animation from §6 so the row visibly
+leaves the Open section before landing in Done.
+
+## UI
+
+`routes/todos/index.tsx` — SSR loader calls `TodoRepo.getAll(householdId)` and
+passes the result to the island. `/todos` is a top-level tab, so it takes the
+default section-title app bar and sets no `ctx.state.appBar`, exactly like
+`/shopping`.
+
+`islands/todos/TodoBacklog.tsx` — named for the domain, matching
+`islands/dishes/DishCatalogue.tsx` and `islands/cards/LoyaltyWallet.tsx`.
+
+- **Open section** — each row is a `RoundCheck` plus the title. If the to-do has
+  notes, a truncated hint sits under the title with the 📝 treatment from
+  `islands/items.tsx:247`. Tapping the row opens the edit sheet; tapping the
+  `RoundCheck` ticks it off.
+- **Done section** — same rows, visually secondary, titles struck through. No
+  bulk clear (ADR 0002).
+- **FAB** — `Fab` with `icon="plus"`, `label="New to-do"`, fixed
+  `right-4 z-30` at `bottom: calc(96px + env(safe-area-inset-bottom))`, matching
+  every other module's FAB verbatim. Opens the create sheet.
+- **Create sheet** — title field (autofocused) and notes textarea. Saving adds
+  the to-do, clears the fields and keeps focus so several to-dos can be captured
+  in a row; the sheet closes via its Done button or the scrim. Keeping focus
+  between saves is deliberate: it stops the mobile soft keyboard dismissing, the
+  class of problem behind the keyboard primer at `islands/items.tsx:705` and the
+  autofocus regression in PR #45.
+- **Edit sheet** — the same `Sheet`, holding title, notes, a filled Done button
+  and an error-variant Delete, mirroring `islands/items.tsx:551`.
+- **Delete confirmation** — a bottom `Sheet`, per the component-library rule that
+  confirmations use a sheet rather than a dialog or `confirm()`
+  (`docs/ui-ux-patterns.md:327`). Issue #49 may later standardise the surface
+  app-wide; this follows the current house pattern.
+- **Empty state** — icon, title and warm blurb, in the same shape as
+  `components/md3/ComingSoon.tsx`. There is no generic `EmptyState` component
+  today; generalising `ComingSoon` into one is a reasonable follow-up but is out
+  of scope here.
+
+Copy stays English and warm enough for a child to read, per the product ethos.
+
+## Known hazards
+
+Three specific things to get right, each learned from existing code:
+
+1. **A blank title must not be written.** Shopping never hit this — a list item's
+   name comes from the catalogue, so it has no editable required field. With
+   per-keystroke debounced writes, select-all-delete would `PATCH` an empty
+   title. Suppress the write while the title is blank and keep the last non-empty
+   value when the sheet closes. `POST` rejects a blank title with `400`.
+2. **Deleting must cancel any pending debounced write for that to-do**, or a late
+   flush resurrects a deleted row. `clearCheckedItems` already does exactly this
+   (`hooks/useShoppingList.ts:195`) for the same reason.
+3. **Sorting lives in the repo, not the island** — see `getAll` above.
+
+## Testing
+
+- `database/todo.repo.test.ts` — create, `getAll` ordering (open before done,
+  each correctly sorted), `getById`, partial `update` not clobbering omitted
+  fields, `delete`, and **household isolation** (one household never sees
+  another's to-dos). Follows the conventions in
+  `database/shopping-list-item.repo.test.ts`: `Deno.env.set("KV_PATH", ":memory:")`
+  at module load, `sanitizeResources: false` per test, distinct ids per test
+  because the KV singleton is process-wide.
+- `islands/todos/TodoBacklog.test.tsx` — SSR render shows open and done to-dos,
+  the "New to-do" FAB label, and the empty state when there are none. Follows
+  `islands/dishes/DishCatalogue.test.tsx`.
+- `deno task check` must pass (`deno fmt --check && deno lint && deno check`).
+
+## Roadmap
+
+Iteration 1 ships a backlog. The axes that make it genuinely useful arrive in
+order of how much they need each other:
+
+1. **Iteration 2 — assignment and filters.** Blocked on #17. Adds
+   `assigneeIds` (member ids) and `completedBy`, plus filtering by title,
+   assignee and not-done.
+2. **Iteration 3 — due dates.** Adds `dueDate`, overdue styling, sort-by-due, and
+   the today/this-week views. Also the natural moment to window the Done section.
+3. **Iteration 4 — recurrence.** An attribute on a to-do, not a separate type
+   (see `CONTEXT.md`: a routine to-do is one that comes back, not a different
+   kind of thing). This is what monthly bills, the weekly bins and yearly
+   appointments need; it depends on `completedAt` to know when the last
+   occurrence was done.
+4. **Iteration 5 — labels.** Composable grouping for the birthday-party case,
+   following the `DishTagGroupInterface` pattern.
+
+Reconsider splitting **Chore** from **To-do** only if chores grow features
+to-dos do not want — rotation between members, or points and rewards for
+children.

--- a/docs/superpowers/specs/2026-08-03-household-shared-todos-design.md
+++ b/docs/superpowers/specs/2026-08-03-household-shared-todos-design.md
@@ -119,13 +119,15 @@ Notes on the shape:
 
 New: `database/todo.repo.ts`. Hand-rolled, copying `database/loyalty-card.repo.ts`
 — the cleanest household-scoped repo in the codebase. Static methods, `getKv()`
-at the top of each, `householdId` as the first parameter of every method.
+at the top of each, `householdId` as the first parameter of every method **except
+`create`**, which takes the DTO alone because `CreateTodoDto` already carries
+`householdId` (exactly as `LoyaltyCardRepo.create` does).
 
 Key: `["todos", householdId, id]`
 
 | Method | Behaviour |
 | --- | --- |
-| `create(householdId, dto: CreateTodoDto)` | mints `crypto.randomUUID()`, `kv.set`, returns the to-do |
+| `create(data: CreateTodoDto)` | mints `crypto.randomUUID()`, `kv.set`, returns the to-do |
 | `getAll(householdId)` | prefix scan, **sorted** (below) |
 | `getById(householdId, id)` | returns `null` when absent |
 | `update(householdId, id, patch: UpdateTodoDto)` | `mergeDefinedPatch`, then re-read via `getById`; returns `null` when absent |
@@ -193,7 +195,7 @@ Per §1 of `docs/ui-ux-patterns.md`:
 | --- | --- |
 | Create | **Pessimistic** — await the server, adopt the returned to-do. The server mints the id. |
 | Edit title/notes | **Optimistic**, debounced and merged via `utils/debounce-update.ts`, flushed when the sheet closes |
-| Tick off / un-tick | **Optimistic**, immediate `PATCH { completedAt }` — a discrete toggle, not debounced |
+| Tick off / un-tick | **Optimistic**, a single immediate `PATCH { completedAt }` — a discrete toggle, never debounced. Ticking off first holds the row for the ~300ms exit animation (§6); un-ticking is instant, mirroring `uncheckItem` |
 | Delete | **Optimistic**, after the confirmation sheet |
 
 Every optimistic path snapshots, rolls back on failure, and surfaces a `Snackbar`

--- a/docs/ui-ux-patterns.md
+++ b/docs/ui-ux-patterns.md
@@ -454,8 +454,12 @@ useEffect(() => {
 )}
 ```
 
-`fontSize: 16` on the primer (and on the real field it hands off to) is
-deliberate — below 16px, iOS Safari zooms the whole page in on focus.
+The primer's inline `fontSize: 16` is deliberate — below 16px, iOS Safari
+zooms the whole page in on focus. The real field it hands off to hits the
+same 16px floor by a different route: through the `.md-body-large` utility
+class (`assets/styles.css` ~lines 130–136) rather than an inline style. Same
+requirement, different mechanism — whatever the user can focus, one way or
+another, must resolve to ≥16px.
 
 **Don't** reach for this on a surface that's already mounted before the tap, or
 where the user is expected to tap the field themselves — the primer only earns
@@ -465,7 +469,7 @@ its keep when the real field doesn't exist yet at tap-time.
 (~lines 81–100) and the primer element (~lines 704–726), which hands off via
 `AddItems`'s `onSearchFocus` callback. `islands/todos/TodoBacklog.tsx` — the
 same shape for the create sheet: `primerRef`/`handoff`/`openCreate`/
-`closeCreate` (~lines 54–78) and the primer element (~lines 217–232).
+`closeCreate` (~lines 54–78) and the primer element (~lines 222–237).
 
 ---
 
@@ -474,8 +478,9 @@ same shape for the create sheet: `primerRef`/`handoff`/`openCreate`/
 **Rule:** Most create sheets close on save (New list, Add card, Add dish).
 Where a user plausibly adds several things in one sitting — the to-do backlog
 — the sheet **stays open** after a successful save: it clears its fields and
-keeps focus on the title field, and closes only via its own "Close" button or
-the scrim.
+keeps focus on the title field. Dismissing it is a separate, deliberate step —
+same as any other `Sheet` (`components/md3/Sheet.tsx`): its own "Close"
+button, tapping the scrim, pressing Escape, or swiping it down.
 
 **Why:** It removes two taps per item (no re-opening the sheet for each
 entry), and it keeps the mobile keyboard up between entries instead of
@@ -498,13 +503,17 @@ const submitNew = async () => {
     say("Couldn't add that to-do. Try again?");
     return;
   }
-  // Keep the sheet open and the field focused for the next entry.
+  // Keep the sheet open and the field focused for the next entry. The
+  // Enter-key path never loses focus, but a tap on the "Add" button does —
+  // so focus must be reclaimed explicitly (same as handleCreate in
+  // islands/add-items.tsx).
   newTitle.value = "";
   newNotes.value = "";
+  titleRef.current?.focus();
 };
 ```
 
-**See:** `islands/todos/TodoBacklog.tsx` — the create `Sheet` (~line 242) and
+**See:** `islands/todos/TodoBacklog.tsx` — the create `Sheet` (~line 247) and
 `submitNew` (~line 93).
 
 ---

--- a/docs/ui-ux-patterns.md
+++ b/docs/ui-ux-patterns.md
@@ -398,6 +398,117 @@ useEffect(() => {
 
 ---
 
+## 12. Keyboard primer / focus hand-off for dynamically mounted inputs
+
+**Rule:** When a tap should open a surface whose real input field doesn't exist
+yet — it mounts later, on a signal flip — don't call `.focus()` on that field
+after the fact, and don't reach for `autofocus`. Instead, focus a hidden 1×1
+**primer** `<input>` (`aria-hidden`, `tabIndex={-1}`, opacity 0)
+**synchronously inside the tap handler**. The primer holds focus (and the
+mobile keyboard) while the real field mounts, hands focus to it once it
+exists, then unmounts.
+
+**Why:** Mobile browsers only raise the soft keyboard from a `.focus()` call
+made within the user-activation window of a real tap. The real field mounts on
+a later, signal-driven re-render, so focusing it after the fact is usually too
+late — and at tap-time there's nothing to focus anyway. `autofocus` doesn't
+solve this either: browsers only honor it during initial document parse, so
+it's inert on an element that mounts dynamically afterwards. This repo has
+been bitten twice by skipping the hand-off: PR #45 fixed a regression where
+the primer unmounted before the real field confirmed focus, dropping focus to
+`<body>` and dismissing the keyboard; and the to-dos create sheet originally
+shipped with a bare `autofocus` on its title input that never fired, until it
+was replaced with this pattern.
+
+**How:**
+
+```ts
+const primerRef = useRef<HTMLInputElement>(null);
+const realRef = useRef<HTMLInputElement>(null);
+const handoff = useSignal(false);
+
+const openSurface = () => {
+  handoff.value = false;
+  primerRef.current?.focus(); // inside the tap — this is what raises the keyboard
+  open.value = true;
+};
+
+useEffect(() => {
+  if (open.value) {
+    realRef.current?.focus(); // hand off once the real field exists
+    handoff.value = true;
+  }
+}, [open.value]);
+
+// Stays mounted (and focusable) until the hand-off completes, then unmounts —
+// leaving the real field as the keyboard's only accessory-bar entry.
+{(!open.value || !handoff.value) && (
+  <input
+    ref={primerRef}
+    type="text"
+    aria-hidden="true"
+    tabIndex={-1}
+    class="fixed top-0 left-0 opacity-0 pointer-events-none"
+    style={{ width: 1, height: 1, fontSize: 16 }}
+  />
+)}
+```
+
+`fontSize: 16` on the primer (and on the real field it hands off to) is
+deliberate — below 16px, iOS Safari zooms the whole page in on focus.
+
+**Don't** reach for this on a surface that's already mounted before the tap, or
+where the user is expected to tap the field themselves — the primer only earns
+its keep when the real field doesn't exist yet at tap-time.
+
+**See:** `islands/items.tsx` — `primerRef`/`handoff`/`openAdd`/`closeAdd`
+(~lines 81–100) and the primer element (~lines 704–726), which hands off via
+`AddItems`'s `onSearchFocus` callback. `islands/todos/TodoBacklog.tsx` — the
+same shape for the create sheet: `primerRef`/`handoff`/`openCreate`/
+`closeCreate` (~lines 54–78) and the primer element (~lines 217–232).
+
+---
+
+## 13. Create sheets that stay open for rapid capture
+
+**Rule:** Most create sheets close on save (New list, Add card, Add dish).
+Where a user plausibly adds several things in one sitting — the to-do backlog
+— the sheet **stays open** after a successful save: it clears its fields and
+keeps focus on the title field, and closes only via its own "Close" button or
+the scrim.
+
+**Why:** It removes two taps per item (no re-opening the sheet for each
+entry), and it keeps the mobile keyboard up between entries instead of
+dismissing and re-raising it — the same class of problem the keyboard primer
+(§12) exists to solve.
+
+**Don't** use this for creates that need a decision per item (choosing a
+category, a barcode format) — there the sheet closing *is* the confirmation
+that the item was captured correctly.
+
+**How:**
+
+```ts
+const submitNew = async () => {
+  const title = newTitle.value.trim();
+  if (!title) return;
+  const notes = newNotes.value.trim();
+  const created = await addTodo({ title, notes: notes || undefined });
+  if (!created) {
+    say("Couldn't add that to-do. Try again?");
+    return;
+  }
+  // Keep the sheet open and the field focused for the next entry.
+  newTitle.value = "";
+  newNotes.value = "";
+};
+```
+
+**See:** `islands/todos/TodoBacklog.tsx` — the create `Sheet` (~line 242) and
+`submitNew` (~line 93).
+
+---
+
 ## Review checklist for user-facing changes
 
 Before merging anything the user sees, tick these (section refs in parens):
@@ -432,4 +543,4 @@ in the same change.
 
 Candidate topics still to document as they solidify: form validation & inline
 errors, confirmation/destructive-action flow, empty & loading states for whole
-screens, drag-to-reorder, keyboard/focus management, and offline behavior.
+screens, drag-to-reorder, and offline behavior.

--- a/hooks/useTodos.test.ts
+++ b/hooks/useTodos.test.ts
@@ -1,0 +1,168 @@
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import { stub } from "jsr:@std/testing@^1.0.18/mock";
+import { FakeTime } from "jsr:@std/testing@^1.0.18/time";
+import { api } from "@/services/api.ts";
+import { useTodos } from "@/hooks/useTodos.ts";
+import type { TodoInterface } from "@/models/index.ts";
+
+function makeTodo(over: Partial<TodoInterface> = {}): TodoInterface {
+  return {
+    id: "t1",
+    householdId: "hh",
+    title: "Take out the bins",
+    createdBy: "u1",
+    createdAt: "2026-08-03T10:00:00.000Z",
+    completedAt: null,
+    ...over,
+  };
+}
+
+Deno.test("useTodos — splits the initial to-dos into open and done", () => {
+  const hook = useTodos([
+    makeTodo({ id: "t1" }),
+    makeTodo({ id: "t2", completedAt: "2026-08-02T12:00:00.000Z" }),
+  ]);
+
+  assertEquals(hook.openTodos.value.map((t) => t.id), ["t1"]);
+  assertEquals(hook.doneTodos.value.map((t) => t.id), ["t2"]);
+});
+
+Deno.test("tickOff — moves the to-do into done with a completedAt", async () => {
+  using _u = stub(
+    api.todos,
+    "update",
+    (_id: string, _patch: unknown) => Promise.resolve(makeTodo()),
+  );
+  const hook = useTodos([makeTodo({ id: "t1" })]);
+
+  using time = new FakeTime();
+  const promise = hook.tickOff("t1");
+  await time.tickAsync(300);
+  await promise;
+
+  assertEquals(hook.openTodos.value, []);
+  assertEquals(hook.doneTodos.value.length, 1);
+  assertEquals(hook.doneTodos.value[0].id, "t1");
+  assertEquals(hook.doneTodos.value[0].completedAt !== null, true);
+});
+
+Deno.test("tickOff — the to-do is in exitingIds during the 300ms animation", async () => {
+  using _u = stub(
+    api.todos,
+    "update",
+    (_id: string, _patch: unknown) => Promise.resolve(makeTodo()),
+  );
+  const hook = useTodos([makeTodo({ id: "t1" })]);
+
+  using time = new FakeTime();
+  const promise = hook.tickOff("t1");
+
+  assertEquals(hook.exitingIds.value.includes("t1"), true);
+
+  await time.tickAsync(300);
+  await promise;
+
+  assertEquals(hook.exitingIds.value.includes("t1"), false);
+});
+
+Deno.test("tickOff — rolls back and reports failure when the server rejects", async () => {
+  using _u = stub(
+    api.todos,
+    "update",
+    (_id: string, _patch: unknown) => Promise.resolve(null),
+  );
+  const hook = useTodos([makeTodo({ id: "t1" })]);
+
+  using time = new FakeTime();
+  const promise = hook.tickOff("t1");
+  await time.tickAsync(300);
+  const ok = await promise;
+
+  assertEquals(ok, false);
+  assertEquals(hook.openTodos.value.map((t) => t.id), ["t1"]);
+  assertEquals(hook.doneTodos.value, []);
+});
+
+Deno.test("unTick — moves the to-do back to open with a null completedAt", async () => {
+  using _u = stub(
+    api.todos,
+    "update",
+    (_id: string, _patch: unknown) => Promise.resolve(makeTodo()),
+  );
+  const hook = useTodos([
+    makeTodo({ id: "t1", completedAt: "2026-08-02T12:00:00.000Z" }),
+  ]);
+
+  const ok = await hook.unTick("t1");
+
+  assertEquals(ok, true);
+  assertEquals(hook.doneTodos.value, []);
+  assertEquals(hook.openTodos.value.length, 1);
+  assertEquals(hook.openTodos.value[0].completedAt, null);
+});
+
+Deno.test("removeTodo — removes the to-do and cancels a pending edit", async () => {
+  const patches: unknown[] = [];
+  using _u = stub(api.todos, "update", (_id: string, patch: unknown) => {
+    patches.push(patch);
+    return Promise.resolve(makeTodo());
+  });
+  using _d = stub(api.todos, "delete", (_id: string) => Promise.resolve(true));
+  const hook = useTodos([makeTodo({ id: "t1" })]);
+
+  using time = new FakeTime();
+  hook.editTodo("t1", { title: "Changed my mind" }); // schedules a 500ms write
+  const promise = hook.removeTodo("t1");
+  await time.tickAsync(300); // exit animation
+  const ok = await promise;
+  await time.tickAsync(1000); // the cancelled write must never fire
+
+  assertEquals(ok, true);
+  assertEquals(patches, []);
+  assertEquals(hook.openTodos.value, []);
+});
+
+Deno.test("removeTodo — restores the to-do when the delete fails", async () => {
+  using _d = stub(api.todos, "delete", (_id: string) => Promise.resolve(false));
+  const hook = useTodos([makeTodo({ id: "t1" })]);
+
+  using time = new FakeTime();
+  const promise = hook.removeTodo("t1");
+  await time.tickAsync(300);
+  const ok = await promise;
+
+  assertEquals(ok, false);
+  assertEquals(hook.openTodos.value.map((t) => t.id), ["t1"]);
+});
+
+Deno.test("editTodo — echoes locally but never persists a blank title", async () => {
+  const patches: unknown[] = [];
+  using _u = stub(api.todos, "update", (_id: string, patch: unknown) => {
+    patches.push(patch);
+    return Promise.resolve(makeTodo());
+  });
+  const hook = useTodos([makeTodo({ id: "t1" })]);
+
+  using time = new FakeTime();
+  hook.editTodo("t1", { title: "   " });
+  await time.tickAsync(600);
+
+  assertEquals(patches, []); // nothing written
+  assertEquals(hook.openTodos.value[0].title, "   "); // local echo only
+});
+
+Deno.test("editTodo — persists a non-blank title after the debounce", async () => {
+  const patches: unknown[] = [];
+  using _u = stub(api.todos, "update", (_id: string, patch: unknown) => {
+    patches.push(patch);
+    return Promise.resolve(makeTodo());
+  });
+  const hook = useTodos([makeTodo({ id: "t1" })]);
+
+  using time = new FakeTime();
+  hook.editTodo("t1", { title: "Take out the recycling" });
+  await time.tickAsync(600);
+
+  assertEquals(patches, [{ title: "Take out the recycling" }]);
+  assertEquals(hook.openTodos.value[0].title, "Take out the recycling");
+});

--- a/hooks/useTodos.test.ts
+++ b/hooks/useTodos.test.ts
@@ -101,6 +101,23 @@ Deno.test("tickOff — an edit landing during the exit animation is not dropped"
   assertEquals(hook.doneTodos.value[0].title, "Edited during animation");
 });
 
+Deno.test("unTick — rolls back and reports failure when the server rejects", async () => {
+  using _u = stub(
+    api.todos,
+    "update",
+    (_id: string, _patch: unknown) => Promise.resolve(null),
+  );
+  const hook = useTodos([
+    makeTodo({ id: "t1", completedAt: "2026-08-02T12:00:00.000Z" }),
+  ]);
+
+  const ok = await hook.unTick("t1");
+
+  assertEquals(ok, false);
+  assertEquals(hook.openTodos.value, []);
+  assertEquals(hook.doneTodos.value.map((t) => t.id), ["t1"]);
+});
+
 Deno.test("unTick — moves the to-do back to open with a null completedAt", async () => {
   using _u = stub(
     api.todos,
@@ -167,6 +184,45 @@ Deno.test("editTodo — echoes locally but never persists a blank title", async 
 
   assertEquals(patches, []); // nothing written
   assertEquals(hook.openTodos.value[0].title, "   "); // local echo only
+});
+
+Deno.test("editTodo — a blank-title edit doesn't discard the rest of the merged patch", async () => {
+  // Regression for the old guard: `if (patch.title !== undefined &&
+  // !patch.title.trim()) return;` aborted the whole flush, so a merged patch
+  // of {notes, title: ""} silently dropped the notes write too. Against that
+  // guard this test asserts `patches === []`; the fix must make it `[{notes:
+  // "n"}]` instead — only the blank title key is dropped, not the patch.
+  const patches: unknown[] = [];
+  using _u = stub(api.todos, "update", (_id: string, patch: unknown) => {
+    patches.push(patch);
+    return Promise.resolve(makeTodo());
+  });
+  const hook = useTodos([makeTodo({ id: "t1" })]);
+
+  using time = new FakeTime();
+  hook.editTodo("t1", { notes: "n" });
+  hook.editTodo("t1", { title: "   " }); // merged into the same pending patch
+  await time.tickAsync(600);
+
+  assertEquals(patches, [{ notes: "n" }]);
+});
+
+Deno.test("flushTodo — restores the last non-empty title when the sheet closes on a blank field", () => {
+  using _u = stub(
+    api.todos,
+    "update",
+    (_id: string, _patch: unknown) => Promise.resolve(makeTodo()),
+  );
+  const hook = useTodos([
+    makeTodo({ id: "t1", title: "Take out the bins" }),
+  ]);
+
+  hook.editTodo("t1", { title: "" }); // select-all-delete
+  assertEquals(hook.openTodos.value[0].title, ""); // local echo only, still blank
+
+  hook.flushTodo("t1"); // sheet closes
+
+  assertEquals(hook.openTodos.value[0].title, "Take out the bins");
 });
 
 Deno.test("editTodo — persists a non-blank title after the debounce", async () => {

--- a/hooks/useTodos.test.ts
+++ b/hooks/useTodos.test.ts
@@ -83,6 +83,24 @@ Deno.test("tickOff — rolls back and reports failure when the server rejects", 
   assertEquals(hook.doneTodos.value, []);
 });
 
+Deno.test("tickOff — an edit landing during the exit animation is not dropped", async () => {
+  using _u = stub(
+    api.todos,
+    "update",
+    (_id: string, _patch: unknown) => Promise.resolve(makeTodo()),
+  );
+  const hook = useTodos([makeTodo({ id: "t1" })]);
+
+  using time = new FakeTime();
+  const promise = hook.tickOff("t1");
+  hook.editTodo("t1", { title: "Edited during animation" }); // before the wait elapses
+  await time.tickAsync(300);
+  await promise;
+
+  assertEquals(hook.doneTodos.value.length, 1);
+  assertEquals(hook.doneTodos.value[0].title, "Edited during animation");
+});
+
 Deno.test("unTick — moves the to-do back to open with a null completedAt", async () => {
   using _u = stub(
     api.todos,

--- a/hooks/useTodos.ts
+++ b/hooks/useTodos.ts
@@ -6,13 +6,18 @@ import { beginBusy, endBusy } from "@/utils/loading.ts";
 
 type TodoEdit = { title?: string; notes?: string };
 
+/** Exit-animation duration; kept in sync with the row transition in
+ * TodoBacklog.tsx by importing this constant rather than hardcoding it twice. */
+export const EXIT_MS = 300;
+
 /**
  * Reactive store for a household's backlog. Follows the app's mutation
  * conventions: creates are **pessimistic** (the server mints the id, so we wait
  * for the returned to-do), edits are **optimistic and debounced**, and ticking
- * off and deleting are **optimistic with rollback**. The `api` boundary never
- * throws, so every mutation reports failure by return value and the island
- * surfaces a snackbar.
+ * off and deleting are **optimistic with rollback**. The `api` boundary
+ * reports failure by return value rather than throwing for non-ok responses
+ * (a real transport failure — offline, etc. — can still reject; see #52), so
+ * every mutation checks its return value and the island surfaces a snackbar.
  *
  * Call this inside `useMemo(() => useTodos(initial), [])` so the signals are
  * created once — see `islands/todos/TodoBacklog.tsx`.
@@ -32,7 +37,12 @@ export function useTodos(initialTodos: TodoInterface[]) {
   /** Ids mid-exit-animation — the island fades these out (patterns doc §6). */
   const exitingIds = signal<string[]>([]);
 
-  const EXIT_MS = 300; // keep in sync with the row transition in TodoBacklog.tsx
+  // Tracks the last non-blank title seen per to-do while it's being edited, so
+  // a title left blank when the edit sheet closes can be restored instead of
+  // rendering as an empty row until reload (spec hazard #1). Deliberately a
+  // plain Map, not a signal — it's write-only bookkeeping consulted only by
+  // flushTodo, so it doesn't need to drive a re-render itself.
+  const lastNonEmptyTitle = new Map<string, string>();
 
   const startPending = () => {
     pendingCount.value++;
@@ -50,12 +60,16 @@ export function useTodos(initialTodos: TodoInterface[]) {
   /** Debounced title/notes writes, merged per to-do (500ms default). */
   const scheduler = createDebouncedMergeScheduler<TodoEdit>({
     flush: async (id, patch) => {
-      // Never persist a blank title — the sheet's field can be emptied
-      // mid-typing, and the last non-empty value is what the user meant.
-      if (patch.title !== undefined && !patch.title.trim()) return;
+      const next = { ...patch };
+      // Never persist a blank title, but don't discard the rest of a merged
+      // patch — notes edited in the same debounce window would otherwise be
+      // silently lost. The sheet's title field can be emptied mid-typing, and
+      // the last non-empty value is what the user meant.
+      if (next.title !== undefined && !next.title.trim()) delete next.title;
+      if (Object.keys(next).length === 0) return;
       startPending();
       try {
-        await api.todos.update(id, patch);
+        await api.todos.update(id, next);
       } finally {
         endPending();
       }
@@ -76,7 +90,11 @@ export function useTodos(initialTodos: TodoInterface[]) {
   /** Optimistic local edit; the write is debounced and merged. */
   const editTodo = (id: string, patch: TodoEdit): void => {
     const apply = (list: TodoInterface[]) =>
-      list.map((t) => (t.id === id ? { ...t, ...patch } : t));
+      list.map((t) => {
+        if (t.id !== id) return t;
+        if (t.title.trim()) lastNonEmptyTitle.set(id, t.title);
+        return { ...t, ...patch };
+      });
     if (openTodos.value.some((t) => t.id === id)) {
       openTodos.value = apply(openTodos.value);
     } else {
@@ -85,10 +103,35 @@ export function useTodos(initialTodos: TodoInterface[]) {
     scheduler.schedule(id, patch);
   };
 
+  /** If the to-do's local title is currently blank, restore the last
+   * non-empty value recorded for it (spec hazard #1: suppress the write while
+   * blank *and* keep the last non-empty value when the sheet closes). */
+  const restoreBlankTitle = (id: string): void => {
+    const todo = findAnywhere(id);
+    if (!todo || todo.title.trim()) return;
+    const last = lastNonEmptyTitle.get(id);
+    if (!last) return;
+    const apply = (list: TodoInterface[]) =>
+      list.map((t) => (t.id === id ? { ...t, title: last } : t));
+    if (openTodos.value.some((t) => t.id === id)) {
+      openTodos.value = apply(openTodos.value);
+    } else {
+      doneTodos.value = apply(doneTodos.value);
+    }
+  };
+
   /** Persist a pending edit immediately — call when the edit sheet closes. */
-  const flushTodo = (id: string): void => scheduler.flush(id);
+  const flushTodo = (id: string): void => {
+    scheduler.flush(id);
+    restoreBlankTitle(id);
+  };
 
   const tickOff = async (id: string): Promise<boolean> => {
+    // A second tap during the exit animation (ordinary on mobile) must not
+    // start a second run — the row stays in openTodos for EXIT_MS on purpose,
+    // so the plain openTodos guard below wouldn't catch it. Report success:
+    // the first tickOff is already underway and will complete the operation.
+    if (exitingIds.value.includes(id)) return true;
     if (!openTodos.value.some((t) => t.id === id)) return false;
 
     // §6: keep the row on screen for the transition, then move it.
@@ -154,6 +197,9 @@ export function useTodos(initialTodos: TodoInterface[]) {
   };
 
   const removeTodo = async (id: string): Promise<boolean> => {
+    // Same guard as tickOff — a second tap mid-exit-animation must not start
+    // a second run; the first is already underway.
+    if (exitingIds.value.includes(id)) return true;
     if (!findAnywhere(id)) return false;
 
     exitingIds.value = [...exitingIds.value, id];
@@ -166,6 +212,7 @@ export function useTodos(initialTodos: TodoInterface[]) {
     // to-do we just deleted (the hazard clearCheckedItems guards against in
     // hooks/useShoppingList.ts:195).
     scheduler.cancel(id);
+    lastNonEmptyTitle.delete(id);
     openTodos.value = openTodos.value.filter((t) => t.id !== id);
     doneTodos.value = doneTodos.value.filter((t) => t.id !== id);
     exitingIds.value = exitingIds.value.filter((x) => x !== id);

--- a/hooks/useTodos.ts
+++ b/hooks/useTodos.ts
@@ -1,0 +1,204 @@
+import { signal } from "@preact/signals";
+import type { TodoInput, TodoInterface } from "@/models/index.ts";
+import { api } from "@/services/api.ts";
+import { createDebouncedMergeScheduler } from "@/utils/debounce-update.ts";
+import { beginBusy, endBusy } from "@/utils/loading.ts";
+
+type TodoEdit = { title?: string; notes?: string };
+
+/**
+ * Reactive store for a household's backlog. Follows the app's mutation
+ * conventions: creates are **pessimistic** (the server mints the id, so we wait
+ * for the returned to-do), edits are **optimistic and debounced**, and ticking
+ * off and deleting are **optimistic with rollback**. The `api` boundary never
+ * throws, so every mutation reports failure by return value and the island
+ * surfaces a snackbar.
+ *
+ * Call this inside `useMemo(() => useTodos(initial), [])` so the signals are
+ * created once — see `islands/todos/TodoBacklog.tsx`.
+ */
+export function useTodos(initialTodos: TodoInterface[]) {
+  const initial = initialTodos ?? [];
+  // TodoRepo.getAll already returns open before done, so this is a partition.
+  const openTodos = signal<TodoInterface[]>(
+    initial.filter((t) => t.completedAt === null),
+  );
+  const doneTodos = signal<TodoInterface[]>(
+    initial.filter((t) => t.completedAt !== null),
+  );
+  const pendingCount = signal(0);
+  /** Ids mid-exit-animation — the island fades these out (patterns doc §6). */
+  const exitingIds = signal<string[]>([]);
+
+  const EXIT_MS = 300; // keep in sync with the row transition in TodoBacklog.tsx
+
+  const startPending = () => {
+    pendingCount.value++;
+    beginBusy();
+  };
+  const endPending = () => {
+    pendingCount.value--;
+    endBusy();
+  };
+
+  const findAnywhere = (id: string): TodoInterface | undefined =>
+    openTodos.value.find((t) => t.id === id) ??
+      doneTodos.value.find((t) => t.id === id);
+
+  /** Debounced title/notes writes, merged per to-do (500ms default). */
+  const scheduler = createDebouncedMergeScheduler<TodoEdit>({
+    flush: async (id, patch) => {
+      // Never persist a blank title — the sheet's field can be emptied
+      // mid-typing, and the last non-empty value is what the user meant.
+      if (patch.title !== undefined && !patch.title.trim()) return;
+      startPending();
+      try {
+        await api.todos.update(id, patch);
+      } finally {
+        endPending();
+      }
+    },
+  });
+
+  const addTodo = async (input: TodoInput): Promise<TodoInterface | null> => {
+    startPending();
+    try {
+      const created = await api.todos.create(input);
+      if (created) openTodos.value = [created, ...openTodos.value];
+      return created;
+    } finally {
+      endPending();
+    }
+  };
+
+  /** Optimistic local edit; the write is debounced and merged. */
+  const editTodo = (id: string, patch: TodoEdit): void => {
+    const apply = (list: TodoInterface[]) =>
+      list.map((t) => (t.id === id ? { ...t, ...patch } : t));
+    if (openTodos.value.some((t) => t.id === id)) {
+      openTodos.value = apply(openTodos.value);
+    } else {
+      doneTodos.value = apply(doneTodos.value);
+    }
+    scheduler.schedule(id, patch);
+  };
+
+  /** Persist a pending edit immediately — call when the edit sheet closes. */
+  const flushTodo = (id: string): void => scheduler.flush(id);
+
+  const tickOff = async (id: string): Promise<boolean> => {
+    const todo = openTodos.value.find((t) => t.id === id);
+    if (!todo) return false;
+
+    // §6: keep the row on screen for the transition, then move it.
+    exitingIds.value = [...exitingIds.value, id];
+    await new Promise((resolve) => setTimeout(resolve, EXIT_MS));
+
+    // Snapshot after the wait — state may have changed during the animation.
+    const openSnapshot = openTodos.value;
+    const doneSnapshot = doneTodos.value;
+    const completedAt = new Date().toISOString();
+    const ticked = { ...todo, completedAt };
+
+    openTodos.value = openTodos.value.filter((t) => t.id !== id);
+    doneTodos.value = [ticked, ...doneTodos.value];
+    exitingIds.value = exitingIds.value.filter((x) => x !== id);
+
+    // Deliberately does NOT cancel pending edits, unlike useShoppingList's
+    // checkItem: a queued title patch still targets a live record, and both
+    // patches go through mergeDefinedPatch, so neither clobbers the other.
+    startPending();
+    try {
+      const saved = await api.todos.update(id, { completedAt });
+      if (!saved) {
+        openTodos.value = openSnapshot;
+        doneTodos.value = doneSnapshot;
+        return false;
+      }
+      return true;
+    } finally {
+      endPending();
+    }
+  };
+
+  const unTick = async (id: string): Promise<boolean> => {
+    const todo = doneTodos.value.find((t) => t.id === id);
+    if (!todo) return false;
+    const openSnapshot = openTodos.value;
+    const doneSnapshot = doneTodos.value;
+    const reopened = { ...todo, completedAt: null };
+
+    doneTodos.value = doneTodos.value.filter((t) => t.id !== id);
+    openTodos.value = [reopened, ...openTodos.value];
+
+    startPending();
+    try {
+      const saved = await api.todos.update(id, { completedAt: null });
+      if (!saved) {
+        openTodos.value = openSnapshot;
+        doneTodos.value = doneSnapshot;
+        return false;
+      }
+      return true;
+    } finally {
+      endPending();
+    }
+  };
+
+  const removeTodo = async (id: string): Promise<boolean> => {
+    if (!findAnywhere(id)) return false;
+
+    exitingIds.value = [...exitingIds.value, id];
+    await new Promise((resolve) => setTimeout(resolve, EXIT_MS));
+
+    const openSnapshot = openTodos.value;
+    const doneSnapshot = doneTodos.value;
+
+    // Drop any pending debounced edit first, or a late flush would PATCH a
+    // to-do we just deleted (the hazard clearCheckedItems guards against in
+    // hooks/useShoppingList.ts:195).
+    scheduler.cancel(id);
+    openTodos.value = openTodos.value.filter((t) => t.id !== id);
+    doneTodos.value = doneTodos.value.filter((t) => t.id !== id);
+    exitingIds.value = exitingIds.value.filter((x) => x !== id);
+
+    startPending();
+    try {
+      const ok = await api.todos.delete(id);
+      if (!ok) {
+        openTodos.value = openSnapshot;
+        doneTodos.value = doneSnapshot;
+      }
+      return ok;
+    } finally {
+      endPending();
+    }
+  };
+
+  const refresh = async (): Promise<void> => {
+    // Pull-to-refresh renders its own spinner, so this intentionally tracks
+    // pendingCount without driving the global loading bar (beginBusy/endBusy).
+    pendingCount.value++;
+    try {
+      const all = await api.todos.getAll();
+      openTodos.value = all.filter((t) => t.completedAt === null);
+      doneTodos.value = all.filter((t) => t.completedAt !== null);
+    } finally {
+      pendingCount.value--;
+    }
+  };
+
+  return {
+    openTodos,
+    doneTodos,
+    exitingIds,
+    pendingCount,
+    addTodo,
+    editTodo,
+    flushTodo,
+    tickOff,
+    unTick,
+    removeTodo,
+    refresh,
+  };
+}

--- a/hooks/useTodos.ts
+++ b/hooks/useTodos.ts
@@ -19,7 +19,9 @@ type TodoEdit = { title?: string; notes?: string };
  */
 export function useTodos(initialTodos: TodoInterface[]) {
   const initial = initialTodos ?? [];
-  // TodoRepo.getAll already returns open before done, so this is a partition.
+  // Two independent filters splitting on completedAt === null; getAll's
+  // ordering (newest-created first, then most-recently-done first) is what
+  // keeps each resulting list correctly ordered without sorting here.
   const openTodos = signal<TodoInterface[]>(
     initial.filter((t) => t.completedAt === null),
   );
@@ -87,14 +89,20 @@ export function useTodos(initialTodos: TodoInterface[]) {
   const flushTodo = (id: string): void => scheduler.flush(id);
 
   const tickOff = async (id: string): Promise<boolean> => {
-    const todo = openTodos.value.find((t) => t.id === id);
-    if (!todo) return false;
+    if (!openTodos.value.some((t) => t.id === id)) return false;
 
     // §6: keep the row on screen for the transition, then move it.
     exitingIds.value = [...exitingIds.value, id];
     await new Promise((resolve) => setTimeout(resolve, EXIT_MS));
 
-    // Snapshot after the wait — state may have changed during the animation.
+    // Re-read after the wait — state may have changed during the animation
+    // (an edit, or a refresh() replacing the list).
+    const todo = openTodos.value.find((t) => t.id === id);
+    if (!todo) {
+      exitingIds.value = exitingIds.value.filter((x) => x !== id);
+      return false;
+    }
+
     const openSnapshot = openTodos.value;
     const doneSnapshot = doneTodos.value;
     const completedAt = new Date().toISOString();

--- a/islands/shell/MoreSheet.tsx
+++ b/islands/shell/MoreSheet.tsx
@@ -47,7 +47,10 @@ export default function MoreSheet({ open, onClose }: MoreSheetProps) {
           leading={badge("checklist")}
           headline="To-dos"
           trailing={chevron()}
-          onClick={() => soon("To-dos")}
+          onClick={() => {
+            onClose();
+            navigateTo("/todos");
+          }}
         />
         <ListItem
           leading={badge("plate")}

--- a/islands/todos/TodoBacklog.test.tsx
+++ b/islands/todos/TodoBacklog.test.tsx
@@ -54,3 +54,15 @@ Deno.test("TodoBacklog — no Done heading when nothing is done yet", () => {
   // SSR output says "Done" — this really is the section heading.
   assertFalse(html.includes(">Done<"));
 });
+
+Deno.test("TodoBacklog — create sheet's title input does not rely on the bare autofocus attribute", () => {
+  const html = render(h(TodoBacklog, { initialTodos: [] }));
+
+  // `autofocus` is only honoured by browsers during initial document parse;
+  // it's inert for the create sheet's title input, which mounts dynamically
+  // when the sheet opens (gated on createOpen.value). Focus is instead set
+  // programmatically — see the "create-sheet focus handoff" comment in
+  // TodoBacklog.tsx — so the attribute must not appear anywhere in the SSR
+  // output.
+  assertFalse(html.includes("autofocus"));
+});

--- a/islands/todos/TodoBacklog.test.tsx
+++ b/islands/todos/TodoBacklog.test.tsx
@@ -1,0 +1,56 @@
+import { assertFalse, assertStringIncludes } from "jsr:@std/assert@^1.0.19";
+import { render } from "npm:preact-render-to-string@^6.6.3";
+import { h } from "preact";
+import TodoBacklog from "./TodoBacklog.tsx";
+import type { TodoInterface } from "@/models/index.ts";
+
+function todo(over: Partial<TodoInterface>): TodoInterface {
+  return {
+    id: "t1",
+    householdId: "hh",
+    title: "Take out the bins",
+    createdBy: "u1",
+    createdAt: "2026-08-03T10:00:00.000Z",
+    completedAt: null,
+    ...over,
+  };
+}
+
+Deno.test("TodoBacklog — renders open and done to-dos, and the FAB", () => {
+  const html = render(h(TodoBacklog, {
+    initialTodos: [
+      todo({ id: "t1", title: "Take out the bins" }),
+      todo({ id: "t2", title: "Call the dentist", notes: "09 123 45 67" }),
+      todo({
+        id: "t3",
+        title: "Pay the water bill",
+        completedAt: "2026-08-02T12:00:00.000Z",
+      }),
+    ],
+  }));
+
+  assertStringIncludes(html, "Take out the bins");
+  assertStringIncludes(html, "Call the dentist");
+  assertStringIncludes(html, "09 123 45 67"); // notes hint on the row
+  assertStringIncludes(html, "Pay the water bill");
+  assertStringIncludes(html, ">Done<"); // done section heading
+  assertStringIncludes(html, "New to-do"); // FAB label
+});
+
+Deno.test("TodoBacklog — empty state when the household has no to-dos", () => {
+  const html = render(h(TodoBacklog, { initialTodos: [] }));
+
+  assertStringIncludes(html, "Nothing to do");
+  assertStringIncludes(html, "New to-do"); // FAB is still offered
+});
+
+Deno.test("TodoBacklog — no Done heading when nothing is done yet", () => {
+  const html = render(h(TodoBacklog, {
+    initialTodos: [todo({ id: "t1", title: "Take out the bins" })],
+  }));
+
+  assertStringIncludes(html, "Take out the bins");
+  // The create sheet's body is gated on its open state, so nothing else in the
+  // SSR output says "Done" — this really is the section heading.
+  assertFalse(html.includes(">Done<"));
+});

--- a/islands/todos/TodoBacklog.tsx
+++ b/islands/todos/TodoBacklog.tsx
@@ -1,0 +1,314 @@
+import { useMemo } from "preact/hooks";
+import { useSignal } from "@preact/signals";
+import type { TodoInterface } from "@/models/index.ts";
+import { useTodos } from "@/hooks/useTodos.ts";
+import { PullToRefresh } from "@/components/md3/PullToRefresh.tsx";
+import { Sheet } from "@/components/md3/Sheet.tsx";
+import { Button } from "@/components/md3/Button.tsx";
+import { RoundCheck } from "@/components/md3/RoundCheck.tsx";
+import { Icon } from "@/components/md3/Icon.tsx";
+import { Snackbar } from "@/components/md3/Snackbar.tsx";
+import { Pressable } from "@/components/md3/Pressable.tsx";
+import Fab from "@/islands/shell/Fab.tsx";
+
+interface Props {
+  initialTodos: TodoInterface[];
+}
+
+export default function TodoBacklog({ initialTodos }: Props) {
+  // useMemo([]) so the hook's signals are created once from SSR props.
+  const {
+    openTodos,
+    doneTodos,
+    exitingIds,
+    addTodo,
+    editTodo,
+    flushTodo,
+    tickOff,
+    unTick,
+    removeTodo,
+    refresh,
+  } = useMemo(() => useTodos(initialTodos), []);
+
+  const createOpen = useSignal(false);
+  const newTitle = useSignal("");
+  const newNotes = useSignal("");
+  const editingId = useSignal<string | null>(null);
+  const confirmingId = useSignal<string | null>(null);
+  const snack = useSignal<{ msg: string } | null>(null);
+
+  const open = openTodos.value;
+  const done = doneTodos.value;
+  const exiting = exitingIds.value;
+
+  const editing = () =>
+    open.find((t) => t.id === editingId.value) ??
+      done.find((t) => t.id === editingId.value);
+
+  const say = (msg: string) => {
+    snack.value = { msg };
+    setTimeout(() => (snack.value = null), 4000);
+  };
+
+  const submitNew = async () => {
+    const title = newTitle.value.trim();
+    if (!title) return;
+    const notes = newNotes.value.trim();
+    const created = await addTodo({ title, notes: notes || undefined });
+    if (!created) {
+      say("Couldn't add that to-do. Try again?");
+      return;
+    }
+    // Keep the sheet open and the field focused so several to-dos can be
+    // captured in a row without the mobile keyboard dismissing.
+    newTitle.value = "";
+    newNotes.value = "";
+  };
+
+  const closeEditor = () => {
+    const id = editingId.value;
+    if (id) flushTodo(id);
+    editingId.value = null;
+  };
+
+  // The 300ms here must match EXIT_MS in useTodos (patterns doc §6).
+  const row = (t: TodoInterface, isDone: boolean) => (
+    <div
+      key={t.id}
+      class="flex items-start gap-3 px-1 py-2.5"
+      style={{
+        opacity: exiting.includes(t.id) ? 0 : 1,
+        transform: exiting.includes(t.id)
+          ? "translateX(12px)"
+          : "translateX(0)",
+        transition:
+          "opacity .3s var(--md-emphasized), transform .3s var(--md-emphasized)",
+      }}
+    >
+      <Pressable
+        onClick={async () => {
+          const ok = isDone ? await unTick(t.id) : await tickOff(t.id);
+          if (!ok) say("That didn't save. Try again?");
+        }}
+        aria-label={isDone ? `Reopen ${t.title}` : `Tick off ${t.title}`}
+        class="pt-0.5"
+      >
+        <RoundCheck checked={isDone} />
+      </Pressable>
+      <Pressable
+        onClick={() => (editingId.value = t.id)}
+        class="flex-1 min-w-0 text-left"
+      >
+        <div
+          class={`md-body-large ${
+            isDone ? "text-on-surface-variant line-through" : "text-on-surface"
+          }`}
+        >
+          {t.title}
+        </div>
+        {t.notes && (
+          <div class="md-body-small text-on-surface-variant truncate">
+            📝 {t.notes}
+          </div>
+        )}
+      </Pressable>
+    </div>
+  );
+
+  return (
+    <PullToRefresh onRefresh={refresh}>
+      <div class="px-4 pt-4 pb-[calc(96px+env(safe-area-inset-bottom))] flex flex-col gap-4">
+        {open.length === 0 && done.length === 0
+          ? (
+            <div class="flex flex-col items-center text-center gap-4 pt-12 px-7">
+              <div
+                class="grid place-items-center bg-primary-container text-on-primary-container"
+                style={{
+                  width: 88,
+                  height: 88,
+                  borderRadius: "var(--md-shape-xl)",
+                }}
+              >
+                <Icon name="checklist" size={44} />
+              </div>
+              <div class="md-headline-small text-on-surface">Nothing to do</div>
+              <div
+                class="md-body-medium text-on-surface-variant"
+                style={{ maxWidth: 280 }}
+              >
+                When something needs doing around the house, add it here so
+                everyone can see it.
+              </div>
+            </div>
+          )
+          : (
+            <>
+              {open.length > 0 && (
+                <div class="flex flex-col">
+                  {open.map((t) => row(t, false))}
+                </div>
+              )}
+
+              {done.length > 0 && (
+                <div class="flex flex-col gap-1">
+                  <div class="md-label-medium uppercase text-on-surface-variant px-1 pt-2">
+                    Done
+                  </div>
+                  {done.map((t) => row(t, true))}
+                </div>
+              )}
+            </>
+          )}
+      </div>
+
+      {/* New-to-do FAB — shared component, fixed below the nav chrome */}
+      <div
+        class="fixed right-4 z-30"
+        style={{ bottom: "calc(96px + env(safe-area-inset-bottom))" }}
+      >
+        <Fab
+          icon="plus"
+          label="New to-do"
+          aria-label="New to-do"
+          onClick={() => {
+            newTitle.value = "";
+            newNotes.value = "";
+            createOpen.value = true;
+          }}
+        />
+      </div>
+
+      {
+        /* Create sheet — stays open between saves for rapid capture.
+          Body gated on createOpen: <Sheet> renders its children even when
+          closed (see islands/items.tsx:442), so an ungated `autofocus` would
+          steal focus and raise the mobile keyboard on page load. Gating also
+          means `autofocus` fires on mount, i.e. exactly when the sheet opens. */
+      }
+      <Sheet
+        open={createOpen.value}
+        onClose={() => (createOpen.value = false)}
+        title="New to-do"
+      >
+        {createOpen.value && (
+          <div class="flex flex-col gap-3 pb-1">
+            <input
+              autofocus
+              value={newTitle.value}
+              onInput={(e) => (newTitle.value = e.currentTarget.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  submitNew();
+                }
+              }}
+              placeholder="What needs doing?"
+              aria-label="What needs doing?"
+              class="w-full md-body-large text-on-surface bg-surface-chigh border-0 rounded-[var(--md-shape-lg)] py-3 px-4 outline-none"
+            />
+            <textarea
+              value={newNotes.value}
+              onInput={(e) => (newNotes.value = e.currentTarget.value)}
+              rows={2}
+              placeholder="Notes (optional)"
+              aria-label="Notes (optional)"
+              class="w-full md-body-large text-on-surface bg-surface-chigh border-0 rounded-[var(--md-shape-lg)] py-3 px-4 outline-none resize-none"
+            />
+            <Button variant="filled" full onClick={submitNew}>Add</Button>
+            {
+              /* "Close", not "Done" — "Done" beside "Add" reads as a second
+                save, and the Done *section* heading must stay unambiguous. */
+            }
+            <Button
+              variant="text"
+              full
+              onClick={() => (createOpen.value = false)}
+            >
+              Close
+            </Button>
+          </div>
+        )}
+      </Sheet>
+
+      {/* Edit sheet */}
+      <Sheet
+        open={editingId.value !== null}
+        onClose={closeEditor}
+        title="Edit to-do"
+      >
+        {(() => {
+          const t = editing();
+          if (!t) return null;
+          return (
+            <div class="flex flex-col gap-3 pb-1">
+              <input
+                value={t.title}
+                onInput={(e) =>
+                  editTodo(t.id, { title: e.currentTarget.value })}
+                aria-label="Title"
+                class="w-full md-body-large text-on-surface bg-surface-chigh border-0 rounded-[var(--md-shape-lg)] py-3 px-4 outline-none"
+              />
+              <textarea
+                value={t.notes ?? ""}
+                onInput={(e) =>
+                  editTodo(t.id, { notes: e.currentTarget.value })}
+                rows={2}
+                placeholder="Notes (optional)"
+                aria-label="Notes"
+                class="w-full md-body-large text-on-surface bg-surface-chigh border-0 rounded-[var(--md-shape-lg)] py-3 px-4 outline-none resize-none"
+              />
+              <Button variant="filled" full onClick={closeEditor}>Done</Button>
+              <Button
+                variant="error"
+                full
+                onClick={() => {
+                  const id = t.id;
+                  closeEditor();
+                  confirmingId.value = id;
+                }}
+              >
+                Delete
+              </Button>
+            </div>
+          );
+        })()}
+      </Sheet>
+
+      {/* Delete confirmation — the house pattern is a sheet, not a dialog */}
+      <Sheet
+        open={confirmingId.value !== null}
+        onClose={() => (confirmingId.value = null)}
+        title="Delete this to-do?"
+      >
+        <div class="flex flex-col gap-3 pb-1">
+          <div class="md-body-medium text-on-surface-variant">
+            This removes it for everyone. Use it when the to-do never needed
+            doing — ticking it off is how you say it's done.
+          </div>
+          <Button
+            variant="error"
+            full
+            onClick={async () => {
+              const id = confirmingId.value;
+              confirmingId.value = null;
+              if (!id) return;
+              const ok = await removeTodo(id);
+              if (!ok) say("Couldn't delete that. Try again?");
+            }}
+          >
+            Delete
+          </Button>
+          <Button
+            variant="text"
+            full
+            onClick={() => (confirmingId.value = null)}
+          >
+            Keep it
+          </Button>
+        </div>
+      </Sheet>
+
+      <Snackbar data={snack.value} />
+    </PullToRefresh>
+  );
+}

--- a/islands/todos/TodoBacklog.tsx
+++ b/islands/todos/TodoBacklog.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "preact/hooks";
+import { useEffect, useMemo, useRef } from "preact/hooks";
 import { useSignal } from "@preact/signals";
 import type { TodoInterface } from "@/models/index.ts";
 import { useTodos } from "@/hooks/useTodos.ts";
@@ -36,6 +36,46 @@ export default function TodoBacklog({ initialTodos }: Props) {
   const editingId = useSignal<string | null>(null);
   const confirmingId = useSignal<string | null>(null);
   const snack = useSignal<{ msg: string } | null>(null);
+
+  // ── create-sheet focus handoff ───────────────────────────────────────────
+  // `autofocus` doesn't work on the title input below because it's dynamically
+  // mounted (gated on createOpen.value — see the comment above the sheet), and
+  // browsers only honor `autofocus` during initial document parse.
+  //
+  // Focusing it from an effect after the sheet opens fixes that on desktop,
+  // but on mobile a programmatic .focus() called after an async signal-driven
+  // re-render runs outside the tap's user-activation window, so the soft
+  // keyboard won't raise (see the primer comment near the FAB in
+  // islands/items.tsx — this is the same "autofocus regression" PR #45 fixed).
+  // So we reuse that primer pattern here: the FAB tap focuses `primerRef`
+  // synchronously (within the tap), keeping the keyboard up across the async
+  // re-render that mounts the sheet body, then hands focus to the real title
+  // field once it exists.
+  const primerRef = useRef<HTMLInputElement>(null);
+  const titleRef = useRef<HTMLInputElement>(null);
+  // Set once the title field has taken focus, i.e. the keyboard hand-off is
+  // done and the primer can safely leave the DOM.
+  const handoff = useSignal(false);
+
+  const openCreate = () => {
+    newTitle.value = "";
+    newNotes.value = "";
+    handoff.value = false;
+    primerRef.current?.focus();
+    createOpen.value = true;
+  };
+
+  const closeCreate = () => {
+    createOpen.value = false;
+    handoff.value = false;
+  };
+
+  useEffect(() => {
+    if (createOpen.value) {
+      titleRef.current?.focus();
+      handoff.value = true;
+    }
+  }, [createOpen.value]);
 
   const open = openTodos.value;
   const done = doneTodos.value;
@@ -170,30 +210,44 @@ export default function TodoBacklog({ initialTodos }: Props) {
           icon="plus"
           label="New to-do"
           aria-label="New to-do"
-          onClick={() => {
-            newTitle.value = "";
-            newNotes.value = "";
-            createOpen.value = true;
-          }}
+          onClick={openCreate}
         />
       </div>
 
       {
+        /* Primer — see the "create-sheet focus handoff" comment above. Present
+          whenever the sheet is closed (so it's focusable synchronously inside
+          the FAB tap) or still waiting on the hand-off; unmounts once the real
+          title field takes focus. */
+      }
+      {(!createOpen.value || !handoff.value) && (
+        <input
+          ref={primerRef}
+          type="text"
+          aria-hidden="true"
+          tabIndex={-1}
+          class="fixed top-0 left-0 opacity-0 pointer-events-none"
+          style={{ width: 1, height: 1, fontSize: 16 }}
+        />
+      )}
+
+      {
         /* Create sheet — stays open between saves for rapid capture.
           Body gated on createOpen: <Sheet> renders its children even when
-          closed (see islands/items.tsx:442), so an ungated `autofocus` would
-          steal focus and raise the mobile keyboard on page load. Gating also
-          means `autofocus` fires on mount, i.e. exactly when the sheet opens. */
+          closed (see islands/items.tsx:442), so an ungated title input would
+          stay mounted (and stealing focus, see below) while the sheet is
+          closed. Gating also means the title input mounts fresh each time the
+          sheet opens, which is exactly when the focus effect above should run. */
       }
       <Sheet
         open={createOpen.value}
-        onClose={() => (createOpen.value = false)}
+        onClose={closeCreate}
         title="New to-do"
       >
         {createOpen.value && (
           <div class="flex flex-col gap-3 pb-1">
             <input
-              autofocus
+              ref={titleRef}
               value={newTitle.value}
               onInput={(e) => (newTitle.value = e.currentTarget.value)}
               onKeyDown={(e) => {
@@ -222,7 +276,7 @@ export default function TodoBacklog({ initialTodos }: Props) {
             <Button
               variant="text"
               full
-              onClick={() => (createOpen.value = false)}
+              onClick={closeCreate}
             >
               Close
             </Button>

--- a/islands/todos/TodoBacklog.tsx
+++ b/islands/todos/TodoBacklog.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef } from "preact/hooks";
 import { useSignal } from "@preact/signals";
 import type { TodoInterface } from "@/models/index.ts";
-import { useTodos } from "@/hooks/useTodos.ts";
+import { EXIT_MS, useTodos } from "@/hooks/useTodos.ts";
 import { PullToRefresh } from "@/components/md3/PullToRefresh.tsx";
 import { Sheet } from "@/components/md3/Sheet.tsx";
 import { Button } from "@/components/md3/Button.tsx";
@@ -36,6 +36,7 @@ export default function TodoBacklog({ initialTodos }: Props) {
   const editingId = useSignal<string | null>(null);
   const confirmingId = useSignal<string | null>(null);
   const snack = useSignal<{ msg: string } | null>(null);
+  const snackTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // ── create-sheet focus handoff ───────────────────────────────────────────
   // `autofocus` doesn't work on the title input below because it's dynamically
@@ -73,7 +74,10 @@ export default function TodoBacklog({ initialTodos }: Props) {
   useEffect(() => {
     if (createOpen.value) {
       titleRef.current?.focus();
-      handoff.value = true;
+      // Confirm the field actually took focus before declaring the hand-off
+      // done — if it didn't, the primer must stay mounted (closeCreate still
+      // resets this to false, so it never wedges the primer permanently).
+      handoff.value = document.activeElement === titleRef.current;
     }
   }, [createOpen.value]);
 
@@ -87,8 +91,13 @@ export default function TodoBacklog({ initialTodos }: Props) {
 
   const say = (msg: string) => {
     snack.value = { msg };
-    setTimeout(() => (snack.value = null), 4000);
+    if (snackTimer.current) clearTimeout(snackTimer.current);
+    snackTimer.current = setTimeout(() => (snack.value = null), 4000);
   };
+
+  useEffect(() => () => {
+    if (snackTimer.current) clearTimeout(snackTimer.current);
+  }, []);
 
   const submitNew = async () => {
     const title = newTitle.value.trim();
@@ -116,7 +125,8 @@ export default function TodoBacklog({ initialTodos }: Props) {
     editingId.value = null;
   };
 
-  // The 300ms here must match EXIT_MS in useTodos (patterns doc §6).
+  // EXIT_MS is imported from useTodos so this transition and the exit-wait it
+  // must match can't drift apart (patterns doc §6).
   const row = (t: TodoInterface, isDone: boolean) => (
     <div
       key={t.id}
@@ -127,7 +137,11 @@ export default function TodoBacklog({ initialTodos }: Props) {
           ? "translateX(12px)"
           : "translateX(0)",
         transition:
-          "opacity .3s var(--md-emphasized), transform .3s var(--md-emphasized)",
+          `opacity ${EXIT_MS}ms var(--md-emphasized), transform ${EXIT_MS}ms var(--md-emphasized)`,
+        // A row mid-exit-animation stays in the list (see useTodos.tickOff/
+        // removeTodo) but must not be tappable — invisible-but-present rows
+        // would otherwise accept a second tap during the fade.
+        pointerEvents: exiting.includes(t.id) ? "none" : undefined,
       }}
     >
       <Pressable
@@ -161,7 +175,11 @@ export default function TodoBacklog({ initialTodos }: Props) {
   );
 
   return (
-    <PullToRefresh onRefresh={refresh}>
+    <PullToRefresh
+      onRefresh={refresh}
+      disabled={createOpen.value || editingId.value !== null ||
+        confirmingId.value !== null}
+    >
       <div class="px-4 pt-4 pb-[calc(96px+env(safe-area-inset-bottom))] flex flex-col gap-4">
         {open.length === 0 && done.length === 0
           ? (

--- a/islands/todos/TodoBacklog.tsx
+++ b/islands/todos/TodoBacklog.tsx
@@ -100,9 +100,14 @@ export default function TodoBacklog({ initialTodos }: Props) {
       return;
     }
     // Keep the sheet open and the field focused so several to-dos can be
-    // captured in a row without the mobile keyboard dismissing.
+    // captured in a row without the mobile keyboard dismissing. Clearing the
+    // fields doesn't restore focus by itself — the Enter-key path never lost
+    // it, but a pointer tap on the "Add" button below moves focus to the
+    // button, so it must be reclaimed explicitly (mirrors handleCreate in
+    // islands/add-items.tsx).
     newTitle.value = "";
     newNotes.value = "";
+    titleRef.current?.focus();
   };
 
   const closeEditor = () => {

--- a/models/index.ts
+++ b/models/index.ts
@@ -6,3 +6,4 @@ export * from "./category/index.ts";
 export * from "./household/index.ts";
 export * from "./dish/index.ts";
 export * from "./loyalty-card/index.ts";
+export * from "./todo/index.ts";

--- a/models/todo/index.ts
+++ b/models/todo/index.ts
@@ -1,0 +1,1 @@
+export * from "./todo.interface.ts";

--- a/models/todo/todo.interface.ts
+++ b/models/todo/todo.interface.ts
@@ -1,0 +1,30 @@
+export interface TodoInterface {
+  id: string;
+  householdId: string;
+  /** What needs doing, as the household typed it. */
+  title: string;
+  /** Optional detail — a phone number, a deadline someone mentioned. */
+  notes?: string;
+  /** userId of whoever added it. Creating requires a login, so this is a user. */
+  createdBy: string;
+  createdAt: string;
+  /**
+   * When the household actually did this, or null if it is still open. The
+   * timestamp *is* the state — there is no separate `done` boolean. See
+   * docs/adr/0002.
+   */
+  completedAt: string | null;
+}
+
+// Derived type for creation (no ID — the server mints it).
+export type CreateTodoDto = Omit<TodoInterface, "id">;
+
+/**
+ * What the client sends to create a to-do. The server fills in `householdId`,
+ * `createdBy`, `createdAt`, `completedAt` and `id` — the client never sends
+ * (and cannot spoof) the household.
+ */
+export type TodoInput = Pick<TodoInterface, "title" | "notes">;
+
+// Derived type for patch/update: never the id or householdId, everything else optional.
+export type UpdateTodoDto = Partial<Omit<TodoInterface, "id" | "householdId">>;

--- a/routes/api/todos/[id].test.ts
+++ b/routes/api/todos/[id].test.ts
@@ -1,0 +1,191 @@
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import { type Context } from "fresh";
+import { handler } from "@/routes/api/todos/[id].ts";
+import { TodoRepo } from "@/database/todo.repo.ts";
+import { getKv } from "@/database/db.ts";
+
+Deno.env.set("KV_PATH", ":memory:");
+
+interface State {
+  userId?: string;
+  householdId?: string;
+}
+
+function ctx(req: Request, id: string, state: State = {}): Context<State> {
+  return { req, state, params: { id } } as unknown as Context<State>;
+}
+
+async function clearTodos() {
+  const kv = await getKv();
+  for await (const e of kv.list({ prefix: ["todos"] })) {
+    await kv.delete(e.key);
+  }
+}
+
+const AUTH: State = { userId: "u1", householdId: "h1" };
+
+const patch = (body: unknown) =>
+  new Request("http://x/api/todos/x", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+const del = () => new Request("http://x/api/todos/x", { method: "DELETE" });
+
+function seed(householdId = "h1", title = "Take out the bins") {
+  return TodoRepo.create({
+    householdId,
+    title,
+    createdBy: "u1",
+    createdAt: "2026-08-03T10:00:00.000Z",
+    completedAt: null,
+  });
+}
+
+Deno.test({
+  name: "PATCH updates the title",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const todo = await seed();
+    const res = await handler.PATCH(
+      ctx(patch({ title: "  Take out the recycling  " }), todo.id, AUTH),
+    );
+    assertEquals(res.status, 200);
+    assertEquals((await res.json()).title, "Take out the recycling");
+  },
+});
+
+Deno.test({
+  name: "PATCH ticks off and un-ticks via completedAt",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const todo = await seed();
+
+    const ticked = await (await handler.PATCH(
+      ctx(patch({ completedAt: "2026-08-03T12:00:00.000Z" }), todo.id, AUTH),
+    )).json();
+    assertEquals(ticked.completedAt, "2026-08-03T12:00:00.000Z");
+
+    const reopened = await (await handler.PATCH(
+      ctx(patch({ completedAt: null }), todo.id, AUTH),
+    )).json();
+    assertEquals(reopened.completedAt, null);
+  },
+});
+
+Deno.test({
+  name: "PATCH can clear notes",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const todo = await TodoRepo.create({
+      householdId: "h1",
+      title: "Call the dentist",
+      notes: "09 123 45 67",
+      createdBy: "u1",
+      createdAt: "2026-08-03T10:00:00.000Z",
+      completedAt: null,
+    });
+
+    const cleared = await (await handler.PATCH(
+      ctx(patch({ notes: "" }), todo.id, AUTH),
+    )).json();
+    assertEquals(cleared.notes, "");
+  },
+});
+
+Deno.test({
+  name: "PATCH rejects a blank title (400) and leaves the to-do alone",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const todo = await seed();
+    assertEquals(
+      (await handler.PATCH(ctx(patch({ title: "  " }), todo.id, AUTH))).status,
+      400,
+    );
+    const still = await TodoRepo.getById("h1", todo.id);
+    assertEquals(still?.title, "Take out the bins");
+  },
+});
+
+Deno.test({
+  name: "PATCH ignores client-supplied createdBy and createdAt",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const todo = await seed();
+    const updated = await (await handler.PATCH(
+      ctx(
+        patch({ createdBy: "hacker", createdAt: "1999-01-01T00:00:00.000Z" }),
+        todo.id,
+        AUTH,
+      ),
+    )).json();
+    assertEquals(updated.createdBy, "u1");
+    assertEquals(updated.createdAt, "2026-08-03T10:00:00.000Z");
+  },
+});
+
+Deno.test({
+  name: "PATCH on an unknown id is 404",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    assertEquals(
+      (await handler.PATCH(ctx(patch({ title: "x" }), "nope", AUTH))).status,
+      404,
+    );
+  },
+});
+
+Deno.test({
+  name: "DELETE removes the to-do (204), then 404",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const todo = await seed();
+    assertEquals((await handler.DELETE(ctx(del(), todo.id, AUTH))).status, 204);
+    assertEquals((await handler.DELETE(ctx(del(), todo.id, AUTH))).status, 404);
+    assertEquals(await TodoRepo.getById("h1", todo.id), null);
+  },
+});
+
+Deno.test({
+  name: "another household cannot patch or delete your to-do",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const todo = await seed();
+    const theirs: State = { userId: "u2", householdId: "h2" };
+
+    assertEquals(
+      (await handler.PATCH(ctx(patch({ title: "x" }), todo.id, theirs))).status,
+      404,
+    );
+    assertEquals(
+      (await handler.DELETE(ctx(del(), todo.id, theirs))).status,
+      404,
+    );
+    assertEquals(
+      (await TodoRepo.getById("h1", todo.id))?.title,
+      "Take out the bins",
+    );
+  },
+});
+
+Deno.test({
+  name: "PATCH and DELETE require a household (401)",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    assertEquals(
+      (await handler.PATCH(ctx(patch({ title: "x" }), "any"))).status,
+      401,
+    );
+    assertEquals((await handler.DELETE(ctx(del(), "any"))).status, 401);
+  },
+});

--- a/routes/api/todos/[id].test.ts
+++ b/routes/api/todos/[id].test.ts
@@ -113,6 +113,38 @@ Deno.test({
 });
 
 Deno.test({
+  name: "PATCH rejects a non-string title (400) and leaves the to-do alone",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const todo = await seed();
+    assertEquals(
+      (await handler.PATCH(ctx(patch({ title: null }), todo.id, AUTH))).status,
+      400,
+    );
+    const still = await TodoRepo.getById("h1", todo.id);
+    assertEquals(still?.title, "Take out the bins");
+  },
+});
+
+Deno.test({
+  name:
+    "PATCH rejects a non-string completedAt (400) and leaves the to-do alone",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const todo = await seed();
+    assertEquals(
+      (await handler.PATCH(ctx(patch({ completedAt: 123 }), todo.id, AUTH)))
+        .status,
+      400,
+    );
+    const still = await TodoRepo.getById("h1", todo.id);
+    assertEquals(still?.completedAt, null);
+  },
+});
+
+Deno.test({
   name: "PATCH ignores client-supplied createdBy and createdAt",
   sanitizeResources: false,
   async fn() {

--- a/routes/api/todos/[id].ts
+++ b/routes/api/todos/[id].ts
@@ -17,20 +17,34 @@ export const handler = define.handlers({
     const patch: UpdateTodoDto = {};
 
     if (body.title !== undefined) {
-      const title = String(body.title).trim();
+      if (typeof body.title !== "string") {
+        return badRequest("title must be a string");
+      }
+      const title = body.title.trim();
       if (!title) return badRequest("title required");
       patch.title = title;
     }
     if (body.notes !== undefined) {
+      if (typeof body.notes !== "string") {
+        return badRequest("notes must be a string");
+      }
       // Empty string, not undefined: mergeDefinedPatch skips undefined, so
       // `undefined` here would silently leave an existing note in place and
       // clearing notes in the UI would appear to fail.
-      patch.notes = String(body.notes).trim();
+      patch.notes = body.notes.trim();
     }
     if (body.completedAt !== undefined) {
-      patch.completedAt = body.completedAt === null
-        ? null
-        : String(body.completedAt);
+      if (body.completedAt === null) {
+        patch.completedAt = null;
+      } else {
+        if (
+          typeof body.completedAt !== "string" ||
+          Number.isNaN(Date.parse(body.completedAt))
+        ) {
+          return badRequest("completedAt must be null or a valid date string");
+        }
+        patch.completedAt = body.completedAt;
+      }
     }
 
     const updated = await TodoRepo.update(householdId, ctx.params.id, patch);

--- a/routes/api/todos/[id].ts
+++ b/routes/api/todos/[id].ts
@@ -1,0 +1,51 @@
+import {
+  badRequest,
+  define,
+  json,
+  noContent,
+  notFound,
+} from "@/utils/index.ts";
+import { TodoRepo } from "@/database/index.ts";
+import type { UpdateTodoDto } from "@/models/index.ts";
+
+export const handler = define.handlers({
+  async PATCH(ctx) {
+    const householdId = ctx.state.householdId;
+    if (!householdId) return new Response("Unauthorized", { status: 401 });
+
+    const body = await ctx.req.json();
+    const patch: UpdateTodoDto = {};
+
+    if (body.title !== undefined) {
+      const title = String(body.title).trim();
+      if (!title) return badRequest("title required");
+      patch.title = title;
+    }
+    if (body.notes !== undefined) {
+      // Empty string, not undefined: mergeDefinedPatch skips undefined, so
+      // `undefined` here would silently leave an existing note in place and
+      // clearing notes in the UI would appear to fail.
+      patch.notes = String(body.notes).trim();
+    }
+    if (body.completedAt !== undefined) {
+      patch.completedAt = body.completedAt === null
+        ? null
+        : String(body.completedAt);
+    }
+
+    const updated = await TodoRepo.update(householdId, ctx.params.id, patch);
+    if (!updated) return notFound("no such to-do");
+    return json(updated);
+  },
+
+  async DELETE(ctx) {
+    const householdId = ctx.state.householdId;
+    if (!householdId) return new Response("Unauthorized", { status: 401 });
+
+    const existing = await TodoRepo.getById(householdId, ctx.params.id);
+    if (!existing) return notFound("no such to-do");
+
+    await TodoRepo.delete(householdId, existing.id);
+    return noContent();
+  },
+});

--- a/routes/api/todos/index.test.ts
+++ b/routes/api/todos/index.test.ts
@@ -1,0 +1,126 @@
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import { type Context } from "fresh";
+import { handler } from "@/routes/api/todos/index.ts";
+import { getKv } from "@/database/db.ts";
+
+Deno.env.set("KV_PATH", ":memory:");
+
+interface State {
+  userId?: string;
+  householdId?: string;
+}
+
+function ctx(req: Request, state: State = {}): Context<State> {
+  return { req, state } as unknown as Context<State>;
+}
+
+async function clearTodos() {
+  const kv = await getKv();
+  for await (const e of kv.list({ prefix: ["todos"] })) {
+    await kv.delete(e.key);
+  }
+}
+
+const AUTH: State = { userId: "u1", householdId: "h1" };
+
+const post = (body: unknown) =>
+  new Request("http://x/api/todos", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+Deno.test({
+  name: "POST creates an open to-do (201); GET lists it for the household",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const createRes = await handler.POST(
+      ctx(post({ title: "Take out the bins" }), AUTH),
+    );
+    assertEquals(createRes.status, 201);
+    const created = await createRes.json();
+    assertEquals(created.title, "Take out the bins");
+    assertEquals(created.householdId, "h1");
+    assertEquals(created.createdBy, "u1");
+    assertEquals(created.completedAt, null);
+
+    const listRes = await handler.GET(
+      ctx(new Request("http://x/api/todos"), AUTH),
+    );
+    assertEquals(listRes.status, 200);
+    const list = await listRes.json();
+    assertEquals(list.map((t: { title: string }) => t.title), [
+      "Take out the bins",
+    ]);
+  },
+});
+
+Deno.test({
+  name: "POST trims the title and omits blank notes",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const created = await (await handler.POST(
+      ctx(post({ title: "  Call the dentist  ", notes: "   " }), AUTH),
+    )).json();
+    assertEquals(created.title, "Call the dentist");
+    assertEquals(created.notes, undefined);
+  },
+});
+
+Deno.test({
+  name: "POST keeps notes when given",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const created = await (await handler.POST(
+      ctx(post({ title: "Call the dentist", notes: "09 123 45 67" }), AUTH),
+    )).json();
+    assertEquals(created.notes, "09 123 45 67");
+  },
+});
+
+Deno.test({
+  name: "POST rejects a blank title (400)",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    assertEquals(
+      (await handler.POST(ctx(post({ title: "   " }), AUTH))).status,
+      400,
+    );
+    assertEquals((await handler.POST(ctx(post({}), AUTH))).status, 400);
+  },
+});
+
+Deno.test({
+  name: "GET and POST require a household (401)",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    assertEquals(
+      (await handler.GET(ctx(new Request("http://x/api/todos")))).status,
+      401,
+    );
+    assertEquals(
+      (await handler.POST(ctx(post({ title: "x" })))).status,
+      401,
+    );
+  },
+});
+
+Deno.test({
+  name: "GET does not leak another household's to-dos",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    await handler.POST(
+      ctx(post({ title: "Theirs" }), { userId: "u2", householdId: "h2" }),
+    );
+    const list = await (await handler.GET(
+      ctx(new Request("http://x/api/todos"), AUTH),
+    )).json();
+    assertEquals(list, []);
+  },
+});

--- a/routes/api/todos/index.ts
+++ b/routes/api/todos/index.ts
@@ -1,0 +1,32 @@
+import { badRequest, define, json } from "@/utils/index.ts";
+import { TodoRepo } from "@/database/index.ts";
+
+export const handler = define.handlers({
+  async GET(ctx) {
+    const householdId = ctx.state.householdId;
+    if (!householdId) return new Response("Unauthorized", { status: 401 });
+    return json(await TodoRepo.getAll(householdId));
+  },
+
+  async POST(ctx) {
+    const { userId, householdId } = ctx.state;
+    if (!userId || !householdId) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+
+    const body = await ctx.req.json();
+    const title = String(body.title ?? "").trim();
+    if (!title) return badRequest("title required");
+    const rawNotes = String(body.notes ?? "").trim();
+
+    const todo = await TodoRepo.create({
+      householdId,
+      title,
+      notes: rawNotes || undefined,
+      createdBy: userId,
+      createdAt: new Date().toISOString(),
+      completedAt: null,
+    });
+    return json(todo, 201);
+  },
+});

--- a/routes/todos/index.tsx
+++ b/routes/todos/index.tsx
@@ -1,14 +1,19 @@
+import { page } from "fresh";
+import { TodoRepo } from "@/database/index.ts";
+import TodoBacklog from "@/islands/todos/TodoBacklog.tsx";
 import { define } from "@/utils/index.ts";
-import { ComingSoon } from "@/components/md3/ComingSoon.tsx";
 
-export default define.page(function Todos() {
+export const handler = define.handlers({
+  async GET(ctx) {
+    const householdId = ctx.state.householdId!;
+    return page({ todos: await TodoRepo.getAll(householdId) });
+  },
+});
+
+export default define.page<typeof handler>(function Todos({ data }) {
   return (
     <main class="max-w-md mx-auto">
-      <ComingSoon
-        icon="checklist"
-        title="To-dos"
-        blurb="Shared to-dos are coming soon — a place for the whole household's tasks."
-      />
+      <TodoBacklog initialTodos={data.todos} />
     </main>
   );
 });

--- a/services/api.ts
+++ b/services/api.ts
@@ -12,6 +12,7 @@ import {
   DishTagValueInterface,
 } from "@/models/index.ts";
 import { LoyaltyCardInput, LoyaltyCardInterface } from "@/models/index.ts";
+import { TodoInput, TodoInterface, UpdateTodoDto } from "@/models/index.ts";
 
 export const api = {
   items: {
@@ -230,6 +231,38 @@ export const api = {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ id }),
       });
+    },
+  },
+  todos: {
+    getAll: async (): Promise<TodoInterface[]> => {
+      const res = await fetch("/api/todos");
+      if (!res.ok) return [];
+      return res.json();
+    },
+    create: async (input: TodoInput): Promise<TodoInterface | null> => {
+      const res = await fetch("/api/todos", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(input),
+      });
+      if (!res.ok) return null;
+      return res.json();
+    },
+    update: async (
+      id: string,
+      patch: UpdateTodoDto,
+    ): Promise<TodoInterface | null> => {
+      const res = await fetch(`/api/todos/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(patch),
+      });
+      if (!res.ok) return null;
+      return res.json();
+    },
+    delete: async (id: string): Promise<boolean> => {
+      const res = await fetch(`/api/todos/${id}`, { method: "DELETE" });
+      return res.ok;
     },
   },
   dishTagGroups: {

--- a/utils/http.test.ts
+++ b/utils/http.test.ts
@@ -1,0 +1,33 @@
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import { badRequest, json, noContent, notFound } from "./http.ts";
+
+Deno.test("json — serialises the body with a JSON content type and default 200", async () => {
+  const res = json({ ok: true });
+  assertEquals(res.status, 200);
+  assertEquals(res.headers.get("Content-Type"), "application/json");
+  assertEquals(await res.json(), { ok: true });
+});
+
+Deno.test("json — honours an explicit status", async () => {
+  const res = json({ id: "a" }, 201);
+  assertEquals(res.status, 201);
+  assertEquals(await res.json(), { id: "a" });
+});
+
+Deno.test("noContent — 204 with an empty body", async () => {
+  const res = noContent();
+  assertEquals(res.status, 204);
+  assertEquals(await res.text(), "");
+});
+
+Deno.test("badRequest — 400 carrying the message", async () => {
+  const res = badRequest("title required");
+  assertEquals(res.status, 400);
+  assertEquals(await res.text(), "title required");
+});
+
+Deno.test("notFound — 404, with a default message", async () => {
+  assertEquals(notFound().status, 404);
+  assertEquals(await notFound().text(), "Not found");
+  assertEquals(await notFound("no such to-do").text(), "no such to-do");
+});

--- a/utils/http.ts
+++ b/utils/http.ts
@@ -1,0 +1,21 @@
+/** JSON response helpers shared by the API routes, so handlers stop repeating
+ *  `new Response(JSON.stringify(x), { status, headers })`. See issue #51. */
+
+export function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export function noContent(): Response {
+  return new Response(null, { status: 204 });
+}
+
+export function badRequest(message: string): Response {
+  return new Response(message, { status: 400 });
+}
+
+export function notFound(message = "Not found"): Response {
+  return new Response(message, { status: 404 });
+}

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./security.ts";
 export * from "./debounce-update.ts";
 export * from "./define.ts";
+export * from "./http.ts";


### PR DESCRIPTION
Iteration 1 of the shared household to-do list. `/todos` was a `ComingSoon` placeholder; it is now a working module.

Ticking a to-do off means **we did this**; deleting it means **this never needed doing**. Those are the two different exits from the backlog, and the whole design follows from keeping them distinct.

## What's in it

- One household-scoped KV aggregate, keys `["todos", householdId, id]`, behind `TodoRepo`
- `GET/POST /api/todos`, `PATCH/DELETE /api/todos/[id]`
- `hooks/useTodos.ts` — signals store: pessimistic create, optimistic+debounced edits, optimistic tick/delete with rollback
- `islands/todos/TodoBacklog.tsx` — Open and Done sections, FAB → a create sheet that **stays open** so several to-dos can be captured in a row
- New shared JSON response helpers in `utils/http.ts` (the uncontroversial half of #51 — no existing route touched)
- The project's first `CONTEXT.md` glossary, now pointed at from `CLAUDE.md` / `AGENTS.md` / copilot instructions
- Two ADRs, plus `docs/ui-ux-patterns.md` §12–13 documenting the capture-sheet and keyboard-primer patterns

## Decisions worth knowing

Both deviate from the shopping module sitting next to it, so both have ADRs:

- **[ADR 0001](docs/adr/0001-one-household-backlog-no-todo-lists.md) — one household backlog, no to-do lists.** Shopping has multiple named lists; to-dos deliberately don't. Slicing happens by filter and label, not by container — a to-do can be "for the birthday party" *and* "shopping" *and* assigned to someone at once. Accepted cost: real multiple lists later would mean a length-3 → length-4 key migration.
- **[ADR 0002](docs/adr/0002-completion-is-a-timestamp-not-needed-is-a-deletion.md) — completion is a timestamp; "not needed" is a deletion.** `completedAt: string \| null` rather than a `checked` boolean, because recurrence (iteration 4) needs to know *when* something was last done. And deliberately **no** bulk "clear done" twin of `clearChecked` — purging done to-dos would destroy the very record `completedAt` exists to keep.

`completedBy` is deliberately absent: with one user per household it carries no information, and the thing that will eventually complete a to-do is a **member** (possibly a child with no login), not a user — so storing a userId now would only buy a migration.

## Scope

Iteration 1 is CRUD + tick-off. Deferred: assignment + filters (2), due dates + views (3), recurrence (4), labels (5).

**Assignment is hard-blocked on #17.** A household currently holds exactly one user — `UserRepo.create` always mints a fresh household and there's no signup route — so "shared" is architectural, not yet observable. Scoping by `householdId` from day one costs nothing today and avoids the migration #42 is currently paying for on the catalogue.

## Verification

`deno task check` clean. **245 tests passing** (196 on main, so +49): repo, HTTP helpers, both API route files, the hook (including rollback paths and the debounce/delete race), and island SSR.

Driven end-to-end in a browser at mobile viewport: empty state, create, newest-first ordering, tick-off into a struck-through Done section, un-tick, notes with a 📝 hint, delete behind a confirmation sheet, and full persistence across a reload (SSR and hydrated view agree).

**Three defects were caught by review and fixed; two were bugs in the plan, not the implementation:**

| | |
|---|---|
| `tickOff` built the moved record from a **pre-wait** read | An edit during the 300ms exit animation was dropped locally while still persisting server-side — permanent divergence |
| The create sheet's `autofocus` focused **nothing** | It's inert for dynamically-mounted elements; replaced with the repo's keyboard-primer hand-off |
| A blank title aborted the **whole merged patch** | Edit the notes, then clear the title, and the notes were silently lost and never retried. The guard is now subtractive |

Also fixed from the final review: a real tap on **Add** used to leave focus on the button (dismissing the mobile keyboard after every add); double-tapping tick-off showed a **false** "didn't save" error; and `PullToRefresh` wasn't disabled while a sheet was open, so a drag in the sheet body could refresh and discard un-flushed edits.

## Not verified

The mobile soft-keyboard raise for the primer hand-off needs a physical device — the same open question as #45. Desktop focus is verified with real pointer and key events.

## Follow-ups (not blocking)

`requireHousehold(ctx)` helper once a fifth route needs it (belongs with #51); extracting the sort comparator so the repo and hook can't drift; `aria-label`s duplicating placeholders; overlapping sheet transitions on Edit → Delete (#49 territory); and the `api` boundary throwing on transport errors rather than returning `null` (#52).

🤖 Generated with [Claude Code](https://claude.com/claude-code)