### PR TITLE
feat(todos): due dates, urgency grouping and a windowed Done section (iteration 3)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -15,11 +15,19 @@ _Avoid_: family, account, group, tenant
 
 ### To-dos
 
-**To-do**: Something the household needs to get done. It carries its own freely
-typed title — there is nothing to pick it from. It covers both the one-off
-("book the venue") and the routine ("take out the bins"); a routine to-do is not
-a separate kind of thing, only one that comes back. _Avoid_: task, chore, item,
-action item, ticket
+**To-do**: Something the household needs to get done **once** — "book the
+venue", "renew the passport", "return the library books". It carries its own
+freely typed title; there is nothing to pick it from. Its purpose is
+remembering: a to-do exists because a one-off would otherwise be forgotten.
+Something that comes back on a schedule is a **Chore**, not a to-do. _Avoid_:
+task, item, action item, ticket
+
+**Chore**: Routine household work that recurs on a schedule — the bins, the
+monthly bills, the yearly dentist appointment. A chore is **not** a to-do that
+happens to repeat: it is driven by its schedule rather than by someone
+remembering it, and it never really finishes. Happie does not model chores yet;
+the word is defined here so the two are never conflated when it does. _Avoid_:
+recurring to-do, routine, task
 
 **Backlog**: The single collection of every to-do a household has. A household
 has exactly one, and it is never divided into sub-lists — a to-do is found by
@@ -30,6 +38,16 @@ to-do list, list, inbox
 time, not a flag: a done to-do knows the moment it happened. It stays in the
 backlog once done — finishing something is worth seeing. _Avoid_: checked,
 completed, closed, finished, archived
+
+**Due**: The moment a to-do should be done by. It is always a moment, never just
+a day — a to-do due "on the 1st" is due at a particular time on the 1st, because
+that is when the household will be reminded of it. Read in the viewer's own
+timezone. _Avoid_: deadline, due by, target date, due date (as a day)
+
+**Overdue**: A to-do whose due moment has passed while it is still open. Being
+overdue is not a failure to be scolded for — it is the module doing its job,
+surfacing something the household meant to do and hasn't. _Avoid_: late, missed,
+expired, failed
 
 **Not needed**: The other way a to-do leaves the backlog: the household decided
 it never had to happen at all. Unlike being done, this is not a state a to-do

--- a/database/todo.repo.test.ts
+++ b/database/todo.repo.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from "jsr:@std/assert@^1.0.19";
 import { TodoRepo } from "@/database/todo.repo.ts";
+import { getKv } from "@/database/db.ts";
 import type { CreateTodoDto } from "@/models/index.ts";
 
 // Isolated in-memory KV for this test process. getKv() reads KV_PATH lazily on
@@ -203,5 +204,113 @@ Deno.test({
       await TodoRepo.update("hh-theirs", mine.id, { title: "x" }),
       null,
     );
+  },
+});
+
+Deno.test({
+  name: "getAll — dated open to-dos come before undated ones, soonest first",
+  sanitizeResources: false,
+  async fn() {
+    const hh = "hh-order-due";
+    await TodoRepo.create(draft(hh, "undated newer", {
+      createdAt: "2026-08-03T10:00:00.000Z",
+    }));
+    await TodoRepo.create(draft(hh, "undated older", {
+      createdAt: "2026-08-01T10:00:00.000Z",
+    }));
+    await TodoRepo.create(draft(hh, "due later", {
+      createdAt: "2026-08-01T10:00:00.000Z",
+      dueAt: "2026-09-01T09:00:00.000Z",
+    }));
+    await TodoRepo.create(draft(hh, "due soon", {
+      createdAt: "2026-08-01T10:00:00.000Z",
+      dueAt: "2026-08-10T09:00:00.000Z",
+    }));
+
+    const all = await TodoRepo.getAll(hh);
+
+    assertEquals(all.map((t) => t.title), [
+      "due soon",
+      "due later",
+      "undated newer",
+      "undated older",
+    ]);
+  },
+});
+
+Deno.test({
+  name: "getAll — ties on identical dueAt break by id for a stable order",
+  sanitizeResources: false,
+  async fn() {
+    const hh = "hh-order-due-tie";
+    const a = await TodoRepo.create(draft(hh, "a", {
+      dueAt: "2026-08-10T09:00:00.000Z",
+    }));
+    const b = await TodoRepo.create(draft(hh, "b", {
+      dueAt: "2026-08-10T09:00:00.000Z",
+    }));
+
+    const all = await TodoRepo.getAll(hh);
+    const expected = [a.id, b.id].sort((x, y) => x.localeCompare(y));
+
+    assertEquals(all.map((t) => t.id), expected);
+  },
+});
+
+Deno.test({
+  name: "getAll — done to-dos stay after every open one, dated or not",
+  sanitizeResources: false,
+  async fn() {
+    const hh = "hh-order-due-done";
+    await TodoRepo.create(draft(hh, "done", {
+      completedAt: "2026-08-04T12:00:00.000Z",
+      dueAt: "2026-08-01T09:00:00.000Z",
+    }));
+    await TodoRepo.create(draft(hh, "open undated"));
+
+    const all = await TodoRepo.getAll(hh);
+
+    assertEquals(all.map((t) => t.title), ["open undated", "done"]);
+  },
+});
+
+Deno.test({
+  name: "getAll — a record stored without dueAt reads back as null",
+  sanitizeResources: false,
+  async fn() {
+    const hh = "hh-legacy";
+    const kv = await getKv();
+    const id = "legacy-1";
+    // Write a pre-dueAt record shape directly, bypassing create().
+    await kv.set(["todos", hh, id], {
+      id,
+      householdId: hh,
+      title: "written before dueAt existed",
+      createdBy: "user-1",
+      createdAt: "2026-07-01T10:00:00.000Z",
+      completedAt: null,
+    });
+
+    const all = await TodoRepo.getAll(hh);
+
+    assertEquals(all.length, 1);
+    assertEquals(all[0].dueAt, null);
+    assertEquals((await TodoRepo.getById(hh, id))?.dueAt, null);
+  },
+});
+
+Deno.test({
+  name: "update — clearing dueAt to null sticks",
+  sanitizeResources: false,
+  async fn() {
+    const hh = "hh-clear-due";
+    const todo = await TodoRepo.create(draft(hh, "Book the venue", {
+      dueAt: "2026-08-10T09:00:00.000Z",
+    }));
+
+    const updated = await TodoRepo.update(hh, todo.id, { dueAt: null });
+
+    assertEquals(updated?.dueAt, null);
+    assertEquals(updated?.title, "Book the venue");
   },
 });

--- a/database/todo.repo.test.ts
+++ b/database/todo.repo.test.ts
@@ -25,6 +25,7 @@ function draft(
     createdBy: "user-1",
     createdAt: new Date().toISOString(),
     completedAt: null,
+    dueAt: null,
     ...overrides,
   };
 }

--- a/database/todo.repo.ts
+++ b/database/todo.repo.ts
@@ -7,6 +7,16 @@ import { getKv } from "./db.ts";
 import { mergeDefinedPatch } from "./merge-patch.ts";
 
 /**
+ * `dueAt` was added after the first to-dos were written, so older records have
+ * no such key and `value.dueAt` is `undefined`. Normalising here — once, at the
+ * read boundary — keeps every consumer free of `?? null` defensiveness. No
+ * migration is needed: the field is additive and optional in storage.
+ */
+function normalise(value: TodoInterface): TodoInterface {
+  return value.dueAt === undefined ? { ...value, dueAt: null } : value;
+}
+
+/**
  * To-dos are shared within a household. Keys are scoped by household so a
  * member only ever reads or writes their own household's to-dos
  * (`["todos", householdId, id]`), mirroring `LoyaltyCardRepo`. A household has
@@ -23,31 +33,54 @@ export class TodoRepo {
 
   /**
    * Every consumer gets the same order, so the SSR render and the hydrated view
-   * agree and the island only has to find the partition point: open to-dos
-   * first (newest created first), then done ones (most recently done first).
+   * agree and the island only has to bucket: open to-dos first — those with a
+   * due moment ordered soonest-first, then undated ones newest-created first —
+   * and finally done ones, most recently done first.
+   *
+   * Dated-ascending-then-undated-newest is what lets `groupOpenTodos` in
+   * utils/todo-due.ts bucket in a single pass without sorting: each urgency
+   * group comes out ascending, and "No date" keeps the newest-first order that
+   * makes quick capture feel responsive.
    */
   static async getAll(householdId: string): Promise<TodoInterface[]> {
     const kv = await getKv();
     const iter = kv.list<TodoInterface>({ prefix: ["todos", householdId] });
     const todos: TodoInterface[] = [];
-    for await (const { value } of iter) todos.push(value);
+    for await (const { value } of iter) todos.push(normalise(value));
 
     return todos.sort((a, b) => {
-      if (a.completedAt === null && b.completedAt === null) {
-        // Plain string comparison, not localeCompare: two to-dos captured in
-        // the same rapid-capture burst can share a millisecond-precision
-        // createdAt, so ties are broken by id for a total, stable order —
-        // otherwise they'd fall back to KV iteration order and could swap
-        // places relative to the optimistic prepend on reload.
+      const aOpen = a.completedAt === null;
+      const bOpen = b.completedAt === null;
+
+      // Open before done.
+      if (aOpen !== bOpen) return aOpen ? -1 : 1;
+
+      if (aOpen) {
+        const aDated = a.dueAt !== null;
+        const bDated = b.dueAt !== null;
+        // Dated before undated.
+        if (aDated !== bDated) return aDated ? -1 : 1;
+
+        if (aDated) {
+          // Soonest due first.
+          if (a.dueAt !== b.dueAt) return a.dueAt! < b.dueAt! ? -1 : 1;
+          return a.id.localeCompare(b.id);
+        }
+
+        // Undated: newest created first. Plain string comparison, not
+        // localeCompare — two to-dos captured in the same rapid-capture burst
+        // can share a millisecond-precision createdAt, so ties break by id for
+        // a total, stable order; otherwise they'd fall back to KV iteration
+        // order and could swap places relative to the optimistic prepend.
         if (a.createdAt !== b.createdAt) {
           return a.createdAt < b.createdAt ? 1 : -1;
         }
         return a.id.localeCompare(b.id);
       }
-      if (a.completedAt === null) return -1;
-      if (b.completedAt === null) return 1;
+
+      // Both done: most recently done first.
       if (a.completedAt !== b.completedAt) {
-        return a.completedAt < b.completedAt ? 1 : -1;
+        return a.completedAt! < b.completedAt! ? 1 : -1;
       }
       return a.id.localeCompare(b.id);
     });
@@ -59,7 +92,7 @@ export class TodoRepo {
   ): Promise<TodoInterface | null> {
     const kv = await getKv();
     const result = await kv.get<TodoInterface>(["todos", householdId, id]);
-    return result.value;
+    return result.value === null ? null : normalise(result.value);
   }
 
   static async update(

--- a/database/todo.repo.ts
+++ b/database/todo.repo.ts
@@ -5,6 +5,7 @@ import type {
 } from "@/models/index.ts";
 import { getKv } from "./db.ts";
 import { mergeDefinedPatch } from "./merge-patch.ts";
+import { compareTodos } from "@/utils/todo-due.ts";
 
 /**
  * `dueAt` was added after the first to-dos were written, so older records have
@@ -35,7 +36,11 @@ export class TodoRepo {
    * Every consumer gets the same order, so the SSR render and the hydrated view
    * agree and the island only has to bucket: open to-dos first — those with a
    * due moment ordered soonest-first, then undated ones newest-created first —
-   * and finally done ones, most recently done first.
+   * and finally done ones, most recently done first. The full ordering
+   * semantics (and why they're what they are) live on `compareTodos` in
+   * utils/todo-due.ts, which `hooks/useTodos.ts` also uses to re-sort after an
+   * optimistic patch changes a to-do's rank — this method and that hook must
+   * never disagree about order, hence the shared comparator.
    *
    * Dated-ascending-then-undated-newest is what lets `groupOpenTodos` in
    * utils/todo-due.ts bucket in a single pass without sorting: each urgency
@@ -48,42 +53,7 @@ export class TodoRepo {
     const todos: TodoInterface[] = [];
     for await (const { value } of iter) todos.push(normalise(value));
 
-    return todos.sort((a, b) => {
-      const aOpen = a.completedAt === null;
-      const bOpen = b.completedAt === null;
-
-      // Open before done.
-      if (aOpen !== bOpen) return aOpen ? -1 : 1;
-
-      if (aOpen) {
-        const aDated = a.dueAt !== null;
-        const bDated = b.dueAt !== null;
-        // Dated before undated.
-        if (aDated !== bDated) return aDated ? -1 : 1;
-
-        if (aDated) {
-          // Soonest due first.
-          if (a.dueAt !== b.dueAt) return a.dueAt! < b.dueAt! ? -1 : 1;
-          return a.id.localeCompare(b.id);
-        }
-
-        // Undated: newest created first. Plain string comparison, not
-        // localeCompare — two to-dos captured in the same rapid-capture burst
-        // can share a millisecond-precision createdAt, so ties break by id for
-        // a total, stable order; otherwise they'd fall back to KV iteration
-        // order and could swap places relative to the optimistic prepend.
-        if (a.createdAt !== b.createdAt) {
-          return a.createdAt < b.createdAt ? 1 : -1;
-        }
-        return a.id.localeCompare(b.id);
-      }
-
-      // Both done: most recently done first.
-      if (a.completedAt !== b.completedAt) {
-        return a.completedAt! < b.completedAt! ? 1 : -1;
-      }
-      return a.id.localeCompare(b.id);
-    });
+    return todos.sort(compareTodos);
   }
 
   static async getById(

--- a/docs/adr/0001-one-household-backlog-no-todo-lists.md
+++ b/docs/adr/0001-one-household-backlog-no-todo-lists.md
@@ -40,3 +40,17 @@ length-4 keys. This is an accepted bet.
 Grouping arrives as **labels**, not lists — composable with filters and with
 assignment, and there is an existing pattern to follow in
 `DishTagGroupInterface`.
+
+## Update (2026-08-04): one of the rejection arguments has retired
+
+The decision stands, but the first rejection argument above no longer applies. It
+leaned on recurring examples — monthly bills, weekly bins, the yearly dentist —
+to claim that lists solve grouping and not recurrence. Those are **chores**, and
+a to-do is now defined as strictly one-off (see `CONTEXT.md`); recurrence has
+left the to-dos roadmap for a future Chores module with its own model.
+
+The conclusion survives on the two remaining arguments, and the capture-friction
+one is now *stronger*: a to-do exists because a one-off would otherwise be
+forgotten, so making someone choose a container before they can write it down is
+worse here than it would have been for a routine task they were never going to
+forget anyway.

--- a/docs/adr/0003-todos-are-one-off-chores-are-a-separate-module.md
+++ b/docs/adr/0003-todos-are-one-off-chores-are-a-separate-module.md
@@ -1,0 +1,47 @@
+# To-dos are one-off; chores are a separate module
+
+A to-do is something the household needs to do **once** — "book the venue",
+"renew the passport". Routine work that recurs on a schedule — the bins, the
+monthly bills, the yearly dentist appointment — is a **chore**, a different
+concept that Happie will model in its own module. Recurrence has therefore left
+the to-dos roadmap entirely, and to-dos will never grow a recurrence field.
+
+This **reverses** the decision taken when the module was designed, which treated
+a to-do as one concept with recurrence as an optional attribute, on the reasoning
+that "a chore is a to-do that repeats".
+
+## Why the reversal
+
+The original decision was made from examples — bills, bins, appointments — that
+turned out to be chores rather than to-dos. Once that was noticed, the two
+concepts separated cleanly on something more fundamental than whether a date
+repeats:
+
+A **to-do exists because it would otherwise be forgotten.** Its whole purpose is
+remembering, which is why due dates and reminders are the features that make the
+module work at all.
+
+A **chore is driven by its schedule, not by anyone's memory.** Nobody forgets
+that bins happen weekly; the questions a chore raises are *whose turn is it* and
+*was it done since Tuesday* — rotation and history. It also never finishes, so
+"done" means something different: a completion event in a series, not an end.
+
+Those are different aggregates with different fields, different lifecycles and
+different screens. Modelling them as one type means a `recurrence` field that is
+null for most records, a "done" that means two things, and rotation and points
+logic sitting unused on every one-off.
+
+## Consequences
+
+To-dos stay simple: a title, notes, a due moment, and a completion moment.
+
+Because a done to-do is finished forever rather than one occurrence in a series,
+its completion record has little ongoing value — which is what makes windowing
+the Done section to the last seven days cheap rather than lossy.
+
+The first rejection argument in [ADR 0001](./0001-one-household-backlog-no-todo-lists.md)
+relied on the recurring examples and has been retired; that ADR carries an update
+note. Its conclusion still stands.
+
+Chores are unbuilt and unscheduled. When they are built, they get their own
+aggregate — not a flag on `TodoInterface`.

--- a/docs/adr/0004-due-dates-are-utc-instants-timezone-is-presentation.md
+++ b/docs/adr/0004-due-dates-are-utc-instants-timezone-is-presentation.md
@@ -1,0 +1,53 @@
+# Due dates are UTC instants; timezone is presentation only
+
+A to-do's due moment is stored as a single full ISO timestamp in UTC —
+`dueAt: string | null` — not as a calendar date, and not as a date plus a
+separate optional time. Timezone is never stored anywhere: entry and display use
+the **viewer's device timezone**, and nothing on the server needs to know it.
+
+## Why an instant rather than a date
+
+A date-only field (`"2026-08-07"`) is the tempting choice for household work,
+which is day-grained in conversation, and it makes timezone ambiguity
+structurally impossible.
+
+It was rejected because **notifications and reminders are the point of the
+feature.** A notification fires at a moment, so a bare date would have to be
+given a notional time anyway — and midnight, the obvious default, is the worst
+possible one. Reminders make it sharper still: "one week before" is computed
+*from* the due moment, so the due moment has to be a moment.
+
+A date plus an optional time was also rejected: two fields for one concept means
+every display site branches on which it is, and every comparator has to decide
+how an all-day to-do orders against a timed one on the same day. Instead the time
+is always present, defaulted to 09:00 when the user doesn't care, and always
+shown — once notifications exist the time is not decoration, it is when the phone
+will buzz, so hiding it would be dishonest.
+
+## Why timezone is presentation only
+
+Storing the instant means the *stored* value is unambiguous, so the timezone
+question reduces to how it is parsed on the way in and formatted on the way out.
+The device's zone answers both, for free and correctly: everyone in a household
+is in the same house, and `<input type="datetime-local">` resolves local
+wall-clock time natively.
+
+Crucially this keeps notifications correct regardless: whoever sets "18:00" does
+so in their own zone, the instant is absolute, and `Deno.cron` runs in UTC — so
+the future sweep compares instants and needs no timezone knowledge at all.
+
+A per-household timezone setting is a reasonable later refinement for the
+travelling-member case. Because storage is UTC it changes rendering only, needs no
+migration, and is therefore exactly the kind of decision worth deferring.
+
+## Consequences
+
+"Today", "this week" and "overdue" are computed against the **viewer's** clock, so
+two members in different countries can briefly disagree about which section a
+to-do sits under. The set of to-dos and their order are identical either way.
+
+For the same reason, grouping cannot be computed on the server, which does not
+know the viewer's zone. The repository emits a timezone-independent order and a
+pure `groupOpenTodos(todos, now)` function buckets it — the same function on both
+sides, differing only in `now`. Server-rendered and hydrated markup can therefore
+disagree for to-dos due within hours of a boundary, until hydration settles it.

--- a/docs/superpowers/plans/2026-08-04-todo-due-dates.md
+++ b/docs/superpowers/plans/2026-08-04-todo-due-dates.md
@@ -1,0 +1,1683 @@
+# To-do Due Dates Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give a to-do an optional due moment, group the open backlog by urgency, and let a due date be set or changed in one tap from the row.
+
+**Architecture:** One new nullable field (`dueAt`, a UTC instant) threaded through model → repo → API → hook → island. The repo's ordering changes so a single-pass bucketer preserves order inside every section. All date reasoning lives in one pure, unit-tested module (`utils/todo-due.ts`) used by both the SSR loader and the island, because grouping depends on the *viewer's* timezone and the server doesn't know it.
+
+**Tech Stack:** Deno, Fresh 2 (SSR + islands), Preact, `@preact/signals`, Deno KV, Tailwind CSS v4, native `<input type="datetime-local">`, `@std/assert` + `preact-render-to-string` for tests.
+
+**Spec:** [`docs/superpowers/specs/2026-08-04-todo-due-dates-design.md`](../specs/2026-08-04-todo-due-dates-design.md)
+**Decisions of record:** [ADR 0003](../../adr/0003-todos-are-one-off-chores-are-a-separate-module.md) (to-dos are one-off; chores are a separate module), [ADR 0004](../../adr/0004-due-dates-are-utc-instants-timezone-is-presentation.md) (due dates are UTC instants; timezone is presentation only)
+
+## Before you start
+
+Baseline on this branch (`feature/todos-due-dates`, off `main` at `ee43204`): `deno task check` passes and `deno task test` reports **274 passed, 0 failed**. If yours differs, find out why before starting — don't attribute a pre-existing failure to your own work. If `deno check` complains about missing npm packages, run `deno install` once.
+
+## Global Constraints
+
+- **Deno + Fresh 2.** Handlers are `define.handlers({...})` with `define` from `@/utils/index.ts`; context type is `Context` from `"fresh"`, never the deprecated `FreshContext`.
+- **Imports use the `@/` alias** for project root. Repos come from `@/database/index.ts`, models from `@/models/index.ts`, HTTP helpers (`json`, `noContent`, `badRequest`, `notFound`) from `@/utils/index.ts`.
+- **JSX is `precompile`** — write `class`, never `className`.
+- **Never call `Deno.openKv()` directly** — always `getKv()` from `@/database/db.ts`.
+- **Signals:** hooks create state with `signal()` at hook-body level; the island calls the hook inside `useMemo(() => useTodos(initialTodos), [])` so signals are created once. Island-local state uses `useSignal()`. Do not change either.
+- **`dueAt` is a required key with a nullable value** (`string | null`), matching `completedAt` — never optional-and-absent, so every write path states it.
+- **`dueAt` is always stored as a canonical UTC ISO string.** `<input type="datetime-local">` yields *local wall-clock with no zone*, so convert with `new Date(localValue).toISOString()` on the way in, and format from the instant on the way out. Never send the raw input value to the API; never render `dueAt` without converting.
+- **Timezone is never stored.** Entry and display use the viewer's device zone. Nothing on the server knows it.
+- **Grouping is computed at render, not on a timer.** A page left open overnight goes stale until the next interaction, navigation or pull-to-refresh. That is intended.
+- **`mergeDefinedPatch` skips `undefined`, not `null`.** That is what lets `{ dueAt: null }` clear a due date. Never bypass it.
+- **The PATCH allow-list stays an allow-list** — `createdBy` and `createdAt` remain unpatchable.
+- **Copy stays English** and warm enough for a child to read; issue #13 converts the app in one pass.
+- **Existing tests must keep passing untouched.** If an existing assertion needs weakening, the implementation is wrong, not the test.
+- **Conventional Commits.** `deno task check` (`deno fmt --check && deno lint && deno check`) and `deno task test` (`deno test --unstable-kv -A`) must both pass before each commit.
+- **Out of scope, do not build:** notifications, reminders, recurrence (ADR 0003 — it belongs to a future Chores module), assignment, `completedBy`, filters, labels, a review/meeting flow, a per-household timezone or week-boundary setting, a custom MD3 date picker.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| Modify `models/todo/todo.interface.ts` | Add `dueAt` to the interface and `TodoInput`. |
+| Create `utils/todo-due.ts` | **All** date reasoning: grouping boundaries and row formatting. Pure, no DOM, no KV. |
+| Create `utils/todo-due.test.ts` | The bulk of new coverage — boundaries are the feature. |
+| Modify `database/todo.repo.ts` | Read-normalise `dueAt`; change the open-to-do comparator. |
+| Modify `database/todo.repo.test.ts` | Add `dueAt: null` to `draft()`; add dated-ordering cases. |
+| Modify `routes/api/todos/index.ts` | Accept `dueAt` on create. |
+| Modify `routes/api/todos/[id].ts` | Add `dueAt` to the PATCH allow-list. |
+| Modify `routes/api/todos/index.test.ts` | `dueAt` on create, normalisation, validation. |
+| Modify `routes/api/todos/[id].test.ts` | Add `dueAt: null` to `seed()`; patch/clear/validate cases. |
+| Modify `hooks/useTodos.ts` | Add `setDueAt`. |
+| Modify `hooks/useTodos.test.ts` | Add `dueAt: null` to `makeTodo()`; `setDueAt` success + rollback. |
+| Create `islands/todos/DueChip.tsx` | The row's due chip: formatting, overdue colour, the undated affordance. One responsibility, so the island doesn't grow another 60 lines. |
+| Modify `islands/todos/TodoBacklog.tsx` | Sections, the chip wiring, the picker sheet, the Done window. |
+| Modify `islands/todos/TodoBacklog.test.tsx` | Add `dueAt: null` to `todo()`; section headers, chip, Done window. |
+| Modify `routes/todos/index.tsx` | No change to the loader; it already passes the whole ordered list. **Verify only.** |
+
+Task order follows the dependency chain: model → pure date logic → persistence → API → hook → UI. Each task ends green and committed.
+
+---
+
+### Task 1: Add `dueAt` to the model and fix the test helpers
+
+**Files:**
+- Modify: `models/todo/todo.interface.ts`
+- Modify: `database/todo.repo.test.ts` (the `draft()` helper only)
+- Modify: `routes/api/todos/[id].test.ts` (the `seed()` helper only)
+- Modify: `hooks/useTodos.test.ts` (the `makeTodo()` helper only)
+- Modify: `islands/todos/TodoBacklog.test.tsx` (the `todo()` helper only)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `TodoInterface.dueAt: string | null`, and `TodoInput = Pick<TodoInterface, "title" | "notes" | "dueAt">`. `CreateTodoDto` and `UpdateTodoDto` are derived and pick `dueAt` up automatically.
+
+Making `dueAt` a required key **breaks compilation of four test helpers** that build `TodoInterface` / `CreateTodoDto`. Fixing them is part of this task, and each gains `dueAt: null` in its defaults so every existing assertion behaves exactly as before. This task deliberately has no new test of its own — `deno check` plus the untouched 274 are the gate.
+
+- [ ] **Step 1: Add the field**
+
+In `models/todo/todo.interface.ts`, add to `TodoInterface` after `completedAt`:
+
+```ts
+  /**
+   * When this is due, as a UTC instant, or null if it has no due moment.
+   * Always a moment and never just a day — see docs/adr/0004. Entered and
+   * displayed in the viewer's timezone; neither this record nor the server
+   * knows what that zone is.
+   */
+  dueAt: string | null;
+```
+
+- [ ] **Step 2: Let the client send it at capture time**
+
+In the same file, change `TodoInput`:
+
+```ts
+export type TodoInput = Pick<TodoInterface, "title" | "notes" | "dueAt">;
+```
+
+Leave `CreateTodoDto` and `UpdateTodoDto` alone — they are derived from `TodoInterface` and already include `dueAt`.
+
+- [ ] **Step 3: Confirm the breakage is exactly the four helpers**
+
+Run: `deno check`
+Expected: FAIL, with errors pointing at the four helper functions named above (missing property `dueAt`). If any *other* file fails, stop and report it — that means something constructs a to-do somewhere this plan didn't account for.
+
+- [ ] **Step 4: Fix all four helpers**
+
+In `database/todo.repo.test.ts`, add to the object `draft()` returns, before the `...overrides` spread:
+
+```ts
+    dueAt: null,
+```
+
+In `routes/api/todos/[id].test.ts`, add the same line to the object `seed()` passes to `TodoRepo.create`.
+
+In `hooks/useTodos.test.ts`, add the same line to the object `makeTodo()` returns, before its `...over` spread.
+
+In `islands/todos/TodoBacklog.test.tsx`, add the same line to the object `todo()` returns, before its `...over` spread.
+
+In each case the line goes **before** the spread, so a test can still override it.
+
+- [ ] **Step 5: Verify check and the whole suite pass**
+
+Run: `deno task check && deno task test`
+Expected: both PASS, **274 passed** — unchanged, because every helper now supplies `dueAt: null` and no assertion depended on the field.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add models/todo/todo.interface.ts database/todo.repo.test.ts routes/api/todos/[id].test.ts hooks/useTodos.test.ts islands/todos/TodoBacklog.test.tsx
+git commit -m "feat(todos): add dueAt to the Todo model"
+```
+
+---
+
+### Task 2: `utils/todo-due.ts` — grouping and formatting
+
+**Files:**
+- Create: `utils/todo-due.ts`
+- Create: `utils/todo-due.test.ts`
+
+**Interfaces:**
+- Consumes: `TodoInterface` from `@/models/index.ts` (Task 1).
+- Produces:
+  - `type TodoGroupKey = "overdue" | "today" | "thisWeek" | "later" | "noDate"`
+  - `interface TodoGroup { key: TodoGroupKey; todos: TodoInterface[] }`
+  - `groupOpenTodos(todos: TodoInterface[], now: Date): TodoGroup[]` — preserves input order within each group, omits empty groups, returns groups in the fixed order overdue → today → thisWeek → later → noDate
+  - `formatDueAt(dueAt: string, now: Date): string`
+  - `GROUP_LABELS: Record<TodoGroupKey, string>` — the user-facing headers
+  - `isOverdue(dueAt: string | null, now: Date): boolean`
+  - `parseDueAt(raw: unknown): string | null | undefined` — the server-side
+    parser: canonical UTC string, `null` to clear, or `undefined` when unusable
+    so the caller can `400`. It lives here rather than in a route because it is
+    date reasoning, and Task 4's two handlers both need it — a route importing a
+    helper from a sibling route would be the wrong seam.
+
+This module is deliberately **pure**: no DOM, no KV, no signals. That is what makes the boundaries testable without a browser, and the boundaries *are* the feature. It is **not** exported from `utils/index.ts` — that barrel is for cross-cutting helpers, and this is to-do-specific; import it by path, as `hooks/useDishes.ts` and friends are imported by path.
+
+Boundary rules, all evaluated in the local zone of the `now` you are given:
+
+- **overdue** — `dueAt < now`. A to-do due at 09:00 seen at 18:00 is overdue, not today.
+- **today** — `dueAt >= now` and the same local calendar day as `now`.
+- **thisWeek** — after today, through the end of the coming Sunday. **When `now` is itself a Sunday**, that would collapse the group and push Monday into *later* — wrong on the evening a household plans the week — so on a Sunday the window runs to the end of the *following* Sunday.
+- **later** — any dated to-do beyond that.
+- **noDate** — `dueAt === null`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `utils/todo-due.test.ts`:
+
+```ts
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import {
+  formatDueAt,
+  GROUP_LABELS,
+  groupOpenTodos,
+  isOverdue,
+  parseDueAt,
+  type TodoGroupKey,
+} from "./todo-due.ts";
+import type { TodoInterface } from "@/models/index.ts";
+
+// Local-time constructor so these tests are independent of the machine's zone:
+// `new Date(y, m, d, h, min)` interprets its arguments in local time, which is
+// exactly the zone the functions under test reason in.
+const local = (
+  y: number,
+  m: number,
+  d: number,
+  h = 0,
+  min = 0,
+): Date => new Date(y, m - 1, d, h, min, 0, 0);
+
+function todo(id: string, dueAt: string | null, createdAt = "2026-08-01T00:00:00.000Z"): TodoInterface {
+  return {
+    id,
+    householdId: "hh",
+    title: `todo ${id}`,
+    createdBy: "u1",
+    createdAt,
+    completedAt: null,
+    dueAt,
+  };
+}
+
+const keys = (todos: TodoInterface[], now: Date): TodoGroupKey[] =>
+  groupOpenTodos(todos, now).map((g) => g.key);
+
+// ── grouping boundaries ──────────────────────────────────────────────────────
+
+Deno.test("groupOpenTodos — a to-do due earlier today is overdue, not today", () => {
+  const now = local(2026, 8, 5, 18, 0); // Wednesday 18:00
+  const t = todo("a", local(2026, 8, 5, 9, 0).toISOString());
+
+  assertEquals(keys([t], now), ["overdue"]);
+});
+
+Deno.test("groupOpenTodos — a to-do due later today is today", () => {
+  const now = local(2026, 8, 5, 9, 0);
+  const t = todo("a", local(2026, 8, 5, 18, 0).toISOString());
+
+  assertEquals(keys([t], now), ["today"]);
+});
+
+Deno.test("groupOpenTodos — tomorrow through the coming Sunday is thisWeek", () => {
+  const now = local(2026, 8, 5, 9, 0); // Wednesday
+  const thu = todo("a", local(2026, 8, 6, 9, 0).toISOString());
+  const sun = todo("b", local(2026, 8, 9, 23, 0).toISOString()); // Sunday
+
+  assertEquals(keys([thu, sun], now), ["thisWeek"]);
+  assertEquals(groupOpenTodos([thu, sun], now)[0].todos.map((t) => t.id), [
+    "a",
+    "b",
+  ]);
+});
+
+Deno.test("groupOpenTodos — the Monday after the coming Sunday is later", () => {
+  const now = local(2026, 8, 5, 9, 0); // Wednesday
+  const mon = todo("a", local(2026, 8, 10, 9, 0).toISOString());
+
+  assertEquals(keys([mon], now), ["later"]);
+});
+
+Deno.test("groupOpenTodos — on a Sunday, thisWeek covers the week ahead", () => {
+  const now = local(2026, 8, 9, 18, 0); // Sunday evening
+  const mon = todo("a", local(2026, 8, 10, 9, 0).toISOString());
+  const nextSun = todo("b", local(2026, 8, 16, 9, 0).toISOString());
+  const beyond = todo("c", local(2026, 8, 17, 9, 0).toISOString());
+
+  assertEquals(keys([mon, nextSun, beyond], now), ["thisWeek", "later"]);
+  const groups = groupOpenTodos([mon, nextSun, beyond], now);
+  assertEquals(groups[0].todos.map((t) => t.id), ["a", "b"]);
+  assertEquals(groups[1].todos.map((t) => t.id), ["c"]);
+});
+
+Deno.test("groupOpenTodos — undated to-dos land in noDate", () => {
+  const now = local(2026, 8, 5, 9, 0);
+
+  assertEquals(keys([todo("a", null)], now), ["noDate"]);
+});
+
+// ── group mechanics ──────────────────────────────────────────────────────────
+
+Deno.test("groupOpenTodos — empty groups are omitted and order is fixed", () => {
+  const now = local(2026, 8, 5, 12, 0); // Wednesday
+  const list = [
+    todo("late", local(2026, 8, 4, 9, 0).toISOString()),
+    todo("soon", local(2026, 8, 5, 20, 0).toISOString()),
+    todo("far", local(2026, 8, 20, 9, 0).toISOString()),
+    todo("none", null),
+  ];
+
+  assertEquals(keys(list, now), ["overdue", "today", "later", "noDate"]);
+});
+
+Deno.test("groupOpenTodos — input order is preserved inside a group", () => {
+  const now = local(2026, 8, 5, 12, 0);
+  const first = todo("first", local(2026, 8, 6, 9, 0).toISOString());
+  const second = todo("second", local(2026, 8, 7, 9, 0).toISOString());
+
+  const group = groupOpenTodos([first, second], now)[0];
+  assertEquals(group.todos.map((t) => t.id), ["first", "second"]);
+});
+
+Deno.test("groupOpenTodos — an empty input yields no groups", () => {
+  assertEquals(groupOpenTodos([], local(2026, 8, 5)), []);
+});
+
+Deno.test("GROUP_LABELS — every key has a user-facing header", () => {
+  assertEquals(GROUP_LABELS.overdue, "Overdue");
+  assertEquals(GROUP_LABELS.today, "Today");
+  assertEquals(GROUP_LABELS.thisWeek, "This week");
+  assertEquals(GROUP_LABELS.later, "Later");
+  assertEquals(GROUP_LABELS.noDate, "No date");
+});
+
+// ── isOverdue ────────────────────────────────────────────────────────────────
+
+Deno.test("isOverdue — past is overdue, future is not, null never is", () => {
+  const now = local(2026, 8, 5, 12, 0);
+
+  assertEquals(isOverdue(local(2026, 8, 5, 11, 0).toISOString(), now), true);
+  assertEquals(isOverdue(local(2026, 8, 5, 13, 0).toISOString(), now), false);
+  assertEquals(isOverdue(null, now), false);
+});
+
+// ── formatDueAt ──────────────────────────────────────────────────────────────
+
+Deno.test("formatDueAt — always includes the time", () => {
+  const now = local(2026, 8, 5, 12, 0);
+  const out = formatDueAt(local(2026, 8, 7, 9, 0).toISOString(), now);
+
+  assertEquals(out.includes("09"), true);
+});
+
+Deno.test("formatDueAt — omits the year in the current year, includes it otherwise", () => {
+  const now = local(2026, 8, 5, 12, 0);
+
+  const sameYear = formatDueAt(local(2026, 12, 1, 9, 0).toISOString(), now);
+  assertEquals(sameYear.includes("2026"), false);
+
+  const nextYear = formatDueAt(local(2027, 1, 5, 9, 0).toISOString(), now);
+  assertEquals(nextYear.includes("2027"), true);
+});
+
+// ── parseDueAt ───────────────────────────────────────────────────────────────
+
+Deno.test("parseDueAt — null clears, and passes through as null", () => {
+  assertEquals(parseDueAt(null), null);
+});
+
+Deno.test("parseDueAt — canonicalises an offset form to UTC", () => {
+  assertEquals(
+    parseDueAt("2026-08-05T18:00:00+02:00"),
+    "2026-08-05T16:00:00.000Z",
+  );
+});
+
+Deno.test("parseDueAt — leaves an already-canonical instant unchanged", () => {
+  assertEquals(
+    parseDueAt("2026-08-05T16:00:00.000Z"),
+    "2026-08-05T16:00:00.000Z",
+  );
+});
+
+Deno.test("parseDueAt — undefined signals unusable input", () => {
+  assertEquals(parseDueAt("not a date"), undefined);
+  assertEquals(parseDueAt(12345), undefined);
+  assertEquals(parseDueAt(undefined), undefined);
+  assertEquals(parseDueAt({}), undefined);
+});
+```
+
+Add `parseDueAt` to the import list at the top of this test file.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `deno test --unstable-kv -A utils/todo-due.test.ts`
+Expected: FAIL — `Module not found "file:///.../utils/todo-due.ts"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `utils/todo-due.ts`:
+
+```ts
+import type { TodoInterface } from "@/models/index.ts";
+
+/**
+ * All date reasoning for to-do due moments, kept pure and free of DOM, KV and
+ * signals so the boundaries can be tested directly — they are the feature.
+ *
+ * Everything here reasons in the **local zone of the `now` it is handed**.
+ * Grouping cannot be computed on the server, which does not know the viewer's
+ * zone (see docs/adr/0004); the SSR loader and the island therefore call the
+ * same functions with a different `now`, and can briefly disagree about which
+ * group a boundary-adjacent to-do belongs to until hydration settles it.
+ */
+
+export type TodoGroupKey =
+  | "overdue"
+  | "today"
+  | "thisWeek"
+  | "later"
+  | "noDate";
+
+export interface TodoGroup {
+  key: TodoGroupKey;
+  todos: TodoInterface[];
+}
+
+export const GROUP_LABELS: Record<TodoGroupKey, string> = {
+  overdue: "Overdue",
+  today: "Today",
+  thisWeek: "This week",
+  later: "Later",
+  noDate: "No date",
+};
+
+/** Fixed render order — urgent first, undated last. */
+const GROUP_ORDER: TodoGroupKey[] = [
+  "overdue",
+  "today",
+  "thisWeek",
+  "later",
+  "noDate",
+];
+
+export function isOverdue(dueAt: string | null, now: Date): boolean {
+  if (dueAt === null) return false;
+  return new Date(dueAt).getTime() < now.getTime();
+}
+
+/** Local midnight at the start of the day `d` falls on. */
+function startOfDay(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0, 0);
+}
+
+/**
+ * Local midnight ending the "this week" window: the end of the coming Sunday.
+ * When `now` is itself a Sunday the window would collapse to nothing and push
+ * Monday into `later` — wrong on the evening a household plans the week ahead —
+ * so a Sunday extends to the end of the following Sunday.
+ */
+function endOfWeekWindow(now: Date): Date {
+  const day = now.getDay(); // 0 = Sunday
+  const daysUntilSunday = day === 0 ? 7 : 7 - day;
+  const start = startOfDay(now);
+  return new Date(
+    start.getFullYear(),
+    start.getMonth(),
+    start.getDate() + daysUntilSunday + 1,
+  );
+}
+
+function classify(todo: TodoInterface, now: Date): TodoGroupKey {
+  if (todo.dueAt === null) return "noDate";
+  const due = new Date(todo.dueAt);
+  if (due.getTime() < now.getTime()) return "overdue";
+
+  const tomorrow = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate() + 1,
+  );
+  if (due.getTime() < tomorrow.getTime()) return "today";
+  if (due.getTime() < endOfWeekWindow(now).getTime()) return "thisWeek";
+  return "later";
+}
+
+/**
+ * Buckets already-ordered open to-dos by urgency. Preserves input order within
+ * each group — `TodoRepo.getAll` emits dated-ascending then undated-newest
+ * precisely so this single pass needs no sorting of its own — and omits groups
+ * that end up empty.
+ */
+export function groupOpenTodos(
+  todos: TodoInterface[],
+  now: Date,
+): TodoGroup[] {
+  const buckets = new Map<TodoGroupKey, TodoInterface[]>();
+  for (const todo of todos) {
+    const key = classify(todo, now);
+    const bucket = buckets.get(key);
+    if (bucket) bucket.push(todo);
+    else buckets.set(key, [todo]);
+  }
+
+  return GROUP_ORDER
+    .filter((key) => buckets.has(key))
+    .map((key) => ({ key, todos: buckets.get(key)! }));
+}
+
+/**
+ * The row label for a due moment, e.g. "Fri 1 Aug, 09:00". The time is always
+ * included: once notifications exist it is when the phone will buzz, so hiding
+ * it would be dishonest. The year is included only when it differs from `now`'s.
+ * No explicit locale, so the device's is used and issue #13's Dutch conversion
+ * is automatic.
+ */
+export function formatDueAt(dueAt: string, now: Date): string {
+  const due = new Date(dueAt);
+  const date = due.toLocaleDateString(undefined, {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    ...(due.getFullYear() !== now.getFullYear() ? { year: "numeric" } : {}),
+  });
+  const time = due.toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  return `${date}, ${time}`;
+}
+
+/**
+ * Parses a client-supplied due moment. Returns the canonical UTC string, `null`
+ * to clear, or `undefined` when the value is unusable so the caller can 400.
+ *
+ * Canonicalising matters: `TodoRepo.getAll` compares `dueAt` as **strings**, so
+ * an offset form like "2026-08-05T18:00:00+02:00" stored verbatim would sort
+ * wrongly against "…Z" values. `<input type="datetime-local">` also yields a
+ * zoneless local string, which the client converts before sending — this is the
+ * server-side backstop for both.
+ */
+export function parseDueAt(raw: unknown): string | null | undefined {
+  if (raw === null) return null;
+  if (typeof raw !== "string") return undefined;
+  const ms = Date.parse(raw);
+  if (Number.isNaN(ms)) return undefined;
+  return new Date(ms).toISOString();
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `deno test --unstable-kv -A utils/todo-due.test.ts`
+Expected: PASS, 17 passed.
+
+- [ ] **Step 5: Verify check and the whole suite**
+
+Run: `deno task check && deno task test`
+Expected: both PASS, 291 passed (274 + 17).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add utils/todo-due.ts utils/todo-due.test.ts
+git commit -m "feat(todos): add pure due-date grouping and formatting"
+```
+
+---
+
+### Task 3: Repo — normalise `dueAt` on read, order dated to-dos first
+
+**Files:**
+- Modify: `database/todo.repo.ts`
+- Modify: `database/todo.repo.test.ts`
+
+**Interfaces:**
+- Consumes: `TodoInterface` with `dueAt` (Task 1).
+- Produces: `TodoRepo.getAll(householdId)` emits — open dated by `dueAt` **ascending**, then open undated by `createdAt` **descending**, then done by `completedAt` **descending**; ties broken by `id` throughout. Every returned to-do has `dueAt` present (`null` when absent in storage). Method signatures are unchanged.
+
+Two changes, and the ordering one is what makes Task 2's single-pass bucketer correct.
+
+**Read-normalisation.** Records written before `dueAt` existed have no such key, so `value.dueAt` is `undefined` rather than `null`. Normalise once, in the repo, rather than defending at every call site. **No migration is needed** — this is an additive optional field, unlike #42's household-scoping migration.
+
+- [ ] **Step 1: Add the failing tests**
+
+Append to `database/todo.repo.test.ts`:
+
+```ts
+Deno.test({
+  name: "getAll — dated open to-dos come before undated ones, soonest first",
+  sanitizeResources: false,
+  async fn() {
+    const hh = "hh-order-due";
+    await TodoRepo.create(draft(hh, "undated newer", {
+      createdAt: "2026-08-03T10:00:00.000Z",
+    }));
+    await TodoRepo.create(draft(hh, "undated older", {
+      createdAt: "2026-08-01T10:00:00.000Z",
+    }));
+    await TodoRepo.create(draft(hh, "due later", {
+      createdAt: "2026-08-01T10:00:00.000Z",
+      dueAt: "2026-09-01T09:00:00.000Z",
+    }));
+    await TodoRepo.create(draft(hh, "due soon", {
+      createdAt: "2026-08-01T10:00:00.000Z",
+      dueAt: "2026-08-10T09:00:00.000Z",
+    }));
+
+    const all = await TodoRepo.getAll(hh);
+
+    assertEquals(all.map((t) => t.title), [
+      "due soon",
+      "due later",
+      "undated newer",
+      "undated older",
+    ]);
+  },
+});
+
+Deno.test({
+  name: "getAll — ties on identical dueAt break by id for a stable order",
+  sanitizeResources: false,
+  async fn() {
+    const hh = "hh-order-due-tie";
+    const a = await TodoRepo.create(draft(hh, "a", {
+      dueAt: "2026-08-10T09:00:00.000Z",
+    }));
+    const b = await TodoRepo.create(draft(hh, "b", {
+      dueAt: "2026-08-10T09:00:00.000Z",
+    }));
+
+    const all = await TodoRepo.getAll(hh);
+    const expected = [a.id, b.id].sort((x, y) => x.localeCompare(y));
+
+    assertEquals(all.map((t) => t.id), expected);
+  },
+});
+
+Deno.test({
+  name: "getAll — done to-dos stay after every open one, dated or not",
+  sanitizeResources: false,
+  async fn() {
+    const hh = "hh-order-due-done";
+    await TodoRepo.create(draft(hh, "done", {
+      completedAt: "2026-08-04T12:00:00.000Z",
+      dueAt: "2026-08-01T09:00:00.000Z",
+    }));
+    await TodoRepo.create(draft(hh, "open undated"));
+
+    const all = await TodoRepo.getAll(hh);
+
+    assertEquals(all.map((t) => t.title), ["open undated", "done"]);
+  },
+});
+
+Deno.test({
+  name: "getAll — a record stored without dueAt reads back as null",
+  sanitizeResources: false,
+  async fn() {
+    const hh = "hh-legacy";
+    const kv = await getKv();
+    const id = "legacy-1";
+    // Write a pre-dueAt record shape directly, bypassing create().
+    await kv.set(["todos", hh, id], {
+      id,
+      householdId: hh,
+      title: "written before dueAt existed",
+      createdBy: "user-1",
+      createdAt: "2026-07-01T10:00:00.000Z",
+      completedAt: null,
+    });
+
+    const all = await TodoRepo.getAll(hh);
+
+    assertEquals(all.length, 1);
+    assertEquals(all[0].dueAt, null);
+    assertEquals((await TodoRepo.getById(hh, id))?.dueAt, null);
+  },
+});
+
+Deno.test({
+  name: "update — clearing dueAt to null sticks",
+  sanitizeResources: false,
+  async fn() {
+    const hh = "hh-clear-due";
+    const todo = await TodoRepo.create(draft(hh, "Book the venue", {
+      dueAt: "2026-08-10T09:00:00.000Z",
+    }));
+
+    const updated = await TodoRepo.update(hh, todo.id, { dueAt: null });
+
+    assertEquals(updated?.dueAt, null);
+    assertEquals(updated?.title, "Book the venue");
+  },
+});
+```
+
+The last test needs `getKv`. Add it to the imports at the top of the file:
+
+```ts
+import { getKv } from "@/database/db.ts";
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `deno test --unstable-kv -A database/todo.repo.test.ts`
+Expected: FAIL — the dated-ordering test fails (dated to-dos are not yet ordered first) and the legacy-record test fails (`dueAt` reads back `undefined`, not `null`).
+
+- [ ] **Step 3: Normalise on read**
+
+In `database/todo.repo.ts`, add a private normaliser above the class:
+
+```ts
+/**
+ * `dueAt` was added after the first to-dos were written, so older records have
+ * no such key and `value.dueAt` is `undefined`. Normalising here — once, at the
+ * read boundary — keeps every consumer free of `?? null` defensiveness. No
+ * migration is needed: the field is additive and optional in storage.
+ */
+function normalise(value: TodoInterface): TodoInterface {
+  return value.dueAt === undefined ? { ...value, dueAt: null } : value;
+}
+```
+
+Then apply it at both read paths. In `getAll`, change the scan loop:
+
+```ts
+    for await (const { value } of iter) todos.push(normalise(value));
+```
+
+And in `getById`, change the return:
+
+```ts
+    const result = await kv.get<TodoInterface>(["todos", householdId, id]);
+    return result.value === null ? null : normalise(result.value);
+```
+
+- [ ] **Step 4: Change the open-to-do ordering**
+
+Replace `getAll`'s docblock and comparator. The docblock:
+
+```ts
+  /**
+   * Every consumer gets the same order, so the SSR render and the hydrated view
+   * agree and the island only has to bucket: open to-dos first — those with a
+   * due moment ordered soonest-first, then undated ones newest-created first —
+   * and finally done ones, most recently done first.
+   *
+   * Dated-ascending-then-undated-newest is what lets `groupOpenTodos` in
+   * utils/todo-due.ts bucket in a single pass without sorting: each urgency
+   * group comes out ascending, and "No date" keeps the newest-first order that
+   * makes quick capture feel responsive.
+   */
+```
+
+And the comparator body:
+
+```ts
+    return todos.sort((a, b) => {
+      const aOpen = a.completedAt === null;
+      const bOpen = b.completedAt === null;
+
+      // Open before done.
+      if (aOpen !== bOpen) return aOpen ? -1 : 1;
+
+      if (aOpen) {
+        const aDated = a.dueAt !== null;
+        const bDated = b.dueAt !== null;
+        // Dated before undated.
+        if (aDated !== bDated) return aDated ? -1 : 1;
+
+        if (aDated) {
+          // Soonest due first.
+          if (a.dueAt !== b.dueAt) return a.dueAt! < b.dueAt! ? -1 : 1;
+          return a.id.localeCompare(b.id);
+        }
+
+        // Undated: newest created first. Plain string comparison, not
+        // localeCompare — two to-dos captured in the same rapid-capture burst
+        // can share a millisecond-precision createdAt, so ties break by id for
+        // a total, stable order; otherwise they'd fall back to KV iteration
+        // order and could swap places relative to the optimistic prepend.
+        if (a.createdAt !== b.createdAt) {
+          return a.createdAt < b.createdAt ? 1 : -1;
+        }
+        return a.id.localeCompare(b.id);
+      }
+
+      // Both done: most recently done first.
+      if (a.completedAt !== b.completedAt) {
+        return a.completedAt! < b.completedAt! ? 1 : -1;
+      }
+      return a.id.localeCompare(b.id);
+    });
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `deno test --unstable-kv -A database/todo.repo.test.ts`
+Expected: PASS — the five new tests plus all ten pre-existing ones. **The pre-existing ordering tests must pass untouched**: they construct only undated to-dos, which still sort newest-first. If one needs changing to pass, the comparator is wrong — stop and report it.
+
+- [ ] **Step 6: Verify check and the whole suite**
+
+Run: `deno task check && deno task test`
+Expected: both PASS, 296 passed (291 + 5).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add database/todo.repo.ts database/todo.repo.test.ts
+git commit -m "feat(todos): order dated to-dos first and normalise dueAt on read"
+```
+
+---
+
+### Task 4: API — accept and validate `dueAt`
+
+**Files:**
+- Modify: `routes/api/todos/index.ts`
+- Modify: `routes/api/todos/[id].ts`
+- Modify: `routes/api/todos/index.test.ts`
+- Modify: `routes/api/todos/[id].test.ts`
+
+**Interfaces:**
+- Consumes: `TodoRepo` (Task 3); `badRequest` / `json` from `@/utils/index.ts`.
+- Produces the wire contract Task 5 relies on:
+  - `POST /api/todos` accepts an optional `dueAt` — `null`, absent, or a date-parseable string. Stores the **canonical** `new Date(value).toISOString()`. `400` on anything else.
+  - `PATCH /api/todos/:id` accepts `dueAt` in its allow-list with the same rules, including `null` to clear.
+
+Normalising to `toISOString()` rather than storing the raw string matters: a client may legitimately send an offset form like `"2026-08-05T18:00:00+02:00"`, and the repo's comparator compares `dueAt` values as **strings**. Mixed representations of the same instant would sort wrongly. Canonicalising at the boundary keeps every stored value directly comparable.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `routes/api/todos/index.test.ts`:
+
+```ts
+Deno.test({
+  name: "POST accepts a dueAt and stores it canonicalised to UTC",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const created = await (await handler.POST(
+      ctx(
+        post({ title: "Book the venue", dueAt: "2026-08-05T18:00:00+02:00" }),
+        AUTH,
+      ),
+    )).json();
+
+    assertEquals(created.dueAt, "2026-08-05T16:00:00.000Z");
+  },
+});
+
+Deno.test({
+  name: "POST defaults dueAt to null when absent or explicitly null",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const absent = await (await handler.POST(
+      ctx(post({ title: "no date" }), AUTH),
+    )).json();
+    assertEquals(absent.dueAt, null);
+
+    const explicit = await (await handler.POST(
+      ctx(post({ title: "null date", dueAt: null }), AUTH),
+    )).json();
+    assertEquals(explicit.dueAt, null);
+  },
+});
+
+Deno.test({
+  name: "POST rejects a dueAt that is neither null nor a valid date (400)",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    assertEquals(
+      (await handler.POST(
+        ctx(post({ title: "x", dueAt: "not a date" }), AUTH),
+      )).status,
+      400,
+    );
+    assertEquals(
+      (await handler.POST(ctx(post({ title: "x", dueAt: 12345 }), AUTH)))
+        .status,
+      400,
+    );
+  },
+});
+```
+
+Append to `routes/api/todos/[id].test.ts`:
+
+```ts
+Deno.test({
+  name: "PATCH sets dueAt, canonicalising to UTC",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const t = await seed();
+    const updated = await (await handler.PATCH(
+      ctx(patch({ dueAt: "2026-08-05T18:00:00+02:00" }), t.id, AUTH),
+    )).json();
+
+    assertEquals(updated.dueAt, "2026-08-05T16:00:00.000Z");
+  },
+});
+
+Deno.test({
+  name: "PATCH clears dueAt with null",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const t = await TodoRepo.create({
+      householdId: "h1",
+      title: "Book the venue",
+      createdBy: "u1",
+      createdAt: "2026-08-03T10:00:00.000Z",
+      completedAt: null,
+      dueAt: "2026-08-10T09:00:00.000Z",
+    });
+
+    const updated = await (await handler.PATCH(
+      ctx(patch({ dueAt: null }), t.id, AUTH),
+    )).json();
+
+    assertEquals(updated.dueAt, null);
+  },
+});
+
+Deno.test({
+  name: "PATCH rejects an invalid dueAt (400) and leaves the to-do alone",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const t = await seed();
+    assertEquals(
+      (await handler.PATCH(ctx(patch({ dueAt: "nope" }), t.id, AUTH))).status,
+      400,
+    );
+    assertEquals(
+      (await handler.PATCH(ctx(patch({ dueAt: 7 }), t.id, AUTH))).status,
+      400,
+    );
+    assertEquals((await TodoRepo.getById("h1", t.id))?.dueAt, null);
+  },
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `deno test --unstable-kv -A routes/api/todos/`
+Expected: FAIL — `dueAt` comes back `null` where a value was sent (the handlers ignore it), and the invalid-input cases return `201`/`200` instead of `400`.
+
+- [ ] **Step 3: Accept `dueAt` on create**
+
+In `routes/api/todos/index.ts`, add the parser to the imports — it lives in the
+date module from Task 2, not in a route:
+
+```ts
+import { parseDueAt } from "@/utils/todo-due.ts";
+```
+
+Then use it in `POST`, after the `rawNotes` line:
+
+```ts
+    let dueAt: string | null = null;
+    if (body.dueAt !== undefined) {
+      const parsed = parseDueAt(body.dueAt);
+      if (parsed === undefined) {
+        return badRequest("dueAt must be null or a valid date string");
+      }
+      dueAt = parsed;
+    }
+```
+
+and add `dueAt,` to the object passed to `TodoRepo.create`.
+
+- [ ] **Step 4: Add `dueAt` to the PATCH allow-list**
+
+In `routes/api/todos/[id].ts`, import the parser:
+
+```ts
+import { parseDueAt } from "@/utils/todo-due.ts";
+```
+
+Then add a branch after the `completedAt` block, still inside the allow-list:
+
+```ts
+    if (body.dueAt !== undefined) {
+      const parsed = parseDueAt(body.dueAt);
+      if (parsed === undefined) {
+        return badRequest("dueAt must be null or a valid date string");
+      }
+      patch.dueAt = parsed;
+    }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `deno test --unstable-kv -A routes/api/todos/`
+Expected: PASS, 21 passed (15 pre-existing + 6 new).
+
+- [ ] **Step 6: Verify check and the whole suite**
+
+Run: `deno task check && deno task test`
+Expected: both PASS, 302 passed (296 + 6).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add routes/api/todos
+git commit -m "feat(todos): accept and canonicalise dueAt in the API"
+```
+
+---
+
+### Task 5: Hook — `setDueAt`
+
+**Files:**
+- Modify: `hooks/useTodos.ts`
+- Modify: `hooks/useTodos.test.ts`
+
+**Interfaces:**
+- Consumes: `api.todos.update(id, patch)` (unchanged — `UpdateTodoDto` already carries `dueAt`).
+- Produces: `setDueAt(id: string, dueAt: string | null): Promise<boolean>` on the object `useTodos` returns.
+
+`setDueAt` is **optimistic with rollback and an immediate PATCH — never debounced.** Picking a date is a discrete commit, like ticking off, not like typing a title. It needs no exit animation: the to-do stays in the open list, it just moves between groups, which the island re-derives from `openTodos`.
+
+It must also handle a due date being set on a **done** to-do (reachable from the edit sheet, which opens for done to-dos too), so it looks in both lists.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `hooks/useTodos.test.ts`:
+
+```ts
+Deno.test("setDueAt — sets the due moment optimistically", async () => {
+  const patches: unknown[] = [];
+  using _u = stub(api.todos, "update", (_id: string, patch: unknown) => {
+    patches.push(patch);
+    return Promise.resolve(makeTodo());
+  });
+  const hook = useTodos([makeTodo({ id: "t1" })]);
+
+  const ok = await hook.setDueAt("t1", "2026-08-10T09:00:00.000Z");
+
+  assertEquals(ok, true);
+  assertEquals(patches, [{ dueAt: "2026-08-10T09:00:00.000Z" }]);
+  assertEquals(hook.openTodos.value[0].dueAt, "2026-08-10T09:00:00.000Z");
+});
+
+Deno.test("setDueAt — clears the due moment with null", async () => {
+  using _u = stub(
+    api.todos,
+    "update",
+    (_id: string, _patch: unknown) => Promise.resolve(makeTodo()),
+  );
+  const hook = useTodos([
+    makeTodo({ id: "t1", dueAt: "2026-08-10T09:00:00.000Z" }),
+  ]);
+
+  const ok = await hook.setDueAt("t1", null);
+
+  assertEquals(ok, true);
+  assertEquals(hook.openTodos.value[0].dueAt, null);
+});
+
+Deno.test("setDueAt — rolls back and reports failure when the server rejects", async () => {
+  using _u = stub(
+    api.todos,
+    "update",
+    (_id: string, _patch: unknown) => Promise.resolve(null),
+  );
+  const hook = useTodos([makeTodo({ id: "t1", dueAt: null })]);
+
+  const ok = await hook.setDueAt("t1", "2026-08-10T09:00:00.000Z");
+
+  assertEquals(ok, false);
+  assertEquals(hook.openTodos.value[0].dueAt, null);
+});
+
+Deno.test("setDueAt — works on a done to-do", async () => {
+  using _u = stub(
+    api.todos,
+    "update",
+    (_id: string, _patch: unknown) => Promise.resolve(makeTodo()),
+  );
+  const hook = useTodos([
+    makeTodo({ id: "t1", completedAt: "2026-08-02T12:00:00.000Z" }),
+  ]);
+
+  const ok = await hook.setDueAt("t1", "2026-08-10T09:00:00.000Z");
+
+  assertEquals(ok, true);
+  assertEquals(hook.doneTodos.value[0].dueAt, "2026-08-10T09:00:00.000Z");
+});
+
+Deno.test("setDueAt — returns false for an unknown id without calling the api", async () => {
+  const calls: unknown[] = [];
+  using _u = stub(api.todos, "update", (_id: string, patch: unknown) => {
+    calls.push(patch);
+    return Promise.resolve(makeTodo());
+  });
+  const hook = useTodos([makeTodo({ id: "t1" })]);
+
+  assertEquals(await hook.setDueAt("nope", null), false);
+  assertEquals(calls, []);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `deno test --unstable-kv -A hooks/useTodos.test.ts`
+Expected: FAIL — `hook.setDueAt is not a function`.
+
+- [ ] **Step 3: Implement `setDueAt`**
+
+In `hooks/useTodos.ts`, add after `flushTodo`:
+
+```ts
+  /**
+   * Set or clear a to-do's due moment. Optimistic with rollback and an
+   * immediate PATCH — deliberately **not** debounced, because picking a date is
+   * a discrete commit like ticking off, not incremental typing.
+   *
+   * No exit animation: the to-do stays open, it only moves between urgency
+   * groups, and the island derives those from `openTodos`. Works on done to-dos
+   * too, since the edit sheet opens for them.
+   */
+  const setDueAt = async (
+    id: string,
+    dueAt: string | null,
+  ): Promise<boolean> => {
+    const inOpen = openTodos.value.some((t) => t.id === id);
+    const inDone = doneTodos.value.some((t) => t.id === id);
+    if (!inOpen && !inDone) return false;
+
+    const openSnapshot = openTodos.value;
+    const doneSnapshot = doneTodos.value;
+    const apply = (list: TodoInterface[]) =>
+      list.map((t) => (t.id === id ? { ...t, dueAt } : t));
+
+    if (inOpen) openTodos.value = apply(openTodos.value);
+    else doneTodos.value = apply(doneTodos.value);
+
+    startPending();
+    try {
+      const saved = await api.todos.update(id, { dueAt });
+      if (!saved) {
+        openTodos.value = openSnapshot;
+        doneTodos.value = doneSnapshot;
+        return false;
+      }
+      return true;
+    } finally {
+      endPending();
+    }
+  };
+```
+
+Then add `setDueAt,` to the returned object, after `flushTodo,`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `deno test --unstable-kv -A hooks/useTodos.test.ts`
+Expected: PASS, 15 passed (10 pre-existing + 5 new).
+
+- [ ] **Step 5: Verify check and the whole suite**
+
+Run: `deno task check && deno task test`
+Expected: both PASS, 307 passed (302 + 5).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add hooks/useTodos.ts hooks/useTodos.test.ts
+git commit -m "feat(todos): add setDueAt to the useTodos store"
+```
+
+---
+
+### Task 6: `DueChip` component
+
+**Files:**
+- Create: `islands/todos/DueChip.tsx`
+- Create: `islands/todos/DueChip.test.tsx`
+
+**Interfaces:**
+- Consumes: `formatDueAt`, `isOverdue` from `@/utils/todo-due.ts` (Task 2); `Pressable` from `@/components/md3/Pressable.tsx`; `Icon` from `@/components/md3/Icon.tsx`.
+- Produces: default-exported `DueChip({ dueAt, now, onClick }: { dueAt: string | null; now: Date; onClick: () => void })`, consumed by Task 7.
+
+Its own file so `TodoBacklog.tsx` doesn't grow another sixty lines of presentation logic — it already carries the sheets, the primer hand-off and the sections.
+
+Two rules that matter:
+
+**Overdue uses error colour on text and outline, never a filled badge.** `bg-error` is the destructive-action colour in this codebase (the Delete buttons), and borrowing it for "late" would dilute a meaning worth protecting. A screen of overdue to-dos must not become a wall of red.
+
+**The chip needs a real hit area.** It sits inside a row that already has a checkbox and a body tap, so it gets `py-1 px-2` and its own `Pressable` — small chips are the classic mobile mis-tap.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `islands/todos/DueChip.test.tsx`:
+
+```tsx
+import { assertFalse, assertStringIncludes } from "jsr:@std/assert@^1.0.19";
+import { render } from "npm:preact-render-to-string@^6.6.3";
+import { h } from "preact";
+import DueChip from "./DueChip.tsx";
+
+const now = new Date(2026, 7, 5, 12, 0); // 5 Aug 2026, local noon
+
+Deno.test("DueChip — undated shows the add affordance, not a date", () => {
+  const html = render(
+    h(DueChip, { dueAt: null, now, onClick: () => {} }),
+  );
+
+  assertStringIncludes(html, "due");
+  assertFalse(html.includes("Aug"));
+});
+
+Deno.test("DueChip — dated shows the formatted moment including the time", () => {
+  const due = new Date(2026, 7, 7, 9, 0).toISOString();
+  const html = render(h(DueChip, { dueAt: due, now, onClick: () => {} }));
+
+  assertStringIncludes(html, "Aug");
+  assertStringIncludes(html, "09");
+});
+
+Deno.test("DueChip — an overdue moment is rendered in error colour", () => {
+  const past = new Date(2026, 7, 4, 9, 0).toISOString();
+  const html = render(h(DueChip, { dueAt: past, now, onClick: () => {} }));
+
+  assertStringIncludes(html, "text-error");
+});
+
+Deno.test("DueChip — a future moment is not rendered in error colour", () => {
+  const future = new Date(2026, 7, 9, 9, 0).toISOString();
+  const html = render(h(DueChip, { dueAt: future, now, onClick: () => {} }));
+
+  assertFalse(html.includes("text-error"));
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `deno test --unstable-kv -A islands/todos/DueChip.test.tsx`
+Expected: FAIL — `Module not found "file:///.../islands/todos/DueChip.tsx"`.
+
+- [ ] **Step 3: Write the component**
+
+Create `islands/todos/DueChip.tsx`:
+
+```tsx
+import { Pressable } from "@/components/md3/Pressable.tsx";
+import { Icon } from "@/components/md3/Icon.tsx";
+import { formatDueAt, isOverdue } from "@/utils/todo-due.ts";
+
+interface Props {
+  dueAt: string | null;
+  /** Passed in rather than read here so SSR and the island agree on one clock. */
+  now: Date;
+  onClick: () => void;
+}
+
+/**
+ * A to-do's due moment, and the control for changing it.
+ *
+ * Overdue is marked with error colour on text and outline — never a filled
+ * badge. `bg-error` is this codebase's destructive-action colour (the Delete
+ * buttons), so filling a chip with it would both dilute that meaning and turn a
+ * screen of overdue to-dos into a wall of red. The section header does the
+ * structural shouting; the chip only has to be unmistakable once you look at it.
+ */
+export default function DueChip({ dueAt, now, onClick }: Props) {
+  const overdue = isOverdue(dueAt, now);
+  const tone = overdue
+    ? "text-error border-error"
+    : "text-on-surface-variant border-outline-variant";
+
+  return (
+    <Pressable
+      onClick={onClick}
+      aria-label={dueAt ? `Change due date` : "Add a due date"}
+      // py-1/px-2 plus the row's own spacing keeps this above the mobile
+      // mis-tap threshold; it sits beside a checkbox and a full-row tap target.
+      class={`inline-flex items-center gap-1 self-start border rounded-[var(--md-shape-full)] py-1 px-2 md-label-medium ${tone}`}
+    >
+      {dueAt
+        ? (
+          <>
+            <Icon name="calendar" size={13} />
+            {formatDueAt(dueAt, now)}
+          </>
+        )
+        : (
+          <>
+            <Icon name="plus" size={13} />
+            due
+          </>
+        )}
+    </Pressable>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `deno test --unstable-kv -A islands/todos/DueChip.test.tsx`
+Expected: PASS, 4 passed.
+
+- [ ] **Step 5: Verify check and the whole suite**
+
+Run: `deno task check && deno task test`
+Expected: both PASS, 311 passed (307 + 4).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add islands/todos/DueChip.tsx islands/todos/DueChip.test.tsx
+git commit -m "feat(todos): add the DueChip row component"
+```
+
+---
+
+### Task 7: Island — sections, the chip, the picker, the Done window
+
+**Files:**
+- Modify: `islands/todos/TodoBacklog.tsx`
+- Modify: `islands/todos/TodoBacklog.test.tsx`
+
+**Interfaces:**
+- Consumes: `setDueAt` from `useTodos` (Task 5); `groupOpenTodos`, `GROUP_LABELS`, `formatDueAt` from `@/utils/todo-due.ts` (Task 2); `DueChip` (Task 6).
+- Produces: the finished screen. Nothing downstream consumes it.
+
+This is the largest task. Five changes, in order.
+
+**One clock for the whole render.** Read `Date.now()` **once** per render into a local `now`, and pass it to every grouping and formatting call. Calling `new Date()` separately in each helper would let a row and its section header disagree if the render straddles a second.
+
+**Copy the tests assert on, keep exact:** section headers come from `GROUP_LABELS` (`"Overdue"`, `"Today"`, `"This week"`, `"Later"`, `"No date"`), and the Done reveal reads `Show earlier`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `islands/todos/TodoBacklog.test.tsx`. The existing `todo()` helper already gained `dueAt: null` in Task 1; these override it:
+
+```tsx
+Deno.test("TodoBacklog — renders a section header per populated group", () => {
+  const soon = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+  const past = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+  const html = render(h(TodoBacklog, {
+    initialTodos: [
+      todo({ id: "t1", title: "Overdue one", dueAt: past }),
+      todo({ id: "t2", title: "Due later today", dueAt: soon }),
+      todo({ id: "t3", title: "Undated one", dueAt: null }),
+    ],
+  }));
+
+  assertStringIncludes(html, ">Overdue<");
+  assertStringIncludes(html, ">Today<");
+  assertStringIncludes(html, ">No date<");
+  assertStringIncludes(html, "Overdue one");
+  assertStringIncludes(html, "Undated one");
+});
+
+Deno.test("TodoBacklog — omits headers for empty groups", () => {
+  const html = render(h(TodoBacklog, {
+    initialTodos: [todo({ id: "t1", title: "Undated one", dueAt: null })],
+  }));
+
+  assertStringIncludes(html, ">No date<");
+  assertFalse(html.includes(">Overdue<"));
+  assertFalse(html.includes(">This week<"));
+});
+
+Deno.test("TodoBacklog — an undated to-do offers the add-due affordance", () => {
+  const html = render(h(TodoBacklog, {
+    initialTodos: [todo({ id: "t1", dueAt: null })],
+  }));
+
+  assertStringIncludes(html, "Add a due date");
+});
+
+Deno.test("TodoBacklog — Done hides to-dos completed more than 7 days ago", () => {
+  const recent = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+  const old = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+  const html = render(h(TodoBacklog, {
+    initialTodos: [
+      todo({ id: "t1", title: "Done recently", completedAt: recent }),
+      todo({ id: "t2", title: "Done ages ago", completedAt: old }),
+    ],
+  }));
+
+  assertStringIncludes(html, "Done recently");
+  assertFalse(html.includes("Done ages ago"));
+  assertStringIncludes(html, "Show earlier");
+});
+
+Deno.test("TodoBacklog — no Show earlier button when nothing is outside the window", () => {
+  const recent = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+  const html = render(h(TodoBacklog, {
+    initialTodos: [todo({ id: "t1", title: "Done recently", completedAt: recent })],
+  }));
+
+  assertStringIncludes(html, "Done recently");
+  assertFalse(html.includes("Show earlier"));
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `deno test --unstable-kv -A islands/todos/TodoBacklog.test.tsx`
+Expected: FAIL — no section headers, no due affordance, and both done to-dos rendered.
+
+- [ ] **Step 3: Add imports, `setDueAt`, and the render clock**
+
+In `islands/todos/TodoBacklog.tsx`, add to the imports:
+
+```tsx
+import DueChip from "@/islands/todos/DueChip.tsx";
+import { GROUP_LABELS, groupOpenTodos } from "@/utils/todo-due.ts";
+```
+
+Add `setDueAt,` to the destructured `useTodos` result, after `flushTodo,`.
+
+Add three island-local signals beside the existing ones:
+
+```tsx
+  const dueEditingId = useSignal<string | null>(null);
+  const dueDraft = useSignal("");
+  const showEarlierDone = useSignal(false);
+```
+
+Then, immediately after the existing `const exiting = exitingIds.value;`:
+
+```tsx
+  // One clock for the whole render: a row and its section header must never
+  // disagree because the render straddled a second.
+  const now = new Date();
+
+  const groups = groupOpenTodos(open, now);
+
+  // Done is windowed to a rolling 7 days (spec + ADR 0002): a done one-off is
+  // finished forever, so the long tail has almost no value — but this is a
+  // *render* window, not a fetch window. The loader still pulls the whole
+  // backlog, because keys are ["todos", householdId, id] and filtering by
+  // completion date would scan everything anyway.
+  const doneCutoff = now.getTime() - 7 * 24 * 60 * 60 * 1000;
+  const recentDone = done.filter((t) =>
+    new Date(t.completedAt!).getTime() >= doneCutoff
+  );
+  const earlierDoneCount = done.length - recentDone.length;
+  const visibleDone = showEarlierDone.value ? done : recentDone;
+```
+
+- [ ] **Step 4: Add the picker handlers**
+
+Add after `closeEditor`:
+
+```tsx
+  /**
+   * `<input type="datetime-local">` speaks **local wall-clock with no zone**, so
+   * both directions need converting: an existing UTC instant becomes a local
+   * "YYYY-MM-DDTHH:mm" for the input, and the value the user picks becomes a UTC
+   * instant via `new Date(local).toISOString()`. Never round-trip the raw value.
+   */
+  const toLocalInputValue = (iso: string): string => {
+    const d = new Date(iso);
+    const pad = (n: number) => String(n).padStart(2, "0");
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${
+      pad(d.getHours())
+    }:${pad(d.getMinutes())}`;
+  };
+
+  /** 09:00 tomorrow, as the pre-filled default when no due moment is set. A
+   *  household to-do wants telling at the start of a day, and midnight — the
+   *  obvious alternative — is the worst possible moment to be reminded. */
+  const defaultDueInputValue = (): string => {
+    const d = new Date(now);
+    d.setDate(d.getDate() + 1);
+    d.setHours(9, 0, 0, 0);
+    return toLocalInputValue(d.toISOString());
+  };
+
+  const openDuePicker = (id: string, current: string | null) => {
+    dueDraft.value = current
+      ? toLocalInputValue(current)
+      : defaultDueInputValue();
+    dueEditingId.value = id;
+  };
+
+  const commitDue = async () => {
+    const id = dueEditingId.value;
+    const local = dueDraft.value;
+    dueEditingId.value = null;
+    if (!id || !local) return;
+    const ok = await setDueAt(id, new Date(local).toISOString());
+    if (!ok) say("Couldn't save that due date. Try again?");
+  };
+
+  const clearDue = async () => {
+    const id = dueEditingId.value;
+    dueEditingId.value = null;
+    if (!id) return;
+    const ok = await setDueAt(id, null);
+    if (!ok) say("Couldn't remove that due date. Try again?");
+  };
+```
+
+- [ ] **Step 5: Add the chip to the row**
+
+The chip must be **below the title** *and* **outside the body `Pressable`** — below so the row stays readable on a narrow phone, and outside so tapping the chip doesn't also open the edit sheet. Neither alone is enough: a sibling of the body `Pressable` at row level would sit to its *right*, and a child of it would swallow the tap. So the title/notes `Pressable` and the chip become siblings inside a new **text column**.
+
+Replace the body `Pressable` (from `<Pressable onClick={() => (editingId.value = t.id)}` through its closing `</Pressable>`) with:
+
+```tsx
+      <div class="flex-1 min-w-0 flex flex-col gap-1.5 items-start">
+        <Pressable
+          onClick={() => (editingId.value = t.id)}
+          class="w-full text-left"
+        >
+          <div
+            class={`md-body-large ${
+              isDone
+                ? "text-on-surface-variant line-through"
+                : "text-on-surface"
+            }`}
+          >
+            {t.title}
+          </div>
+          {t.notes && (
+            <div class="md-body-small text-on-surface-variant truncate">
+              📝 {t.notes}
+            </div>
+          )}
+        </Pressable>
+        <DueChip
+          dueAt={t.dueAt}
+          now={now}
+          onClick={() => openDuePicker(t.id, t.dueAt)}
+        />
+      </div>
+```
+
+The row's outer `class="flex items-start gap-3 px-1 py-2.5"` is unchanged, and the `flex-1 min-w-0` that used to sit on the `Pressable` moves to the new column so long titles still truncate rather than pushing the layout wide.
+
+- [ ] **Step 6: Replace the flat Open list with grouped sections**
+
+Replace this block:
+
+```tsx
+              {open.length > 0 && (
+                <div class="flex flex-col">
+                  {open.map((t) => row(t, false))}
+                </div>
+              )}
+```
+
+with:
+
+```tsx
+              {groups.map((g) => (
+                <div key={g.key} class="flex flex-col gap-1">
+                  <div class="md-label-medium uppercase text-on-surface-variant px-1 pt-2">
+                    {GROUP_LABELS[g.key]}
+                  </div>
+                  {g.todos.map((t) => row(t, false))}
+                </div>
+              ))}
+```
+
+- [ ] **Step 7: Window the Done section**
+
+Replace this block:
+
+```tsx
+              {done.length > 0 && (
+                <div class="flex flex-col gap-1">
+                  <div class="md-label-medium uppercase text-on-surface-variant px-1 pt-2">
+                    Done
+                  </div>
+                  {done.map((t) => row(t, true))}
+                </div>
+              )}
+```
+
+with:
+
+```tsx
+              {visibleDone.length > 0 && (
+                <div class="flex flex-col gap-1">
+                  <div class="md-label-medium uppercase text-on-surface-variant px-1 pt-2">
+                    Done
+                  </div>
+                  {visibleDone.map((t) => row(t, true))}
+                  {earlierDoneCount > 0 && !showEarlierDone.value && (
+                    <Pressable
+                      onClick={() => (showEarlierDone.value = true)}
+                      class="self-start md-label-large text-primary px-1 py-2"
+                    >
+                      Show earlier ({earlierDoneCount})
+                    </Pressable>
+                  )}
+                </div>
+              )}
+```
+
+- [ ] **Step 8: Add the picker sheet**
+
+Add a fourth `Sheet` just before the closing `<Snackbar ... />`, following the same body-gating the create sheet uses:
+
+```tsx
+      {/* Due-date picker. Native <input type="datetime-local"> rather than a
+          custom MD3 picker: on mobile it opens the platform's own control,
+          which is familiar, accessible and localised for free, and resolves
+          local wall-clock time natively — exactly what docs/adr/0004 needs. */}
+      <Sheet
+        open={dueEditingId.value !== null}
+        onClose={() => (dueEditingId.value = null)}
+        title="When is it due?"
+      >
+        {dueEditingId.value !== null && (
+          <div class="flex flex-col gap-3 pb-1">
+            <input
+              type="datetime-local"
+              value={dueDraft.value}
+              onInput={(e) => (dueDraft.value = e.currentTarget.value)}
+              aria-label="Due date and time"
+              class="w-full md-body-large text-on-surface bg-surface-chigh border-0 rounded-[var(--md-shape-lg)] py-3 px-4 outline-none"
+            />
+            <Button variant="filled" full onClick={commitDue}>Save</Button>
+            <Button variant="text" full onClick={clearDue}>
+              Remove due date
+            </Button>
+          </div>
+        )}
+      </Sheet>
+```
+
+- [ ] **Step 9: Disable pull-to-refresh while the picker is open**
+
+The existing `PullToRefresh` already guards the other three sheets. Add the fourth, or a drag inside the picker will refresh the list and discard the draft:
+
+```tsx
+      disabled={createOpen.value || editingId.value !== null ||
+        confirmingId.value !== null || dueEditingId.value !== null}
+```
+
+- [ ] **Step 10: Run tests to verify they pass**
+
+Run: `deno test --unstable-kv -A islands/todos/TodoBacklog.test.tsx`
+Expected: PASS, 9 passed (4 pre-existing + 5 new).
+
+- [ ] **Step 11: Verify check and the whole suite**
+
+Run: `deno task check && deno task test`
+Expected: both PASS, 316 passed (311 + 5).
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add islands/todos/TodoBacklog.tsx islands/todos/TodoBacklog.test.tsx
+git commit -m "feat(todos): group the backlog by urgency and add the due picker"
+```
+
+---
+
+### Task 8: Verify end to end in the browser
+
+**Files:**
+- Verify only: `routes/todos/index.tsx` (should need **no** change — it already passes the whole ordered list to the island)
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: nothing. This task is proof.
+
+- [ ] **Step 1: Confirm the loader needs no change**
+
+Read `routes/todos/index.tsx`. It calls `TodoRepo.getAll(householdId)` and passes the result as `initialTodos`. Grouping happens in the island, so **no change is required**. If you find yourself wanting to group in the loader, re-read ADR 0004 — the server does not know the viewer's timezone.
+
+- [ ] **Step 2: Confirm check and the full suite are green**
+
+Run: `deno task check && deno task test`
+Expected: both PASS, 316 passed.
+
+- [ ] **Step 3: Start the dev server**
+
+Use the project's preview tooling (`.claude/launch.json` has a `dev-wt` entry for worktrees). Do **not** run a dev server with a raw shell command.
+
+- [ ] **Step 4: Walk the journey**
+
+Confirm each, in order:
+
+1. `/todos` renders with existing to-dos under a **No date** header (they have no `dueAt` yet).
+2. Tap a row's `＋ due` chip → the picker sheet opens, pre-filled with 09:00 tomorrow.
+3. Save → the row moves under **This week** (or **Later**), and the chip shows the formatted moment *including the time*.
+4. Reload → the grouping, the chip and the time all survive (SSR and hydration agree).
+5. Set a to-do's due moment to a time earlier today → it appears under **Overdue**, and the chip is in error colour — **not** a filled red badge.
+6. Set one to later today → it appears under **Today**, chip in normal colour.
+7. Tap the chip on a dated to-do → the picker opens pre-filled with that moment, not the default.
+8. Tap **Remove due date** → the to-do returns to **No date** and the chip reverts to `＋ due`.
+9. Tap the row **body** (not the chip) → the *edit* sheet opens, not the picker. Then tap the chip → the picker opens, not the editor. Both must work independently.
+10. Tick off a dated to-do → it leaves its group and lands under **Done**.
+11. Drag downward inside an open picker sheet → the list must **not** pull-to-refresh.
+
+**Use real pointer events, not programmatic `.click()`.** During iteration 1 a synthetic click twice reported a passing focus behaviour that was actually broken — untrusted events don't run the browser's default actions.
+
+- [ ] **Step 5: Report the result and stop the dev server**
+
+If everything passes, report done with the observations. If anything fails, report it as a finding rather than patching past it — a failure here likely means a boundary rule in `utils/todo-due.ts` is wrong, which is a unit-test-level fix, not a UI tweak.
+
+---
+
+## Verification before calling this done
+
+- [ ] `deno task check` passes
+- [ ] `deno task test` passes: **316** (274 baseline + 42 new)
+- [ ] The pre-existing repo ordering tests were **not modified** — only `draft()` gained `dueAt: null`
+- [ ] The 11-step journey in Task 8 was walked with real pointer events, not assumed
+- [ ] No file outside the File Structure table was modified
+
+## Deliberately not built
+
+Re-read before adding anything: notifications, reminders, recurrence (ADR 0003 — future Chores module), assignment, `completedBy`, filters, labels, a meeting/review flow, a per-household timezone or week-boundary setting, a custom MD3 date picker, and any change to `services/api.ts` (`dueAt` rides the existing DTOs).

--- a/docs/superpowers/plans/2026-08-04-todo-due-dates.md
+++ b/docs/superpowers/plans/2026-08-04-todo-due-dates.md
@@ -1626,6 +1626,8 @@ git commit -m "feat(todos): group the backlog by urgency and add the due picker"
 
 ### Task 8: Verify end to end in the browser
 
+> **This task is the controller's, not a subagent's.** Browser and preview tooling belong to the orchestrating session; a subagent cannot open the app. Do not dispatch this one — run it yourself after Task 7's review comes back clean.
+
 **Files:**
 - Verify only: `routes/todos/index.tsx` (should need **no** change — it already passes the whole ordered list to the island)
 

--- a/docs/superpowers/plans/2026-08-04-todo-due-dates.md
+++ b/docs/superpowers/plans/2026-08-04-todo-due-dates.md
@@ -1689,3 +1689,176 @@ If everything passes, report done with the observations. If anything fails, repo
 ## Deliberately not built
 
 Re-read before adding anything: notifications, reminders, recurrence (ADR 0003 — future Chores module), assignment, `completedBy`, filters, labels, a meeting/review flow, a per-household timezone or week-boundary setting, a custom MD3 date picker, and any change to `services/api.ts` (`dueAt` rides the existing DTOs).
+
+---
+
+### Task 9: Due controls in the create and edit sheets
+
+**Files:**
+- Modify: `islands/todos/TodoBacklog.tsx`
+- Modify: `hooks/useTodos.ts`
+- Modify: `hooks/useTodos.test.ts`
+
+**Interfaces:**
+- Consumes: `toLocalInputValue` (already in the island), `setDueAt` and `addTodo` from `useTodos`, `compareTodos` from `@/utils/todo-due.ts`.
+- Produces: no new exported surface. `addTodo`'s signature is unchanged — `TodoInput` already carries `dueAt`.
+
+Grilling Q5 chose "edit sheet + create sheet + a chip on the row". Only the chip was built; the spec's scope line says three places. This task closes that, and fixes a bug the change creates.
+
+**The bug it creates, which must be fixed in the same task.** `addTodo` currently prepends the created to-do to `openTodos`. That was correct only because a new to-do was always undated, and undated to-dos sort newest-first — so the front was its rightful place. **Once the create sheet can set a due date, a new to-do can be dated**, and prepending puts it at the front of a list whose order is `compareTodos`. That is the same defect the final review found in `setDueAt`. Sort after adopting the server's record.
+
+**Why the controls are plain inline inputs rather than the picker sheet.** The picker is itself a `Sheet`; opening it from inside the create or edit sheet would stack sheet on sheet. Both these surfaces are already open modals with room for a field, so they get an inline `<input type="datetime-local">` — the same native control, no new component, no nesting.
+
+**Commit semantics differ between the two, deliberately.** In the create sheet the value is part of the not-yet-created to-do, so it is held in island state and passed to `addTodo`. In the edit sheet the to-do already exists, so a change is a discrete commit through `setDueAt` — the same reasoning that kept `setDueAt` out of the debounced text scheduler. Use `onChange` (fires when a complete value is committed), not `onInput`.
+
+- [ ] **Step 1: Write the failing hook tests**
+
+Add to `hooks/useTodos.test.ts`:
+
+```ts
+Deno.test("addTodo — a dated new to-do lands in dueAt order, not at the front", async () => {
+  const created = makeTodo({ id: "new", dueAt: "2026-08-20T09:00:00.000Z" });
+  using _c = stub(
+    api.todos,
+    "create",
+    (_input: unknown) => Promise.resolve(created),
+  );
+  const hook = useTodos([
+    makeTodo({ id: "sooner", dueAt: "2026-08-10T09:00:00.000Z" }),
+    makeTodo({ id: "later", dueAt: "2026-08-25T09:00:00.000Z" }),
+  ]);
+
+  await hook.addTodo({
+    title: "new",
+    notes: undefined,
+    dueAt: "2026-08-20T09:00:00.000Z",
+  });
+
+  assertEquals(hook.openTodos.value.map((t) => t.id), [
+    "sooner",
+    "new",
+    "later",
+  ]);
+});
+
+Deno.test("addTodo — an undated new to-do still goes to the front of the undated tail", async () => {
+  const created = makeTodo({
+    id: "new",
+    dueAt: null,
+    createdAt: "2026-08-05T12:00:00.000Z",
+  });
+  using _c = stub(
+    api.todos,
+    "create",
+    (_input: unknown) => Promise.resolve(created),
+  );
+  const hook = useTodos([
+    makeTodo({ id: "dated", dueAt: "2026-08-10T09:00:00.000Z" }),
+    makeTodo({ id: "older", dueAt: null, createdAt: "2026-08-01T09:00:00.000Z" }),
+  ]);
+
+  await hook.addTodo({ title: "new", notes: undefined, dueAt: null });
+
+  assertEquals(hook.openTodos.value.map((t) => t.id), [
+    "dated",
+    "new",
+    "older",
+  ]);
+});
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `deno test --unstable-kv -A hooks/useTodos.test.ts`
+Expected: FAIL — the dated case comes back `["new","sooner","later"]` because `addTodo` prepends.
+
+- [ ] **Step 3: Sort in `addTodo`**
+
+In `hooks/useTodos.ts`, in `addTodo`, replace the prepend with a sorted insert:
+
+```ts
+      const created = await api.todos.create(input);
+      if (created) {
+        // Sort rather than prepend: a new to-do can now carry a dueAt (set in
+        // the create sheet), so the front is not automatically its place. Same
+        // invariant setDueAt and unTick maintain — array position IS the order.
+        openTodos.value = [...openTodos.value, created].sort(compareTodos);
+      }
+      return created;
+```
+
+- [ ] **Step 4: Run them to verify they pass**
+
+Run: `deno test --unstable-kv -A hooks/useTodos.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Add the create-sheet due control**
+
+In `islands/todos/TodoBacklog.tsx`, add a signal beside `newTitle` / `newNotes`:
+
+```tsx
+  const newDue = useSignal("");
+```
+
+Clear it wherever `newTitle` / `newNotes` are cleared — in `openCreate` and after a successful save in `submitNew` — so rapid capture starts each to-do fresh.
+
+In `submitNew`, pass it through:
+
+```tsx
+    const created = await addTodo({
+      title,
+      notes: notes || undefined,
+      dueAt: newDue.value ? new Date(newDue.value).toISOString() : null,
+    });
+```
+
+And add the field inside the create sheet's gated body, after the notes textarea and before the Add button:
+
+```tsx
+            <input
+              type="datetime-local"
+              value={newDue.value}
+              onChange={(e) => (newDue.value = e.currentTarget.value)}
+              aria-label="Due date and time (optional)"
+              class="w-full md-body-large text-on-surface bg-surface-chigh border-0 rounded-[var(--md-shape-lg)] py-3 px-4 outline-none"
+            />
+```
+
+Empty means no due date — do not pre-fill it, because most captured to-dos have no deadline and a pre-filled date would silently attach one.
+
+- [ ] **Step 6: Add the edit-sheet due control**
+
+In the edit sheet's body, after the notes textarea and before the Done button:
+
+```tsx
+              <input
+                type="datetime-local"
+                value={t.dueAt ? toLocalInputValue(t.dueAt) : ""}
+                onChange={async (e) => {
+                  const v = e.currentTarget.value;
+                  const ok = await setDueAt(
+                    t.id,
+                    v ? new Date(v).toISOString() : null,
+                  );
+                  if (!ok) say("Couldn't save that due date. Try again?");
+                }}
+                aria-label="Due date and time"
+                class="w-full md-body-large text-on-surface bg-surface-chigh border-0 rounded-[var(--md-shape-lg)] py-3 px-4 outline-none"
+              />
+```
+
+Clearing the field sets `null`, which is how a due date is removed from this surface.
+
+- [ ] **Step 7: Verify check and the whole suite**
+
+Run: `deno task check && deno task test`
+Expected: both PASS, 324 passed (322 + 2).
+
+There is no SSR assertion for either input: both sheets gate their bodies on being open, so neither renders in a server-rendered page. The hook tests above cover the ordering consequence, and the controller verifies the wiring in the browser.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add islands/todos/TodoBacklog.tsx hooks/useTodos.ts hooks/useTodos.test.ts
+git commit -m "feat(todos): set a due date from the create and edit sheets"
+```

--- a/docs/superpowers/plans/2026-08-04-todo-due-dates.md
+++ b/docs/superpowers/plans/2026-08-04-todo-due-dates.md
@@ -67,12 +67,18 @@ Task order follows the dependency chain: model → pure date logic → persisten
 - Modify: `routes/api/todos/[id].test.ts` (the `seed()` helper only)
 - Modify: `hooks/useTodos.test.ts` (the `makeTodo()` helper only)
 - Modify: `islands/todos/TodoBacklog.test.tsx` (the `todo()` helper only)
+- Modify: `routes/api/todos/index.ts` (one line — see Step 4b)
+- Modify: `islands/todos/TodoBacklog.tsx` (one line — see Step 4b)
 
 **Interfaces:**
 - Consumes: nothing.
 - Produces: `TodoInterface.dueAt: string | null`, and `TodoInput = Pick<TodoInterface, "title" | "notes" | "dueAt">`. `CreateTodoDto` and `UpdateTodoDto` are derived and pick `dueAt` up automatically.
 
-Making `dueAt` a required key **breaks compilation of four test helpers** that build `TodoInterface` / `CreateTodoDto`. Fixing them is part of this task, and each gains `dueAt: null` in its defaults so every existing assertion behaves exactly as before. This task deliberately has no new test of its own — `deno check` plus the untouched 274 are the gate.
+Making `dueAt` a required key **breaks compilation in six places**: four test helpers that build `TodoInterface` / `CreateTodoDto`, and two runtime call sites that construct a to-do. Fixing all six is part of this task — otherwise the branch stays red until Task 4 and Task 7, and every task must end green. Each gains a bare `dueAt: null`, so behaviour is identical (a to-do created today has no due moment) and every existing assertion behaves exactly as before.
+
+The two runtime edits are deliberately placeholders that later tasks replace: Task 4 swaps the API one for a parsed client value, Task 7 swaps the island one for the picker's. **Do not build any date logic here.**
+
+This task deliberately has no new test of its own — `deno check` plus the untouched 274 are the gate.
 
 - [ ] **Step 1: Add the field**
 

--- a/docs/superpowers/specs/2026-08-04-todo-due-dates-design.md
+++ b/docs/superpowers/specs/2026-08-04-todo-due-dates-design.md
@@ -1,0 +1,334 @@
+# To-do due dates — iteration 3
+
+**Status:** approved, ready for an implementation plan
+**Date:** 2026-08-04
+**Module:** To-dos (`/todos`) — builds on iteration 1 (merged, PR #62)
+
+## Summary
+
+A to-do gains an optional **due moment**: `dueAt`, a full UTC instant. The flat
+Open list becomes urgency-grouped sections, each row carries a due chip that
+doubles as the control for setting or changing the date, and overdue to-dos are
+marked without being shouted at.
+
+This is the iteration that makes the module do its stated job — helping a
+household remember one-off things — with notifications and reminders following
+immediately after to complete it.
+
+## What changed in the domain since iteration 1
+
+Iteration 1 defined a to-do as covering both the one-off and the routine, with
+recurrence planned as an attribute. **That was wrong and has been reversed:** a
+to-do is strictly one-off, and routine recurring work is a **chore**, a separate
+concept for a future module. See
+[ADR 0003](../../adr/0003-todos-are-one-off-chores-are-a-separate-module.md), the
+update note on [ADR 0001](../../adr/0001-one-household-backlog-no-todo-lists.md),
+and the `To-do` / `Chore` entries in [`CONTEXT.md`](../../../CONTEXT.md).
+
+This matters here because it changes what due dates are *for*. A one-off with a
+deadline is the canonical case, and remembering is the purpose — which is why
+reminders are the next iteration rather than a nice-to-have, and why windowing the
+Done section is cheap.
+
+New glossary terms: **Due**, **Overdue**.
+
+## Decisions of record
+
+- [ADR 0003](../../adr/0003-todos-are-one-off-chores-are-a-separate-module.md) —
+  to-dos are one-off; chores are a separate module
+- [ADR 0004](../../adr/0004-due-dates-are-utc-instants-timezone-is-presentation.md)
+  — due dates are UTC instants; timezone is presentation only
+
+Not given an ADR: the native picker (easily reversed — one component) and the
+grouped-sections layout (presentation, reversible). Both are argued below.
+
+## Scope
+
+### In iteration 3
+
+- `dueAt: string | null` on `TodoInterface`, plus the DTO changes
+- Setting, changing and clearing a due moment from three places: the create sheet,
+  the edit sheet, and a chip on the row
+- Urgency-grouped Open sections: **Overdue → Today → This week → Later → No date**
+- Overdue marked with error colour on the chip
+- Done section windowed to the last 7 days, with "Show earlier (N)"
+- A pure, unit-tested `groupOpenTodos(todos, now)` and a `formatDueAt(dueAt, now)`
+- Repo ordering updated so a single-pass bucketer preserves order
+
+### Out of iteration 3
+
+| Iteration | Deferred work | Why it waits |
+| --- | --- | --- |
+| 4 | Notifications and reminders | Infrastructure with platform caveats; can't be verified in a browser preview. Needs VAPID keys, a push subscription store, a `push` handler in `static/pwa-sw.js` (currently pure Workbox caching), and a `Deno.cron` sweep |
+| 5 | Assignment, `completedBy`, filters | Still hard-blocked on issue #17 |
+| 6 | Labels | The birthday-party grouping case |
+| later | A review flow for the household's weekly meeting | A view over existing data; additive |
+| later | Per-household timezone, and a week boundary aligned to the meeting day | Both presentation-only settings; no household settings screen exists yet |
+| never (here) | Recurrence | ADR 0003 — belongs to a future Chores module |
+
+### Notes for the notifications iteration
+
+Two things learned while designing this one, recorded so that iteration doesn't
+start from the wrong primitive:
+
+- **Deno KV queues are not supported on the new Deno Deploy**, which this project
+  targets (commit `73e8091`). The "enqueue a delayed job when the due date is set"
+  design is unavailable. `Deno.cron` *is* supported identically, so the shape is a
+  periodic sweep — which is also more robust, since editing or deleting a to-do
+  needs no queue cleanup.
+- **A single `notifiedAt` marker is insufficient.** With reminders, one to-do has
+  several fire-points (a week before, a day before, the due moment). Tracking needs
+  to be per-fire-point.
+
+## Data model
+
+`models/todo/todo.interface.ts` gains one field:
+
+```ts
+export interface TodoInterface {
+  // ...unchanged
+  /**
+   * When this is due, as a UTC instant, or null if it has no due moment. Always
+   * a moment and never just a day — see docs/adr/0004. Read and written in the
+   * viewer's timezone; nothing here or on the server knows what that zone is.
+   */
+  dueAt: string | null;
+}
+```
+
+`TodoInput` gains `dueAt` so it can be set at capture time:
+
+```ts
+export type TodoInput = Pick<TodoInterface, "title" | "notes" | "dueAt">;
+```
+
+`CreateTodoDto` and `UpdateTodoDto` are derived and need no edit. `dueAt` is a
+**required key with a nullable value**, matching `completedAt`, so every write
+path states it.
+
+### Existing records
+
+`POST` composes `dueAt: null` when absent. Records written before this change have
+no `dueAt` key at all, so reads must treat `undefined` and `null` alike. Rather
+than scatter that, the repo normalises on read:
+`dueAt: value.dueAt ?? null`. **No migration is needed** — this is an additive
+optional field, unlike the household-scoping migration in #42.
+
+## Ordering and grouping
+
+This is the part with a real constraint, so it is specified precisely.
+
+**The sort is timezone-independent; the grouping is not.** "Due at
+`2026-08-05T16:00:00Z`" sorts identically everywhere, but whether that is *today*
+depends on the viewer's zone, which the server does not know on first request
+(ADR 0004). So the two are split:
+
+**`TodoRepo.getAll` owns the order** (unchanged principle from iteration 1 —
+callers never sort). The open-to-do ordering **changes**:
+
+| Position | Rule |
+| --- | --- |
+| Open, dated | first, by `dueAt` **ascending** (soonest first) |
+| Open, undated | after all dated, by `createdAt` **descending** (newest first) |
+| Done | after all open, by `completedAt` **descending** |
+
+Ties broken by `id` throughout, as the existing comparator already does.
+
+Ordering dated-ascending-then-undated-newest is what lets a **single-pass
+bucketer** preserve the right order inside every section for free: the dated
+prefix arrives soonest-first so Overdue/Today/This week/Later each come out
+ascending, and the undated tail arrives newest-first so **No date** keeps
+iteration 1's quick-capture feedback intact.
+
+**This changes behaviour the existing repo tests assert.** Iteration 1's ordering
+tests expect open to-dos newest-created first. Those expectations must be
+**updated to the new contract**, not deleted — and new cases added for dated
+ordering and the dated/undated boundary.
+
+**`groupOpenTodos(todos, now)`** is a new pure function in
+`utils/todo-due.ts`, used by both the SSR loader and the island so both render
+the same markup:
+
+```ts
+export type TodoGroupKey = "overdue" | "today" | "thisWeek" | "later" | "noDate";
+
+export interface TodoGroup {
+  key: TodoGroupKey;
+  todos: TodoInterface[];
+}
+
+/** Buckets already-ordered open to-dos by urgency relative to `now`, in the
+ *  timezone `now` is expressed in. Preserves input order within each group and
+ *  omits empty groups. */
+export function groupOpenTodos(
+  todos: TodoInterface[],
+  now: Date,
+): TodoGroup[];
+```
+
+Boundaries, all in the viewer's local zone:
+
+- **overdue** — `dueAt < now`. Includes earlier today. A to-do due at 09:00 seen
+  at 18:00 is overdue, not today.
+- **today** — `dueAt >= now` and on the same local calendar day as `now`
+- **thisWeek** — after today, up to and including the **end of the coming Sunday**.
+  Calendar weeks, not "within 7 days", because a household thinks in weeks.
+  **When `now` is itself a Sunday**, that rule would collapse the group to nothing
+  and push Monday into *later*, which reads wrongly on the very evening a
+  household is most likely to be planning the week ahead. So on a Sunday the
+  window extends to the end of the *following* Sunday, and the group always spans
+  the week ahead.
+- **later** — any dated to-do beyond that
+- **noDate** — `dueAt === null`
+
+Groups are computed at render. A page left open overnight goes stale until the
+next interaction, navigation or pull-to-refresh; **no ticking timer** — the
+staleness is cosmetic and a timer in an island is a cost with no benefit here.
+
+Because the server buckets with its own clock (UTC on Deploy) and the client with
+the device's, SSR and hydrated markup can put a boundary-adjacent to-do under
+different headers until hydration settles it. The set and order are identical
+either way. This is the accepted consequence in ADR 0004.
+
+## Formatting
+
+**`formatDueAt(dueAt, now)`** in `utils/todo-due.ts`, pure and unit-tested,
+returns the compact row label. Rules:
+
+- Always include the time: `"Fri 1 Aug, 09:00"`
+- Omit the year unless `dueAt` falls in a different calendar year from `now`
+- Use the device locale (no explicit locale argument) so issue #13's Dutch
+  conversion is automatic
+
+The app's only existing date helper is `relativeTime` in
+`islands/shopping-lists.tsx:24` — local, unexported, and relative-only, so it
+cannot serve an absolute due date. It is **left alone**; extracting and sharing it
+is not this iteration's job.
+
+## API
+
+No new routes. Two handler changes in `routes/api/todos/`:
+
+- `POST /api/todos` accepts an optional `dueAt` in the body and composes
+  `dueAt: null` when absent
+- `PATCH /api/todos/[id]` adds `dueAt` to its allow-list
+
+Validation, matching the strictness the existing handlers settled on: `dueAt` must
+be either `null` or a string that parses to a valid date; anything else is `400`.
+The handler stores the normalised `new Date(value).toISOString()` rather than the
+raw string, so a client sending an offset form (`"2026-08-05T18:00:00+02:00"`)
+lands as a canonical UTC instant.
+
+The `PATCH` allow-list stays an allow-list — `createdBy` and `createdAt` remain
+unpatchable.
+
+## Client and state
+
+`services/api.ts` — no change. `TodoInput` and `UpdateTodoDto` already flow
+through `api.todos.create` / `update`, and `dueAt` rides along.
+
+`hooks/useTodos.ts`:
+
+- `addTodo(input: TodoInput)` — already takes the input type; now carries `dueAt`
+- **`setDueAt(id, dueAt: string | null): Promise<boolean>`** — new. Optimistic
+  with rollback and an immediate `PATCH`, **not** debounced: picking a date is a
+  discrete commit, like ticking off, not typing.
+- Setting a due date can move a to-do between groups, which the island derives
+  from `openTodos`, so no extra signal is needed
+- The `openTodos` / `doneTodos` partition is unchanged
+
+The existing mutation conventions hold: pessimistic create, debounced optimistic
+text edits, optimistic tick/delete with rollback, failures surfaced by return
+value and a `Snackbar`.
+
+## UI
+
+`islands/todos/TodoBacklog.tsx`:
+
+**Rows** gain a due chip below the title, beside the existing notes hint. Dated:
+`formatDueAt` output. Overdue: same text in **error colour on text and outline,
+never a filled badge** — `bg-error` is the destructive-action colour in this
+codebase (the Delete buttons) and that meaning is worth protecting. Undated: a
+quiet `＋ due` affordance. Only the chip changes colour, never the row, so a
+screen of overdue items doesn't become a wall of red and titles stay comfortable
+to read.
+
+The chip is its own tap target opening the picker directly. The row already has a
+checkbox and a body tap, so the chip needs a real hit area (≥44px effective) and
+must not swallow the body tap.
+
+**Sections** replace the flat Open list: `Overdue → Today → This week → Later →
+No date`, then Done. Rendered **only when non-empty**, matching how Done already
+behaves. Headers use the same `md-label-medium uppercase` treatment as the
+existing Done header.
+
+**Done** shows only to-dos completed in the last 7 days — a **rolling**
+`completedAt >= now - 7×24h`, not "since last Monday", so it needs no local-day
+reasoning and no timezone at all — with a `Show earlier (N)` text button revealing
+the rest. This is a **render** window, not a fetch window:
+the loader still pulls the whole backlog, because keys are
+`["todos", householdId, id]` and filtering by completion date would scan
+everything anyway. If payload ever hurts, the fix is a date-bearing index or an
+archive keyspace — decided against real data, not guessed now.
+
+**The picker** is a native `<input type="datetime-local">`, with the *trigger*
+styled on-brand. On mobile this opens the platform's own picker: familiar to every
+family member including children, accessible and localised for free, and it
+resolves local wall-clock time natively — which is exactly what ADR 0004 needs.
+A compliant MD3 date picker (calendar grid, month paging, time selection, focus
+management) is plausibly as much work as the rest of this iteration, for a control
+the platform already provides better on the target device. The accepted cost: it
+looks foreign next to the MD3 library on desktop, where the native control is
+inline rather than a sheet.
+
+Clearing is a **"Remove due date"** action in the picker surface, not a gesture on
+the row — removing should take marginally more deliberation than setting.
+
+Copy stays English and warm; issue #13 converts the app in one pass.
+
+## Testing
+
+- `utils/todo-due.test.ts` — the bulk of the new coverage, and pure so it needs
+  no browser: each boundary (overdue vs today, today vs this week, the Sunday
+  edge, `now` already Sunday, undated), order preservation within groups, empty
+  groups omitted, and `formatDueAt`'s year-omission and time-always rules
+- `database/todo.repo.test.ts` — **update** the existing open-ordering
+  expectations to the new contract, and add dated-ascending, the dated/undated
+  boundary, and `dueAt` surviving a partial update
+- `routes/api/todos/index.test.ts` / `[id].test.ts` — `dueAt` on create, patching
+  it, clearing it to `null`, offset-form normalisation to UTC, and `400` for a
+  non-date
+- `hooks/useTodos.test.ts` — `setDueAt` success, and rollback when the server
+  rejects
+- `islands/todos/TodoBacklog.test.tsx` — SSR shows section headers for populated
+  groups only, a due chip, the `＋ due` affordance, and the Done window
+- `deno task check` and `deno task test` green. Baseline on this branch: **274
+  passing**
+
+## Known hazards
+
+1. **Reading records written before `dueAt` existed.** Normalise in the repo
+   (`value.dueAt ?? null`), once, rather than defending at every call site.
+2. **The repo's ordering change is a behaviour change.** Existing tests assert the
+   old order; update them deliberately to the new contract. A test that has to be
+   *weakened* to pass means the contract is wrong, not the test.
+3. **`datetime-local` speaks local wall-clock, not UTC.** Its value has no zone,
+   so converting is `new Date(localValue).toISOString()` on the way in and a
+   locale-formatted local render on the way out. Never hand its raw value to the
+   API and never render `dueAt` without converting.
+4. **The chip must not steal the row's body tap.** Nested tap targets are how the
+   row becomes frustrating; verify both independently in the browser.
+
+## Verification
+
+The browser checks that matter, on top of the suite: a to-do set due earlier today
+appears under **Overdue** and not Today; a to-do due later today appears under
+**Today**; the Sunday boundary puts a to-do in *This week* rather than *Later*;
+the chip opens the picker and the row body still opens the edit sheet; clearing a
+due date moves the to-do to **No date**; and a reload preserves grouping, chips
+and the Done window.
+
+Verify taps with **real pointer events**, not programmatic `.click()`. During
+iteration 1 a synthetic click twice reported a passing focus behaviour that was
+actually broken — untrusted events don't run the browser's default actions, so
+they never move focus the way a genuine press does.

--- a/docs/superpowers/specs/2026-08-04-todo-due-dates-design.md
+++ b/docs/superpowers/specs/2026-08-04-todo-due-dates-design.md
@@ -140,10 +140,20 @@ prefix arrives soonest-first so Overdue/Today/This week/Later each come out
 ascending, and the undated tail arrives newest-first so **No date** keeps
 iteration 1's quick-capture feedback intact.
 
-**This changes behaviour the existing repo tests assert.** Iteration 1's ordering
-tests expect open to-dos newest-created first. Those expectations must be
-**updated to the new contract**, not deleted — and new cases added for dated
-ordering and the dated/undated boundary.
+**The existing repo ordering tests keep passing unchanged**, and must not be
+touched. They construct only undated to-dos, and undated to-dos still sort
+newest-created first — the new rule only reorders to-dos that *have* a `dueAt`.
+New cases are **added** for dated-ascending order and the dated/undated boundary.
+If an existing ordering test ever needs weakening to pass, the comparator is
+wrong, not the test.
+
+What the type change does break is compilation of the **test helpers**: once
+`dueAt` is a required key, every helper that builds a `TodoInterface` or
+`CreateTodoDto` must supply it. Four of them do:
+`draft()` in `database/todo.repo.test.ts`, `seed()` in
+`routes/api/todos/[id].test.ts`, `makeTodo()` in `hooks/useTodos.test.ts`, and
+`todo()` in `islands/todos/TodoBacklog.test.tsx`. Each gains `dueAt: null` in its
+defaults, which leaves every existing assertion behaving exactly as before.
 
 **`groupOpenTodos(todos, now)`** is a new pure function in
 `utils/todo-due.ts`, used by both the SSR loader and the island so both render

--- a/hooks/useTodos.test.ts
+++ b/hooks/useTodos.test.ts
@@ -241,3 +241,76 @@ Deno.test("editTodo — persists a non-blank title after the debounce", async ()
   assertEquals(patches, [{ title: "Take out the recycling" }]);
   assertEquals(hook.openTodos.value[0].title, "Take out the recycling");
 });
+
+Deno.test("setDueAt — sets the due moment optimistically", async () => {
+  const patches: unknown[] = [];
+  using _u = stub(api.todos, "update", (_id: string, patch: unknown) => {
+    patches.push(patch);
+    return Promise.resolve(makeTodo());
+  });
+  const hook = useTodos([makeTodo({ id: "t1" })]);
+
+  const ok = await hook.setDueAt("t1", "2026-08-10T09:00:00.000Z");
+
+  assertEquals(ok, true);
+  assertEquals(patches, [{ dueAt: "2026-08-10T09:00:00.000Z" }]);
+  assertEquals(hook.openTodos.value[0].dueAt, "2026-08-10T09:00:00.000Z");
+});
+
+Deno.test("setDueAt — clears the due moment with null", async () => {
+  using _u = stub(
+    api.todos,
+    "update",
+    (_id: string, _patch: unknown) => Promise.resolve(makeTodo()),
+  );
+  const hook = useTodos([
+    makeTodo({ id: "t1", dueAt: "2026-08-10T09:00:00.000Z" }),
+  ]);
+
+  const ok = await hook.setDueAt("t1", null);
+
+  assertEquals(ok, true);
+  assertEquals(hook.openTodos.value[0].dueAt, null);
+});
+
+Deno.test("setDueAt — rolls back and reports failure when the server rejects", async () => {
+  using _u = stub(
+    api.todos,
+    "update",
+    (_id: string, _patch: unknown) => Promise.resolve(null),
+  );
+  const hook = useTodos([makeTodo({ id: "t1", dueAt: null })]);
+
+  const ok = await hook.setDueAt("t1", "2026-08-10T09:00:00.000Z");
+
+  assertEquals(ok, false);
+  assertEquals(hook.openTodos.value[0].dueAt, null);
+});
+
+Deno.test("setDueAt — works on a done to-do", async () => {
+  using _u = stub(
+    api.todos,
+    "update",
+    (_id: string, _patch: unknown) => Promise.resolve(makeTodo()),
+  );
+  const hook = useTodos([
+    makeTodo({ id: "t1", completedAt: "2026-08-02T12:00:00.000Z" }),
+  ]);
+
+  const ok = await hook.setDueAt("t1", "2026-08-10T09:00:00.000Z");
+
+  assertEquals(ok, true);
+  assertEquals(hook.doneTodos.value[0].dueAt, "2026-08-10T09:00:00.000Z");
+});
+
+Deno.test("setDueAt — returns false for an unknown id without calling the api", async () => {
+  const calls: unknown[] = [];
+  using _u = stub(api.todos, "update", (_id: string, patch: unknown) => {
+    calls.push(patch);
+    return Promise.resolve(makeTodo());
+  });
+  const hook = useTodos([makeTodo({ id: "t1" })]);
+
+  assertEquals(await hook.setDueAt("nope", null), false);
+  assertEquals(calls, []);
+});

--- a/hooks/useTodos.test.ts
+++ b/hooks/useTodos.test.ts
@@ -13,6 +13,7 @@ function makeTodo(over: Partial<TodoInterface> = {}): TodoInterface {
     createdBy: "u1",
     createdAt: "2026-08-03T10:00:00.000Z",
     completedAt: null,
+    dueAt: null,
     ...over,
   };
 }

--- a/hooks/useTodos.test.ts
+++ b/hooks/useTodos.test.ts
@@ -314,3 +314,68 @@ Deno.test("setDueAt — returns false for an unknown id without calling the api"
   assertEquals(await hook.setDueAt("nope", null), false);
   assertEquals(calls, []);
 });
+
+Deno.test("setDueAt — dating a previously-undated to-do places it in dueAt order among siblings, not at the end", async () => {
+  using _u = stub(
+    api.todos,
+    "update",
+    (_id: string, _patch: unknown) => Promise.resolve(makeTodo()),
+  );
+  const hook = useTodos([
+    makeTodo({ id: "a", dueAt: "2026-08-06T09:00:00.000Z" }),
+    makeTodo({ id: "b", dueAt: "2026-08-20T09:00:00.000Z" }),
+    // Undated to-dos sort after dated ones (TodoRepo.getAll's order), so "c"
+    // starts in the tail position.
+    makeTodo({ id: "c", dueAt: null, createdAt: "2026-08-04T10:00:00.000Z" }),
+  ]);
+
+  // Due moment sits between a's and b's — "c" must move to the middle, not
+  // stay at its stale tail array position.
+  const ok = await hook.setDueAt("c", "2026-08-10T09:00:00.000Z");
+
+  assertEquals(ok, true);
+  assertEquals(hook.openTodos.value.map((t) => t.id), ["a", "c", "b"]);
+});
+
+Deno.test("setDueAt — re-dating a dated to-do moves it to the right position among its siblings", async () => {
+  using _u = stub(
+    api.todos,
+    "update",
+    (_id: string, _patch: unknown) => Promise.resolve(makeTodo()),
+  );
+  const hook = useTodos([
+    makeTodo({ id: "a", dueAt: "2026-08-06T09:00:00.000Z" }),
+    makeTodo({ id: "b", dueAt: "2026-08-10T09:00:00.000Z" }),
+    makeTodo({ id: "c", dueAt: "2026-08-20T09:00:00.000Z" }),
+  ]);
+
+  // "a" starts earliest (array position 0) but is re-dated later than both
+  // siblings — it must move to the end, not keep its stale index.
+  const ok = await hook.setDueAt("a", "2026-08-25T09:00:00.000Z");
+
+  assertEquals(ok, true);
+  assertEquals(hook.openTodos.value.map((t) => t.id), ["b", "c", "a"]);
+});
+
+Deno.test("unTick — a reopened dated to-do lands in dueAt order among open dated to-dos, not at the front", async () => {
+  using _u = stub(
+    api.todos,
+    "update",
+    (_id: string, _patch: unknown) => Promise.resolve(makeTodo()),
+  );
+  const hook = useTodos([
+    makeTodo({ id: "a", dueAt: "2026-08-06T09:00:00.000Z" }),
+    makeTodo({ id: "b", dueAt: "2026-08-20T09:00:00.000Z" }),
+    makeTodo({
+      id: "c",
+      dueAt: "2026-08-10T09:00:00.000Z",
+      completedAt: "2026-08-02T12:00:00.000Z",
+    }),
+  ]);
+
+  const ok = await hook.unTick("c");
+
+  assertEquals(ok, true);
+  assertEquals(hook.doneTodos.value, []);
+  assertEquals(hook.openTodos.value.map((t) => t.id), ["a", "c", "b"]);
+});

--- a/hooks/useTodos.test.ts
+++ b/hooks/useTodos.test.ts
@@ -379,3 +379,57 @@ Deno.test("unTick — a reopened dated to-do lands in dueAt order among open dat
   assertEquals(hook.doneTodos.value, []);
   assertEquals(hook.openTodos.value.map((t) => t.id), ["a", "c", "b"]);
 });
+
+Deno.test("addTodo — a dated new to-do lands in dueAt order, not at the front", async () => {
+  const created = makeTodo({ id: "new", dueAt: "2026-08-20T09:00:00.000Z" });
+  using _c = stub(
+    api.todos,
+    "create",
+    (_input: unknown) => Promise.resolve(created),
+  );
+  const hook = useTodos([
+    makeTodo({ id: "sooner", dueAt: "2026-08-10T09:00:00.000Z" }),
+    makeTodo({ id: "later", dueAt: "2026-08-25T09:00:00.000Z" }),
+  ]);
+
+  await hook.addTodo({
+    title: "new",
+    notes: undefined,
+    dueAt: "2026-08-20T09:00:00.000Z",
+  });
+
+  assertEquals(hook.openTodos.value.map((t) => t.id), [
+    "sooner",
+    "new",
+    "later",
+  ]);
+});
+
+Deno.test("addTodo — an undated new to-do still goes to the front of the undated tail", async () => {
+  const created = makeTodo({
+    id: "new",
+    dueAt: null,
+    createdAt: "2026-08-05T12:00:00.000Z",
+  });
+  using _c = stub(
+    api.todos,
+    "create",
+    (_input: unknown) => Promise.resolve(created),
+  );
+  const hook = useTodos([
+    makeTodo({ id: "dated", dueAt: "2026-08-10T09:00:00.000Z" }),
+    makeTodo({
+      id: "older",
+      dueAt: null,
+      createdAt: "2026-08-01T09:00:00.000Z",
+    }),
+  ]);
+
+  await hook.addTodo({ title: "new", notes: undefined, dueAt: null });
+
+  assertEquals(hook.openTodos.value.map((t) => t.id), [
+    "dated",
+    "new",
+    "older",
+  ]);
+});

--- a/hooks/useTodos.ts
+++ b/hooks/useTodos.ts
@@ -126,6 +126,45 @@ export function useTodos(initialTodos: TodoInterface[]) {
     restoreBlankTitle(id);
   };
 
+  /**
+   * Set or clear a to-do's due moment. Optimistic with rollback and an
+   * immediate PATCH — deliberately **not** debounced, because picking a date is
+   * a discrete commit like ticking off, not incremental typing.
+   *
+   * No exit animation: the to-do stays open, it only moves between urgency
+   * groups, and the island derives those from `openTodos`. Works on done to-dos
+   * too, since the edit sheet opens for them.
+   */
+  const setDueAt = async (
+    id: string,
+    dueAt: string | null,
+  ): Promise<boolean> => {
+    const inOpen = openTodos.value.some((t) => t.id === id);
+    const inDone = doneTodos.value.some((t) => t.id === id);
+    if (!inOpen && !inDone) return false;
+
+    const openSnapshot = openTodos.value;
+    const doneSnapshot = doneTodos.value;
+    const apply = (list: TodoInterface[]) =>
+      list.map((t) => (t.id === id ? { ...t, dueAt } : t));
+
+    if (inOpen) openTodos.value = apply(openTodos.value);
+    else doneTodos.value = apply(doneTodos.value);
+
+    startPending();
+    try {
+      const saved = await api.todos.update(id, { dueAt });
+      if (!saved) {
+        openTodos.value = openSnapshot;
+        doneTodos.value = doneSnapshot;
+        return false;
+      }
+      return true;
+    } finally {
+      endPending();
+    }
+  };
+
   const tickOff = async (id: string): Promise<boolean> => {
     // A second tap during the exit animation (ordinary on mobile) must not
     // start a second run — the row stays in openTodos for EXIT_MS on purpose,
@@ -251,6 +290,7 @@ export function useTodos(initialTodos: TodoInterface[]) {
     addTodo,
     editTodo,
     flushTodo,
+    setDueAt,
     tickOff,
     unTick,
     removeTodo,

--- a/hooks/useTodos.ts
+++ b/hooks/useTodos.ts
@@ -81,7 +81,12 @@ export function useTodos(initialTodos: TodoInterface[]) {
     startPending();
     try {
       const created = await api.todos.create(input);
-      if (created) openTodos.value = [created, ...openTodos.value];
+      if (created) {
+        // Sort rather than prepend: a new to-do can now carry a dueAt (set in
+        // the create sheet), so the front is not automatically its place. Same
+        // invariant setDueAt and unTick maintain — array position IS the order.
+        openTodos.value = [...openTodos.value, created].sort(compareTodos);
+      }
       return created;
     } finally {
       endPending();

--- a/hooks/useTodos.ts
+++ b/hooks/useTodos.ts
@@ -3,6 +3,7 @@ import type { TodoInput, TodoInterface } from "@/models/index.ts";
 import { api } from "@/services/api.ts";
 import { createDebouncedMergeScheduler } from "@/utils/debounce-update.ts";
 import { beginBusy, endBusy } from "@/utils/loading.ts";
+import { compareTodos } from "@/utils/todo-due.ts";
 
 type TodoEdit = { title?: string; notes?: string };
 
@@ -134,6 +135,11 @@ export function useTodos(initialTodos: TodoInterface[]) {
    * No exit animation: the to-do stays open, it only moves between urgency
    * groups, and the island derives those from `openTodos`. Works on done to-dos
    * too, since the edit sheet opens for them.
+   *
+   * Changing `dueAt` changes the to-do's rank (`compareTodos`), so a plain
+   * `.map` that preserves array position would leave the list mis-ordered
+   * until the next reload — re-sort with the same comparator `TodoRepo.getAll`
+   * uses so the optimistic state matches what a refresh would produce.
    */
   const setDueAt = async (
     id: string,
@@ -146,7 +152,7 @@ export function useTodos(initialTodos: TodoInterface[]) {
     const openSnapshot = openTodos.value;
     const doneSnapshot = doneTodos.value;
     const apply = (list: TodoInterface[]) =>
-      list.map((t) => (t.id === id ? { ...t, dueAt } : t));
+      list.map((t) => (t.id === id ? { ...t, dueAt } : t)).sort(compareTodos);
 
     if (inOpen) openTodos.value = apply(openTodos.value);
     else doneTodos.value = apply(doneTodos.value);
@@ -219,7 +225,11 @@ export function useTodos(initialTodos: TodoInterface[]) {
     const reopened = { ...todo, completedAt: null };
 
     doneTodos.value = doneTodos.value.filter((t) => t.id !== id);
-    openTodos.value = [reopened, ...openTodos.value];
+    // A reopened to-do's rank among open ones depends on whether it's dated
+    // (dueAt-ascending) or not (newest-created-first) — a plain prepend is
+    // only correct by accident for an undated to-do, so re-sort with the
+    // same comparator TodoRepo.getAll uses instead of assuming the front.
+    openTodos.value = [...openTodos.value, reopened].sort(compareTodos);
 
     startPending();
     try {

--- a/islands/todos/DueChip.test.tsx
+++ b/islands/todos/DueChip.test.tsx
@@ -1,0 +1,37 @@
+import { assertFalse, assertStringIncludes } from "jsr:@std/assert@^1.0.19";
+import { render } from "npm:preact-render-to-string@^6.6.3";
+import { h } from "preact";
+import DueChip from "./DueChip.tsx";
+
+const now = new Date(2026, 7, 5, 12, 0); // 5 Aug 2026, local noon
+
+Deno.test("DueChip — undated shows the add affordance, not a date", () => {
+  const html = render(
+    h(DueChip, { dueAt: null, now, onClick: () => {} }),
+  );
+
+  assertStringIncludes(html, "due");
+  assertFalse(html.includes("Aug"));
+});
+
+Deno.test("DueChip — dated shows the formatted moment including the time", () => {
+  const due = new Date(2026, 7, 7, 9, 0).toISOString();
+  const html = render(h(DueChip, { dueAt: due, now, onClick: () => {} }));
+
+  assertStringIncludes(html, "Aug");
+  assertStringIncludes(html, "09");
+});
+
+Deno.test("DueChip — an overdue moment is rendered in error colour", () => {
+  const past = new Date(2026, 7, 4, 9, 0).toISOString();
+  const html = render(h(DueChip, { dueAt: past, now, onClick: () => {} }));
+
+  assertStringIncludes(html, "text-error");
+});
+
+Deno.test("DueChip — a future moment is not rendered in error colour", () => {
+  const future = new Date(2026, 7, 9, 9, 0).toISOString();
+  const html = render(h(DueChip, { dueAt: future, now, onClick: () => {} }));
+
+  assertFalse(html.includes("text-error"));
+});

--- a/islands/todos/DueChip.tsx
+++ b/islands/todos/DueChip.tsx
@@ -20,31 +20,37 @@ interface Props {
  */
 export default function DueChip({ dueAt, now, onClick }: Props) {
   const overdue = isOverdue(dueAt, now);
-  const tone = overdue
-    ? "text-error border-error"
-    : "text-on-surface-variant border-outline-variant";
+  const textTone = overdue ? "text-error" : "text-on-surface-variant";
+  const borderTone = overdue ? "border-error" : "border-outline-variant";
 
   return (
     <Pressable
       onClick={onClick}
-      aria-label={dueAt ? `Change due date` : "Add a due date"}
-      // py-1/px-2 plus the row's own spacing keeps this above the mobile
-      // mis-tap threshold; it sits beside a checkbox and a full-row tap target.
-      class={`inline-flex items-center gap-1 self-start border rounded-[var(--md-shape-full)] py-1 px-2 md-label-medium ${tone}`}
+      aria-label={dueAt ? "Change due date" : "Add a due date"}
+      // The visible pill (the inner span below) stays exactly its previous
+      // size — the padding here is invisible: no border, no background, just
+      // room around it. It only grows the *tap target* to a real ≥44px
+      // effective height; it sits beside a checkbox and a full-row tap
+      // target, so 26px of visible chip alone would be an easy mis-tap.
+      class={`inline-flex items-center self-start rounded-[var(--md-shape-full)] py-2.5 ${textTone}`}
     >
-      {dueAt
-        ? (
-          <>
-            <Icon name="calendar" size={13} />
-            {formatDueAt(dueAt, now)}
-          </>
-        )
-        : (
-          <>
-            <Icon name="plus" size={13} />
-            due
-          </>
-        )}
+      <span
+        class={`inline-flex items-center gap-1 border rounded-[var(--md-shape-full)] py-1 px-2 md-label-medium ${textTone} ${borderTone}`}
+      >
+        {dueAt
+          ? (
+            <>
+              <Icon name="calendar" size={13} />
+              {formatDueAt(dueAt, now)}
+            </>
+          )
+          : (
+            <>
+              <Icon name="plus" size={13} />
+              due
+            </>
+          )}
+      </span>
     </Pressable>
   );
 }

--- a/islands/todos/DueChip.tsx
+++ b/islands/todos/DueChip.tsx
@@ -1,0 +1,50 @@
+import { Pressable } from "@/components/md3/Pressable.tsx";
+import { Icon } from "@/components/md3/Icon.tsx";
+import { formatDueAt, isOverdue } from "@/utils/todo-due.ts";
+
+interface Props {
+  dueAt: string | null;
+  /** Passed in rather than read here so SSR and the island agree on one clock. */
+  now: Date;
+  onClick: () => void;
+}
+
+/**
+ * A to-do's due moment, and the control for changing it.
+ *
+ * Overdue is marked with error colour on text and outline — never a filled
+ * badge. `bg-error` is this codebase's destructive-action colour (the Delete
+ * buttons), so filling a chip with it would both dilute that meaning and turn a
+ * screen of overdue to-dos into a wall of red. The section header does the
+ * structural shouting; the chip only has to be unmistakable once you look at it.
+ */
+export default function DueChip({ dueAt, now, onClick }: Props) {
+  const overdue = isOverdue(dueAt, now);
+  const tone = overdue
+    ? "text-error border-error"
+    : "text-on-surface-variant border-outline-variant";
+
+  return (
+    <Pressable
+      onClick={onClick}
+      aria-label={dueAt ? `Change due date` : "Add a due date"}
+      // py-1/px-2 plus the row's own spacing keeps this above the mobile
+      // mis-tap threshold; it sits beside a checkbox and a full-row tap target.
+      class={`inline-flex items-center gap-1 self-start border rounded-[var(--md-shape-full)] py-1 px-2 md-label-medium ${tone}`}
+    >
+      {dueAt
+        ? (
+          <>
+            <Icon name="calendar" size={13} />
+            {formatDueAt(dueAt, now)}
+          </>
+        )
+        : (
+          <>
+            <Icon name="plus" size={13} />
+            due
+          </>
+        )}
+    </Pressable>
+  );
+}

--- a/islands/todos/TodoBacklog.test.tsx
+++ b/islands/todos/TodoBacklog.test.tsx
@@ -67,3 +67,66 @@ Deno.test("TodoBacklog — create sheet's title input does not rely on the bare 
   // output.
   assertFalse(html.includes("autofocus"));
 });
+
+Deno.test("TodoBacklog — renders a section header per populated group", () => {
+  const soon = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+  const past = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+  const html = render(h(TodoBacklog, {
+    initialTodos: [
+      todo({ id: "t1", title: "Overdue one", dueAt: past }),
+      todo({ id: "t2", title: "Due later today", dueAt: soon }),
+      todo({ id: "t3", title: "Undated one", dueAt: null }),
+    ],
+  }));
+
+  assertStringIncludes(html, ">Overdue<");
+  assertStringIncludes(html, ">Today<");
+  assertStringIncludes(html, ">No date<");
+  assertStringIncludes(html, "Overdue one");
+  assertStringIncludes(html, "Undated one");
+});
+
+Deno.test("TodoBacklog — omits headers for empty groups", () => {
+  const html = render(h(TodoBacklog, {
+    initialTodos: [todo({ id: "t1", title: "Undated one", dueAt: null })],
+  }));
+
+  assertStringIncludes(html, ">No date<");
+  assertFalse(html.includes(">Overdue<"));
+  assertFalse(html.includes(">This week<"));
+});
+
+Deno.test("TodoBacklog — an undated to-do offers the add-due affordance", () => {
+  const html = render(h(TodoBacklog, {
+    initialTodos: [todo({ id: "t1", dueAt: null })],
+  }));
+
+  assertStringIncludes(html, "Add a due date");
+});
+
+Deno.test("TodoBacklog — Done hides to-dos completed more than 7 days ago", () => {
+  const recent = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+  const old = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+  const html = render(h(TodoBacklog, {
+    initialTodos: [
+      todo({ id: "t1", title: "Done recently", completedAt: recent }),
+      todo({ id: "t2", title: "Done ages ago", completedAt: old }),
+    ],
+  }));
+
+  assertStringIncludes(html, "Done recently");
+  assertFalse(html.includes("Done ages ago"));
+  assertStringIncludes(html, "Show earlier");
+});
+
+Deno.test("TodoBacklog — no Show earlier button when nothing is outside the window", () => {
+  const recent = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+  const html = render(h(TodoBacklog, {
+    initialTodos: [
+      todo({ id: "t1", title: "Done recently", completedAt: recent }),
+    ],
+  }));
+
+  assertStringIncludes(html, "Done recently");
+  assertFalse(html.includes("Show earlier"));
+});

--- a/islands/todos/TodoBacklog.test.tsx
+++ b/islands/todos/TodoBacklog.test.tsx
@@ -12,6 +12,7 @@ function todo(over: Partial<TodoInterface>): TodoInterface {
     createdBy: "u1",
     createdAt: "2026-08-03T10:00:00.000Z",
     completedAt: null,
+    dueAt: null,
     ...over,
   };
 }

--- a/islands/todos/TodoBacklog.test.tsx
+++ b/islands/todos/TodoBacklog.test.tsx
@@ -130,3 +130,31 @@ Deno.test("TodoBacklog — no Show earlier button when nothing is outside the wi
   assertStringIncludes(html, "Done recently");
   assertFalse(html.includes("Show earlier"));
 });
+
+Deno.test("TodoBacklog — Done section (and its reveal) still renders when every done to-do is outside the window, with no open to-dos", () => {
+  const old = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+  const html = render(h(TodoBacklog, {
+    initialTodos: [
+      todo({ id: "t1", title: "Done ages ago", completedAt: old }),
+    ],
+  }));
+
+  assertStringIncludes(html, ">Done<"); // section exists even with zero visible rows
+  assertStringIncludes(html, "Show earlier (1)"); // the only way to reach it
+  assertFalse(html.includes("Done ages ago")); // outside the window until revealed
+  assertFalse(html.includes("Nothing to do")); // this isn't the empty state
+});
+
+Deno.test("TodoBacklog — Done section (and its reveal) still renders when every done to-do is outside the window, alongside an open to-do", () => {
+  const old = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+  const html = render(h(TodoBacklog, {
+    initialTodos: [
+      todo({ id: "t1", title: "Take out the bins" }),
+      todo({ id: "t2", title: "Done ages ago", completedAt: old }),
+    ],
+  }));
+
+  assertStringIncludes(html, "Take out the bins");
+  assertStringIncludes(html, ">Done<");
+  assertStringIncludes(html, "Show earlier (1)");
+});

--- a/islands/todos/TodoBacklog.tsx
+++ b/islands/todos/TodoBacklog.tsx
@@ -10,6 +10,8 @@ import { Icon } from "@/components/md3/Icon.tsx";
 import { Snackbar } from "@/components/md3/Snackbar.tsx";
 import { Pressable } from "@/components/md3/Pressable.tsx";
 import Fab from "@/islands/shell/Fab.tsx";
+import DueChip from "@/islands/todos/DueChip.tsx";
+import { GROUP_LABELS, groupOpenTodos } from "@/utils/todo-due.ts";
 
 interface Props {
   initialTodos: TodoInterface[];
@@ -24,6 +26,7 @@ export default function TodoBacklog({ initialTodos }: Props) {
     addTodo,
     editTodo,
     flushTodo,
+    setDueAt,
     tickOff,
     unTick,
     removeTodo,
@@ -35,6 +38,9 @@ export default function TodoBacklog({ initialTodos }: Props) {
   const newNotes = useSignal("");
   const editingId = useSignal<string | null>(null);
   const confirmingId = useSignal<string | null>(null);
+  const dueEditingId = useSignal<string | null>(null);
+  const dueDraft = useSignal("");
+  const showEarlierDone = useSignal(false);
   const snack = useSignal<{ msg: string } | null>(null);
   const snackTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -85,6 +91,24 @@ export default function TodoBacklog({ initialTodos }: Props) {
   const done = doneTodos.value;
   const exiting = exitingIds.value;
 
+  // One clock for the whole render: a row and its section header must never
+  // disagree because the render straddled a second.
+  const now = new Date();
+
+  const groups = groupOpenTodos(open, now);
+
+  // Done is windowed to a rolling 7 days (spec + ADR 0002): a done one-off is
+  // finished forever, so the long tail has almost no value — but this is a
+  // *render* window, not a fetch window. The loader still pulls the whole
+  // backlog, because keys are ["todos", householdId, id] and filtering by
+  // completion date would scan everything anyway.
+  const doneCutoff = now.getTime() - 7 * 24 * 60 * 60 * 1000;
+  const recentDone = done.filter((t) =>
+    new Date(t.completedAt!).getTime() >= doneCutoff
+  );
+  const earlierDoneCount = done.length - recentDone.length;
+  const visibleDone = showEarlierDone.value ? done : recentDone;
+
   const editing = () =>
     open.find((t) => t.id === editingId.value) ??
       done.find((t) => t.id === editingId.value);
@@ -129,6 +153,54 @@ export default function TodoBacklog({ initialTodos }: Props) {
     editingId.value = null;
   };
 
+  /**
+   * `<input type="datetime-local">` speaks **local wall-clock with no zone**, so
+   * both directions need converting: an existing UTC instant becomes a local
+   * "YYYY-MM-DDTHH:mm" for the input, and the value the user picks becomes a UTC
+   * instant via `new Date(local).toISOString()`. Never round-trip the raw value.
+   */
+  const toLocalInputValue = (iso: string): string => {
+    const d = new Date(iso);
+    const pad = (n: number) => String(n).padStart(2, "0");
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${
+      pad(d.getHours())
+    }:${pad(d.getMinutes())}`;
+  };
+
+  /** 09:00 tomorrow, as the pre-filled default when no due moment is set. A
+   *  household to-do wants telling at the start of a day, and midnight — the
+   *  obvious alternative — is the worst possible moment to be reminded. */
+  const defaultDueInputValue = (): string => {
+    const d = new Date(now);
+    d.setDate(d.getDate() + 1);
+    d.setHours(9, 0, 0, 0);
+    return toLocalInputValue(d.toISOString());
+  };
+
+  const openDuePicker = (id: string, current: string | null) => {
+    dueDraft.value = current
+      ? toLocalInputValue(current)
+      : defaultDueInputValue();
+    dueEditingId.value = id;
+  };
+
+  const commitDue = async () => {
+    const id = dueEditingId.value;
+    const local = dueDraft.value;
+    dueEditingId.value = null;
+    if (!id || !local) return;
+    const ok = await setDueAt(id, new Date(local).toISOString());
+    if (!ok) say("Couldn't save that due date. Try again?");
+  };
+
+  const clearDue = async () => {
+    const id = dueEditingId.value;
+    dueEditingId.value = null;
+    if (!id) return;
+    const ok = await setDueAt(id, null);
+    if (!ok) say("Couldn't remove that due date. Try again?");
+  };
+
   // EXIT_MS is imported from useTodos so this transition and the exit-wait it
   // must match can't drift apart (patterns doc §6).
   const row = (t: TodoInterface, isDone: boolean) => (
@@ -158,23 +230,32 @@ export default function TodoBacklog({ initialTodos }: Props) {
       >
         <RoundCheck checked={isDone} />
       </Pressable>
-      <Pressable
-        onClick={() => (editingId.value = t.id)}
-        class="flex-1 min-w-0 text-left"
-      >
-        <div
-          class={`md-body-large ${
-            isDone ? "text-on-surface-variant line-through" : "text-on-surface"
-          }`}
+      <div class="flex-1 min-w-0 flex flex-col gap-1.5 items-start">
+        <Pressable
+          onClick={() => (editingId.value = t.id)}
+          class="w-full text-left"
         >
-          {t.title}
-        </div>
-        {t.notes && (
-          <div class="md-body-small text-on-surface-variant truncate">
-            📝 {t.notes}
+          <div
+            class={`md-body-large ${
+              isDone
+                ? "text-on-surface-variant line-through"
+                : "text-on-surface"
+            }`}
+          >
+            {t.title}
           </div>
-        )}
-      </Pressable>
+          {t.notes && (
+            <div class="md-body-small text-on-surface-variant truncate">
+              📝 {t.notes}
+            </div>
+          )}
+        </Pressable>
+        <DueChip
+          dueAt={t.dueAt}
+          now={now}
+          onClick={() => openDuePicker(t.id, t.dueAt)}
+        />
+      </div>
     </div>
   );
 
@@ -182,7 +263,7 @@ export default function TodoBacklog({ initialTodos }: Props) {
     <PullToRefresh
       onRefresh={refresh}
       disabled={createOpen.value || editingId.value !== null ||
-        confirmingId.value !== null}
+        confirmingId.value !== null || dueEditingId.value !== null}
     >
       <div class="px-4 pt-4 pb-[calc(96px+env(safe-area-inset-bottom))] flex flex-col gap-4">
         {open.length === 0 && done.length === 0
@@ -210,18 +291,29 @@ export default function TodoBacklog({ initialTodos }: Props) {
           )
           : (
             <>
-              {open.length > 0 && (
-                <div class="flex flex-col">
-                  {open.map((t) => row(t, false))}
+              {groups.map((g) => (
+                <div key={g.key} class="flex flex-col gap-1">
+                  <div class="md-label-medium uppercase text-on-surface-variant px-1 pt-2">
+                    {GROUP_LABELS[g.key]}
+                  </div>
+                  {g.todos.map((t) => row(t, false))}
                 </div>
-              )}
+              ))}
 
-              {done.length > 0 && (
+              {visibleDone.length > 0 && (
                 <div class="flex flex-col gap-1">
                   <div class="md-label-medium uppercase text-on-surface-variant px-1 pt-2">
                     Done
                   </div>
-                  {done.map((t) => row(t, true))}
+                  {visibleDone.map((t) => row(t, true))}
+                  {earlierDoneCount > 0 && !showEarlierDone.value && (
+                    <Pressable
+                      onClick={() => (showEarlierDone.value = true)}
+                      class="self-start md-label-large text-primary px-1 py-2"
+                    >
+                      Show earlier ({earlierDoneCount})
+                    </Pressable>
+                  )}
                 </div>
               )}
             </>
@@ -387,6 +479,34 @@ export default function TodoBacklog({ initialTodos }: Props) {
             Keep it
           </Button>
         </div>
+      </Sheet>
+
+      {
+        /* Due-date picker. Native <input type="datetime-local"> rather than a
+          custom MD3 picker: on mobile it opens the platform's own control,
+          which is familiar, accessible and localised for free, and resolves
+          local wall-clock time natively — exactly what docs/adr/0004 needs. */
+      }
+      <Sheet
+        open={dueEditingId.value !== null}
+        onClose={() => (dueEditingId.value = null)}
+        title="When is it due?"
+      >
+        {dueEditingId.value !== null && (
+          <div class="flex flex-col gap-3 pb-1">
+            <input
+              type="datetime-local"
+              value={dueDraft.value}
+              onInput={(e) => (dueDraft.value = e.currentTarget.value)}
+              aria-label="Due date and time"
+              class="w-full md-body-large text-on-surface bg-surface-chigh border-0 rounded-[var(--md-shape-lg)] py-3 px-4 outline-none"
+            />
+            <Button variant="filled" full onClick={commitDue}>Save</Button>
+            <Button variant="text" full onClick={clearDue}>
+              Remove due date
+            </Button>
+          </div>
+        )}
       </Sheet>
 
       <Snackbar data={snack.value} />

--- a/islands/todos/TodoBacklog.tsx
+++ b/islands/todos/TodoBacklog.tsx
@@ -300,7 +300,7 @@ export default function TodoBacklog({ initialTodos }: Props) {
                 </div>
               ))}
 
-              {visibleDone.length > 0 && (
+              {done.length > 0 && (
                 <div class="flex flex-col gap-1">
                   <div class="md-label-medium uppercase text-on-surface-variant px-1 pt-2">
                     Done

--- a/islands/todos/TodoBacklog.tsx
+++ b/islands/todos/TodoBacklog.tsx
@@ -36,6 +36,7 @@ export default function TodoBacklog({ initialTodos }: Props) {
   const createOpen = useSignal(false);
   const newTitle = useSignal("");
   const newNotes = useSignal("");
+  const newDue = useSignal("");
   const editingId = useSignal<string | null>(null);
   const confirmingId = useSignal<string | null>(null);
   const dueEditingId = useSignal<string | null>(null);
@@ -67,6 +68,7 @@ export default function TodoBacklog({ initialTodos }: Props) {
   const openCreate = () => {
     newTitle.value = "";
     newNotes.value = "";
+    newDue.value = "";
     handoff.value = false;
     primerRef.current?.focus();
     createOpen.value = true;
@@ -130,7 +132,7 @@ export default function TodoBacklog({ initialTodos }: Props) {
     const created = await addTodo({
       title,
       notes: notes || undefined,
-      dueAt: null,
+      dueAt: newDue.value ? new Date(newDue.value).toISOString() : null,
     });
     if (!created) {
       say("Couldn't add that to-do. Try again?");
@@ -144,6 +146,7 @@ export default function TodoBacklog({ initialTodos }: Props) {
     // islands/add-items.tsx).
     newTitle.value = "";
     newNotes.value = "";
+    newDue.value = "";
     titleRef.current?.focus();
   };
 
@@ -387,6 +390,13 @@ export default function TodoBacklog({ initialTodos }: Props) {
               aria-label="Notes (optional)"
               class="w-full md-body-large text-on-surface bg-surface-chigh border-0 rounded-[var(--md-shape-lg)] py-3 px-4 outline-none resize-none"
             />
+            <input
+              type="datetime-local"
+              value={newDue.value}
+              onChange={(e) => (newDue.value = e.currentTarget.value)}
+              aria-label="Due date and time (optional)"
+              class="w-full md-body-large text-on-surface bg-surface-chigh border-0 rounded-[var(--md-shape-lg)] py-3 px-4 outline-none"
+            />
             <Button variant="filled" full onClick={submitNew}>Add</Button>
             {
               /* "Close", not "Done" — "Done" beside "Add" reads as a second
@@ -429,6 +439,20 @@ export default function TodoBacklog({ initialTodos }: Props) {
                 placeholder="Notes (optional)"
                 aria-label="Notes"
                 class="w-full md-body-large text-on-surface bg-surface-chigh border-0 rounded-[var(--md-shape-lg)] py-3 px-4 outline-none resize-none"
+              />
+              <input
+                type="datetime-local"
+                value={t.dueAt ? toLocalInputValue(t.dueAt) : ""}
+                onChange={async (e) => {
+                  const v = e.currentTarget.value;
+                  const ok = await setDueAt(
+                    t.id,
+                    v ? new Date(v).toISOString() : null,
+                  );
+                  if (!ok) say("Couldn't save that due date. Try again?");
+                }}
+                aria-label="Due date and time"
+                class="w-full md-body-large text-on-surface bg-surface-chigh border-0 rounded-[var(--md-shape-lg)] py-3 px-4 outline-none"
               />
               <Button variant="filled" full onClick={closeEditor}>Done</Button>
               <Button

--- a/islands/todos/TodoBacklog.tsx
+++ b/islands/todos/TodoBacklog.tsx
@@ -103,7 +103,11 @@ export default function TodoBacklog({ initialTodos }: Props) {
     const title = newTitle.value.trim();
     if (!title) return;
     const notes = newNotes.value.trim();
-    const created = await addTodo({ title, notes: notes || undefined });
+    const created = await addTodo({
+      title,
+      notes: notes || undefined,
+      dueAt: null,
+    });
     if (!created) {
       say("Couldn't add that to-do. Try again?");
       return;

--- a/models/todo/todo.interface.ts
+++ b/models/todo/todo.interface.ts
@@ -27,9 +27,10 @@ export interface TodoInterface {
 export type CreateTodoDto = Omit<TodoInterface, "id">;
 
 /**
- * What the client sends to create a to-do. The server fills in `householdId`,
- * `createdBy`, `createdAt`, `completedAt` and `id` — the client never sends
- * (and cannot spoof) the household.
+ * What the client sends to create a to-do: a title, optional notes, and an
+ * optional due moment. The server fills in `householdId`, `createdBy`,
+ * `createdAt`, `completedAt` and `id` — the client never sends (and cannot
+ * spoof) the household.
  */
 export type TodoInput = Pick<TodoInterface, "title" | "notes" | "dueAt">;
 

--- a/models/todo/todo.interface.ts
+++ b/models/todo/todo.interface.ts
@@ -14,6 +14,13 @@ export interface TodoInterface {
    * docs/adr/0002.
    */
   completedAt: string | null;
+  /**
+   * When this is due, as a UTC instant, or null if it has no due moment.
+   * Always a moment and never just a day — see docs/adr/0004. Entered and
+   * displayed in the viewer's timezone; neither this record nor the server
+   * knows what that zone is.
+   */
+  dueAt: string | null;
 }
 
 // Derived type for creation (no ID — the server mints it).
@@ -24,7 +31,7 @@ export type CreateTodoDto = Omit<TodoInterface, "id">;
  * `createdBy`, `createdAt`, `completedAt` and `id` — the client never sends
  * (and cannot spoof) the household.
  */
-export type TodoInput = Pick<TodoInterface, "title" | "notes">;
+export type TodoInput = Pick<TodoInterface, "title" | "notes" | "dueAt">;
 
 // Derived type for patch/update: never the id or householdId, everything else optional.
 export type UpdateTodoDto = Partial<Omit<TodoInterface, "id" | "householdId">>;

--- a/routes/api/todos/[id].test.ts
+++ b/routes/api/todos/[id].test.ts
@@ -223,3 +223,57 @@ Deno.test({
     assertEquals((await handler.DELETE(ctx(del(), "any"))).status, 401);
   },
 });
+
+Deno.test({
+  name: "PATCH sets dueAt, canonicalising to UTC",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const t = await seed();
+    const updated = await (await handler.PATCH(
+      ctx(patch({ dueAt: "2026-08-05T18:00:00+02:00" }), t.id, AUTH),
+    )).json();
+
+    assertEquals(updated.dueAt, "2026-08-05T16:00:00.000Z");
+  },
+});
+
+Deno.test({
+  name: "PATCH clears dueAt with null",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const t = await TodoRepo.create({
+      householdId: "h1",
+      title: "Book the venue",
+      createdBy: "u1",
+      createdAt: "2026-08-03T10:00:00.000Z",
+      completedAt: null,
+      dueAt: "2026-08-10T09:00:00.000Z",
+    });
+
+    const updated = await (await handler.PATCH(
+      ctx(patch({ dueAt: null }), t.id, AUTH),
+    )).json();
+
+    assertEquals(updated.dueAt, null);
+  },
+});
+
+Deno.test({
+  name: "PATCH rejects an invalid dueAt (400) and leaves the to-do alone",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const t = await seed();
+    assertEquals(
+      (await handler.PATCH(ctx(patch({ dueAt: "nope" }), t.id, AUTH))).status,
+      400,
+    );
+    assertEquals(
+      (await handler.PATCH(ctx(patch({ dueAt: 7 }), t.id, AUTH))).status,
+      400,
+    );
+    assertEquals((await TodoRepo.getById("h1", t.id))?.dueAt, null);
+  },
+});

--- a/routes/api/todos/[id].test.ts
+++ b/routes/api/todos/[id].test.ts
@@ -40,6 +40,7 @@ function seed(householdId = "h1", title = "Take out the bins") {
     createdBy: "u1",
     createdAt: "2026-08-03T10:00:00.000Z",
     completedAt: null,
+    dueAt: null,
   });
 }
 
@@ -88,6 +89,7 @@ Deno.test({
       createdBy: "u1",
       createdAt: "2026-08-03T10:00:00.000Z",
       completedAt: null,
+      dueAt: null,
     });
 
     const cleared = await (await handler.PATCH(

--- a/routes/api/todos/[id].ts
+++ b/routes/api/todos/[id].ts
@@ -7,6 +7,7 @@ import {
 } from "@/utils/index.ts";
 import { TodoRepo } from "@/database/index.ts";
 import type { UpdateTodoDto } from "@/models/index.ts";
+import { parseDueAt } from "@/utils/todo-due.ts";
 
 export const handler = define.handlers({
   async PATCH(ctx) {
@@ -45,6 +46,13 @@ export const handler = define.handlers({
         }
         patch.completedAt = body.completedAt;
       }
+    }
+    if (body.dueAt !== undefined) {
+      const parsed = parseDueAt(body.dueAt);
+      if (parsed === undefined) {
+        return badRequest("dueAt must be null or a valid date string");
+      }
+      patch.dueAt = parsed;
     }
 
     const updated = await TodoRepo.update(householdId, ctx.params.id, patch);

--- a/routes/api/todos/index.test.ts
+++ b/routes/api/todos/index.test.ts
@@ -124,3 +124,55 @@ Deno.test({
     assertEquals(list, []);
   },
 });
+
+Deno.test({
+  name: "POST accepts a dueAt and stores it canonicalised to UTC",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const created = await (await handler.POST(
+      ctx(
+        post({ title: "Book the venue", dueAt: "2026-08-05T18:00:00+02:00" }),
+        AUTH,
+      ),
+    )).json();
+
+    assertEquals(created.dueAt, "2026-08-05T16:00:00.000Z");
+  },
+});
+
+Deno.test({
+  name: "POST defaults dueAt to null when absent or explicitly null",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    const absent = await (await handler.POST(
+      ctx(post({ title: "no date" }), AUTH),
+    )).json();
+    assertEquals(absent.dueAt, null);
+
+    const explicit = await (await handler.POST(
+      ctx(post({ title: "null date", dueAt: null }), AUTH),
+    )).json();
+    assertEquals(explicit.dueAt, null);
+  },
+});
+
+Deno.test({
+  name: "POST rejects a dueAt that is neither null nor a valid date (400)",
+  sanitizeResources: false,
+  async fn() {
+    await clearTodos();
+    assertEquals(
+      (await handler.POST(
+        ctx(post({ title: "x", dueAt: "not a date" }), AUTH),
+      )).status,
+      400,
+    );
+    assertEquals(
+      (await handler.POST(ctx(post({ title: "x", dueAt: 12345 }), AUTH)))
+        .status,
+      400,
+    );
+  },
+});

--- a/routes/api/todos/index.ts
+++ b/routes/api/todos/index.ts
@@ -1,5 +1,6 @@
 import { badRequest, define, json } from "@/utils/index.ts";
 import { TodoRepo } from "@/database/index.ts";
+import { parseDueAt } from "@/utils/todo-due.ts";
 
 export const handler = define.handlers({
   async GET(ctx) {
@@ -19,6 +20,15 @@ export const handler = define.handlers({
     if (!title) return badRequest("title required");
     const rawNotes = String(body.notes ?? "").trim();
 
+    let dueAt: string | null = null;
+    if (body.dueAt !== undefined) {
+      const parsed = parseDueAt(body.dueAt);
+      if (parsed === undefined) {
+        return badRequest("dueAt must be null or a valid date string");
+      }
+      dueAt = parsed;
+    }
+
     const todo = await TodoRepo.create({
       householdId,
       title,
@@ -26,7 +36,7 @@ export const handler = define.handlers({
       createdBy: userId,
       createdAt: new Date().toISOString(),
       completedAt: null,
-      dueAt: null,
+      dueAt,
     });
     return json(todo, 201);
   },

--- a/routes/api/todos/index.ts
+++ b/routes/api/todos/index.ts
@@ -26,6 +26,7 @@ export const handler = define.handlers({
       createdBy: userId,
       createdAt: new Date().toISOString(),
       completedAt: null,
+      dueAt: null,
     });
     return json(todo, 201);
   },

--- a/utils/todo-due.test.ts
+++ b/utils/todo-due.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from "jsr:@std/assert@^1.0.19";
 import {
+  compareTodos,
   formatDueAt,
   GROUP_LABELS,
   groupOpenTodos,
@@ -181,4 +182,42 @@ Deno.test("parseDueAt — undefined signals unusable input", () => {
   assertEquals(parseDueAt(12345), undefined);
   assertEquals(parseDueAt(undefined), undefined);
   assertEquals(parseDueAt({}), undefined);
+});
+
+// ── compareTodos ─────────────────────────────────────────────────────────────
+
+Deno.test("compareTodos — produces the full documented order for a mixed list", () => {
+  const dueSoon = todo("due-soon", "2026-08-06T09:00:00.000Z");
+  const dueLater = todo("due-later", "2026-08-20T09:00:00.000Z");
+  const undatedNewer = todo("undated-newer", null, "2026-08-03T10:00:00.000Z");
+  const undatedOlder = todo("undated-older", null, "2026-08-01T10:00:00.000Z");
+  const doneLater = {
+    ...todo("done-later", null),
+    completedAt: "2026-08-04T12:00:00.000Z",
+  };
+  const doneEarlier = {
+    ...todo("done-earlier", null),
+    completedAt: "2026-08-02T12:00:00.000Z",
+  };
+
+  const shuffled = [
+    doneEarlier,
+    undatedOlder,
+    dueLater,
+    doneLater,
+    undatedNewer,
+    dueSoon,
+  ];
+
+  assertEquals(
+    [...shuffled].sort(compareTodos).map((t) => t.id),
+    [
+      "due-soon",
+      "due-later",
+      "undated-newer",
+      "undated-older",
+      "done-later",
+      "done-earlier",
+    ],
+  );
 });

--- a/utils/todo-due.test.ts
+++ b/utils/todo-due.test.ts
@@ -1,0 +1,184 @@
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import {
+  formatDueAt,
+  GROUP_LABELS,
+  groupOpenTodos,
+  isOverdue,
+  parseDueAt,
+  type TodoGroupKey,
+} from "./todo-due.ts";
+import type { TodoInterface } from "@/models/index.ts";
+
+// Local-time constructor so these tests are independent of the machine's zone:
+// `new Date(y, m, d, h, min)` interprets its arguments in local time, which is
+// exactly the zone the functions under test reason in.
+const local = (
+  y: number,
+  m: number,
+  d: number,
+  h = 0,
+  min = 0,
+): Date => new Date(y, m - 1, d, h, min, 0, 0);
+
+function todo(
+  id: string,
+  dueAt: string | null,
+  createdAt = "2026-08-01T00:00:00.000Z",
+): TodoInterface {
+  return {
+    id,
+    householdId: "hh",
+    title: `todo ${id}`,
+    createdBy: "u1",
+    createdAt,
+    completedAt: null,
+    dueAt,
+  };
+}
+
+const keys = (todos: TodoInterface[], now: Date): TodoGroupKey[] =>
+  groupOpenTodos(todos, now).map((g) => g.key);
+
+// ── grouping boundaries ──────────────────────────────────────────────────────
+
+Deno.test("groupOpenTodos — a to-do due earlier today is overdue, not today", () => {
+  const now = local(2026, 8, 5, 18, 0); // Wednesday 18:00
+  const t = todo("a", local(2026, 8, 5, 9, 0).toISOString());
+
+  assertEquals(keys([t], now), ["overdue"]);
+});
+
+Deno.test("groupOpenTodos — a to-do due later today is today", () => {
+  const now = local(2026, 8, 5, 9, 0);
+  const t = todo("a", local(2026, 8, 5, 18, 0).toISOString());
+
+  assertEquals(keys([t], now), ["today"]);
+});
+
+Deno.test("groupOpenTodos — tomorrow through the coming Sunday is thisWeek", () => {
+  const now = local(2026, 8, 5, 9, 0); // Wednesday
+  const thu = todo("a", local(2026, 8, 6, 9, 0).toISOString());
+  const sun = todo("b", local(2026, 8, 9, 23, 0).toISOString()); // Sunday
+
+  assertEquals(keys([thu, sun], now), ["thisWeek"]);
+  assertEquals(groupOpenTodos([thu, sun], now)[0].todos.map((t) => t.id), [
+    "a",
+    "b",
+  ]);
+});
+
+Deno.test("groupOpenTodos — the Monday after the coming Sunday is later", () => {
+  const now = local(2026, 8, 5, 9, 0); // Wednesday
+  const mon = todo("a", local(2026, 8, 10, 9, 0).toISOString());
+
+  assertEquals(keys([mon], now), ["later"]);
+});
+
+Deno.test("groupOpenTodos — on a Sunday, thisWeek covers the week ahead", () => {
+  const now = local(2026, 8, 9, 18, 0); // Sunday evening
+  const mon = todo("a", local(2026, 8, 10, 9, 0).toISOString());
+  const nextSun = todo("b", local(2026, 8, 16, 9, 0).toISOString());
+  const beyond = todo("c", local(2026, 8, 17, 9, 0).toISOString());
+
+  assertEquals(keys([mon, nextSun, beyond], now), ["thisWeek", "later"]);
+  const groups = groupOpenTodos([mon, nextSun, beyond], now);
+  assertEquals(groups[0].todos.map((t) => t.id), ["a", "b"]);
+  assertEquals(groups[1].todos.map((t) => t.id), ["c"]);
+});
+
+Deno.test("groupOpenTodos — undated to-dos land in noDate", () => {
+  const now = local(2026, 8, 5, 9, 0);
+
+  assertEquals(keys([todo("a", null)], now), ["noDate"]);
+});
+
+// ── group mechanics ──────────────────────────────────────────────────────────
+
+Deno.test("groupOpenTodos — empty groups are omitted and order is fixed", () => {
+  const now = local(2026, 8, 5, 12, 0); // Wednesday
+  const list = [
+    todo("late", local(2026, 8, 4, 9, 0).toISOString()),
+    todo("soon", local(2026, 8, 5, 20, 0).toISOString()),
+    todo("far", local(2026, 8, 20, 9, 0).toISOString()),
+    todo("none", null),
+  ];
+
+  assertEquals(keys(list, now), ["overdue", "today", "later", "noDate"]);
+});
+
+Deno.test("groupOpenTodos — input order is preserved inside a group", () => {
+  const now = local(2026, 8, 5, 12, 0);
+  const first = todo("first", local(2026, 8, 6, 9, 0).toISOString());
+  const second = todo("second", local(2026, 8, 7, 9, 0).toISOString());
+
+  const group = groupOpenTodos([first, second], now)[0];
+  assertEquals(group.todos.map((t) => t.id), ["first", "second"]);
+});
+
+Deno.test("groupOpenTodos — an empty input yields no groups", () => {
+  assertEquals(groupOpenTodos([], local(2026, 8, 5)), []);
+});
+
+Deno.test("GROUP_LABELS — every key has a user-facing header", () => {
+  assertEquals(GROUP_LABELS.overdue, "Overdue");
+  assertEquals(GROUP_LABELS.today, "Today");
+  assertEquals(GROUP_LABELS.thisWeek, "This week");
+  assertEquals(GROUP_LABELS.later, "Later");
+  assertEquals(GROUP_LABELS.noDate, "No date");
+});
+
+// ── isOverdue ────────────────────────────────────────────────────────────────
+
+Deno.test("isOverdue — past is overdue, future is not, null never is", () => {
+  const now = local(2026, 8, 5, 12, 0);
+
+  assertEquals(isOverdue(local(2026, 8, 5, 11, 0).toISOString(), now), true);
+  assertEquals(isOverdue(local(2026, 8, 5, 13, 0).toISOString(), now), false);
+  assertEquals(isOverdue(null, now), false);
+});
+
+// ── formatDueAt ──────────────────────────────────────────────────────────────
+
+Deno.test("formatDueAt — always includes the time", () => {
+  const now = local(2026, 8, 5, 12, 0);
+  const out = formatDueAt(local(2026, 8, 7, 9, 0).toISOString(), now);
+
+  assertEquals(out.includes("09"), true);
+});
+
+Deno.test("formatDueAt — omits the year in the current year, includes it otherwise", () => {
+  const now = local(2026, 8, 5, 12, 0);
+
+  const sameYear = formatDueAt(local(2026, 12, 1, 9, 0).toISOString(), now);
+  assertEquals(sameYear.includes("2026"), false);
+
+  const nextYear = formatDueAt(local(2027, 1, 5, 9, 0).toISOString(), now);
+  assertEquals(nextYear.includes("2027"), true);
+});
+
+// ── parseDueAt ───────────────────────────────────────────────────────────────
+
+Deno.test("parseDueAt — null clears, and passes through as null", () => {
+  assertEquals(parseDueAt(null), null);
+});
+
+Deno.test("parseDueAt — canonicalises an offset form to UTC", () => {
+  assertEquals(
+    parseDueAt("2026-08-05T18:00:00+02:00"),
+    "2026-08-05T16:00:00.000Z",
+  );
+});
+
+Deno.test("parseDueAt — leaves an already-canonical instant unchanged", () => {
+  assertEquals(
+    parseDueAt("2026-08-05T16:00:00.000Z"),
+    "2026-08-05T16:00:00.000Z",
+  );
+});
+
+Deno.test("parseDueAt — undefined signals unusable input", () => {
+  assertEquals(parseDueAt("not a date"), undefined);
+  assertEquals(parseDueAt(12345), undefined);
+  assertEquals(parseDueAt(undefined), undefined);
+  assertEquals(parseDueAt({}), undefined);
+});

--- a/utils/todo-due.ts
+++ b/utils/todo-due.ts
@@ -69,8 +69,8 @@ function endOfWeekWindow(now: Date): Date {
 
 function classify(todo: TodoInterface, now: Date): TodoGroupKey {
   if (todo.dueAt === null) return "noDate";
+  if (isOverdue(todo.dueAt, now)) return "overdue";
   const due = new Date(todo.dueAt);
-  if (due.getTime() < now.getTime()) return "overdue";
 
   const tomorrow = new Date(
     now.getFullYear(),
@@ -103,6 +103,57 @@ export function groupOpenTodos(
   return GROUP_ORDER
     .filter((key) => buckets.has(key))
     .map((key) => ({ key, todos: buckets.get(key)! }));
+}
+
+/**
+ * Total order for a household's to-dos — the exact ordering
+ * `TodoRepo.getAll` stores its result in: open before done; within open,
+ * dated before undated, dated soonest-first, undated newest-created-first;
+ * within done, most recently done first. Every leaf ties break by
+ * `id.localeCompare` for a stable, total order.
+ *
+ * Exported so `hooks/useTodos.ts` can re-sort after an optimistic patch that
+ * changes a to-do's rank (`setDueAt`, `unTick`) without moving its array
+ * position — the array position *is* the order (see `groupOpenTodos`'s
+ * doc comment), so any mutation that doesn't preserve rank must re-sort with
+ * this exact comparator or the list silently drifts out of order until the
+ * next reload.
+ */
+export function compareTodos(a: TodoInterface, b: TodoInterface): number {
+  const aOpen = a.completedAt === null;
+  const bOpen = b.completedAt === null;
+
+  // Open before done.
+  if (aOpen !== bOpen) return aOpen ? -1 : 1;
+
+  if (aOpen) {
+    const aDated = a.dueAt !== null;
+    const bDated = b.dueAt !== null;
+    // Dated before undated.
+    if (aDated !== bDated) return aDated ? -1 : 1;
+
+    if (aDated) {
+      // Soonest due first.
+      if (a.dueAt !== b.dueAt) return a.dueAt! < b.dueAt! ? -1 : 1;
+      return a.id.localeCompare(b.id);
+    }
+
+    // Undated: newest created first. Plain string comparison, not
+    // localeCompare — two to-dos captured in the same rapid-capture burst
+    // can share a millisecond-precision createdAt, so ties break by id for
+    // a total, stable order; otherwise they'd fall back to KV iteration
+    // order and could swap places relative to the optimistic prepend.
+    if (a.createdAt !== b.createdAt) {
+      return a.createdAt < b.createdAt ? 1 : -1;
+    }
+    return a.id.localeCompare(b.id);
+  }
+
+  // Both done: most recently done first.
+  if (a.completedAt !== b.completedAt) {
+    return a.completedAt! < b.completedAt! ? 1 : -1;
+  }
+  return a.id.localeCompare(b.id);
 }
 
 /**

--- a/utils/todo-due.ts
+++ b/utils/todo-due.ts
@@ -1,0 +1,146 @@
+import type { TodoInterface } from "@/models/index.ts";
+
+/**
+ * All date reasoning for to-do due moments, kept pure and free of DOM, KV and
+ * signals so the boundaries can be tested directly — they are the feature.
+ *
+ * Everything here reasons in the **local zone of the `now` it is handed**.
+ * Grouping cannot be computed on the server, which does not know the viewer's
+ * zone (see docs/adr/0004); the SSR loader and the island therefore call the
+ * same functions with a different `now`, and can briefly disagree about which
+ * group a boundary-adjacent to-do belongs to until hydration settles it.
+ */
+
+export type TodoGroupKey =
+  | "overdue"
+  | "today"
+  | "thisWeek"
+  | "later"
+  | "noDate";
+
+export interface TodoGroup {
+  key: TodoGroupKey;
+  todos: TodoInterface[];
+}
+
+export const GROUP_LABELS: Record<TodoGroupKey, string> = {
+  overdue: "Overdue",
+  today: "Today",
+  thisWeek: "This week",
+  later: "Later",
+  noDate: "No date",
+};
+
+/** Fixed render order — urgent first, undated last. */
+const GROUP_ORDER: TodoGroupKey[] = [
+  "overdue",
+  "today",
+  "thisWeek",
+  "later",
+  "noDate",
+];
+
+export function isOverdue(dueAt: string | null, now: Date): boolean {
+  if (dueAt === null) return false;
+  return new Date(dueAt).getTime() < now.getTime();
+}
+
+/** Local midnight at the start of the day `d` falls on. */
+function startOfDay(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0, 0);
+}
+
+/**
+ * Local midnight ending the "this week" window: the end of the coming Sunday.
+ * When `now` is itself a Sunday the window would collapse to nothing and push
+ * Monday into `later` — wrong on the evening a household plans the week ahead —
+ * so a Sunday extends to the end of the following Sunday.
+ */
+function endOfWeekWindow(now: Date): Date {
+  const day = now.getDay(); // 0 = Sunday
+  const daysUntilSunday = day === 0 ? 7 : 7 - day;
+  const start = startOfDay(now);
+  return new Date(
+    start.getFullYear(),
+    start.getMonth(),
+    start.getDate() + daysUntilSunday + 1,
+  );
+}
+
+function classify(todo: TodoInterface, now: Date): TodoGroupKey {
+  if (todo.dueAt === null) return "noDate";
+  const due = new Date(todo.dueAt);
+  if (due.getTime() < now.getTime()) return "overdue";
+
+  const tomorrow = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate() + 1,
+  );
+  if (due.getTime() < tomorrow.getTime()) return "today";
+  if (due.getTime() < endOfWeekWindow(now).getTime()) return "thisWeek";
+  return "later";
+}
+
+/**
+ * Buckets already-ordered open to-dos by urgency. Preserves input order within
+ * each group — `TodoRepo.getAll` emits dated-ascending then undated-newest
+ * precisely so this single pass needs no sorting of its own — and omits groups
+ * that end up empty.
+ */
+export function groupOpenTodos(
+  todos: TodoInterface[],
+  now: Date,
+): TodoGroup[] {
+  const buckets = new Map<TodoGroupKey, TodoInterface[]>();
+  for (const todo of todos) {
+    const key = classify(todo, now);
+    const bucket = buckets.get(key);
+    if (bucket) bucket.push(todo);
+    else buckets.set(key, [todo]);
+  }
+
+  return GROUP_ORDER
+    .filter((key) => buckets.has(key))
+    .map((key) => ({ key, todos: buckets.get(key)! }));
+}
+
+/**
+ * The row label for a due moment, e.g. "Fri 1 Aug, 09:00". The time is always
+ * included: once notifications exist it is when the phone will buzz, so hiding
+ * it would be dishonest. The year is included only when it differs from `now`'s.
+ * No explicit locale, so the device's is used and issue #13's Dutch conversion
+ * is automatic.
+ */
+export function formatDueAt(dueAt: string, now: Date): string {
+  const due = new Date(dueAt);
+  const date = due.toLocaleDateString(undefined, {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    ...(due.getFullYear() !== now.getFullYear() ? { year: "numeric" } : {}),
+  });
+  const time = due.toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  return `${date}, ${time}`;
+}
+
+/**
+ * Parses a client-supplied due moment. Returns the canonical UTC string, `null`
+ * to clear, or `undefined` when the value is unusable so the caller can 400.
+ *
+ * Canonicalising matters: `TodoRepo.getAll` compares `dueAt` as **strings**, so
+ * an offset form like "2026-08-05T18:00:00+02:00" stored verbatim would sort
+ * wrongly against "…Z" values. `<input type="datetime-local">` also yields a
+ * zoneless local string, which the client converts before sending — this is the
+ * server-side backstop for both.
+ */
+export function parseDueAt(raw: unknown): string | null | undefined {
+  if (raw === null) return null;
+  if (typeof raw !== "string") return undefined;
+  const ms = Date.parse(raw);
+  if (Number.isNaN(ms)) return undefined;
+  return new Date(ms).toISOString();
+}


### PR DESCRIPTION
A to-do can now be **due** at a moment. The open backlog groups itself by urgency, every row carries a due chip that doubles as the control, and the Done section shows only the last week.

Builds on iteration 1 (#62). Assignment is still blocked on #17; this iteration needed nothing from it.

## What's in it

- `dueAt: string | null` — a full **UTC instant**, threaded model → repo → API → hook → island
- Open sections: **Overdue → Today → This week → Later → No date**, rendered only when non-empty
- Overdue marked in error colour on the chip's **text and outline** — never a filled badge
- A due date is settable from **three** places: the create sheet (while capturing), the edit sheet, and the row chip
- `utils/todo-due.ts` — all date reasoning in one pure module: grouping, formatting, validation, and the shared `compareTodos`
- Done windowed to a rolling 7 days with a **Show earlier (N)** reveal

## Decisions worth knowing

**[ADR 0003](docs/adr/0003-todos-are-one-off-chores-are-a-separate-module.md) — a to-do is strictly one-off; recurring work is a *chore*, a separate future module.** This **reverses** iteration 1's "one concept, recurrence as an attribute", which was decided from examples (monthly bills, weekly bins, the yearly dentist) that turned out to be chores. The two separate on something firmer than whether a date repeats: a to-do exists *because it would be forgotten*; a chore is driven by its *schedule* and asks whose turn it is and whether it's been done since Tuesday. Recurrence has left this roadmap. [ADR 0001](docs/adr/0001-one-household-backlog-no-todo-lists.md) carries an update note, since one of its three arguments leaned on those examples.

**[ADR 0004](docs/adr/0004-due-dates-are-utc-instants-timezone-is-presentation.md) — a UTC instant, not a calendar date, and no timezone is ever stored.** A date-only field was tempting, but notifications and reminders are next and both fire at a *moment* — a bare date would need a notional time anyway, and midnight is the worst possible one. Timezone is presentation-only: the device's zone parses and formats, which keeps notifications correct wherever anyone is standing. The accepted consequence is that grouping is client-side, so SSR and hydration can briefly disagree about a boundary-adjacent to-do's header.

The time is **always shown**, defaulted to 09:00. Once notifications land, the time is when the phone buzzes, so hiding it would be dishonest.

## Notes for the notifications iteration

Two things learned here, so it doesn't start from the wrong primitive:

- **Deno KV queues are not supported on the new Deno Deploy**, which this project targets (`73e8091`). "Enqueue a delayed job when the due date is set" is unavailable. `Deno.cron` works identically, so it's a periodic sweep — which is also more robust, since editing or deleting a to-do needs no queue cleanup.
- **A single `notifiedAt` marker is insufficient.** With reminders, one to-do has several fire-points (a week before, a day before, the moment itself), so tracking must be per-fire-point.

## Verification

`deno task check` clean. **324 tests passing** (274 at branch start, so +50). The bulk sits in `utils/todo-due.test.ts`, since the boundary rules *are* the feature and being pure makes them testable without a browser.

Driven end-to-end in a browser at mobile viewport with **real pointer events and real keystrokes**: grouping across every boundary, the overdue treatment, the picker's pre-fill and both conversion directions, clearing, chip-vs-row tap independence, tick-off, the Done window and its reveal, and creating a dated to-do from the create sheet.

**No migration needed.** `dueAt` is additive and optional in storage and normalised at the read boundary; a test writes a pre-`dueAt` record shape directly to KV and asserts it reads back as `null`.

**Three defects were caught by review, and all three originated in the plan rather than the implementation:**

| | |
|---|---|
| The **Done reveal was unreachable** | Gated on the 7-day window, but "Show earlier" lived *inside* that gate — so once nothing had been ticked off in a week, older done to-dos became unreachable, and with no open to-dos the screen went blank |
| **`setDueAt` broke the ordering invariant** | It patched `dueAt` in place, but array *position* is the order — so a re-dated to-do rendered in the right section at the wrong position. Fixed by extracting `compareTodos` so the repo and the hook share one comparator |
| **`addTodo` prepended** | Correct only while a new to-do was always undated; once the create sheet could set a date it was the same bug. Now sorts |

Also fixed from the final review: the due chip's tap target was 26px against the plan's own 44px bar — now **46px** tappable with the visible pill unchanged.

## Not verified

That a drag inside the open picker doesn't trigger pull-to-refresh. `PullToRefresh` is touch-only, the automation available had no touch action, and a control run confirmed synthetic touch events don't fire it *even with the guard disabled* — so a pass would have been meaningless. It rests on the source check and the identical guard shipping for the other three sheets.

## Follow-ups (not blocking)

Equality-boundary tests for the two exact instants; `docs/ui-ux-patterns.md` should gain the three patterns this iteration established (native `datetime-local` over a custom MD3 picker, one-clock-per-render, render-time windowing); ADR 0002 still cites recurrence as a reason for `completedAt`, superseded by ADR 0003; `formatDueAt`'s "device locale" comment is inaccurate during SSR, which will become visible once #13 ships Dutch; and `TodoBacklog.tsx` is ~515 lines with four sheets, a candidate for extracting the picker state into a hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)