### PR TITLE
feat(cards): edit existing cards and explicit "Auto" format

### DIFF
--- a/components/cards/CardForm.tsx
+++ b/components/cards/CardForm.tsx
@@ -2,13 +2,14 @@ import type { Signal } from "@preact/signals";
 import type { BarcodeFormat } from "@/models/index.ts";
 import {
   detectFormat,
+  formatLabel,
   SUPPORTED_FORMATS,
   validateBarcode,
 } from "@/utils/barcode.ts";
 import { Barcode } from "@/components/md3/Barcode.tsx";
 import { Button } from "@/components/md3/Button.tsx";
 import { Chip } from "@/components/md3/Chip.tsx";
-import { Icon } from "@/components/md3/Icon.tsx";
+import { Icon, type IconName } from "@/components/md3/Icon.tsx";
 import { Pressable } from "@/components/md3/Pressable.tsx";
 import { CARD_COLORS } from "./palette.ts";
 
@@ -25,6 +26,8 @@ interface CardFormProps {
   form: CardFormSignals;
   scannerAvailable: boolean;
   saving: boolean;
+  submitLabel?: string;
+  submitIcon?: IconName;
   onScan: () => void;
   onSubmit: () => void;
   onCancel: () => void;
@@ -36,18 +39,33 @@ const fieldLabel =
   "md-label-medium uppercase tracking-wide text-on-surface-variant px-1 mb-1";
 
 export function CardForm(
-  { form, scannerAvailable, saving, onScan, onSubmit, onCancel }: CardFormProps,
+  {
+    form,
+    scannerAvailable,
+    saving,
+    submitLabel = "Save card",
+    submitIcon = "plus",
+    onScan,
+    onSubmit,
+    onCancel,
+  }: CardFormProps,
 ) {
   const value = form.value.value;
   const format = form.format.value;
   const trimmed = value.trim();
   const check = validateBarcode(value, format);
   const canSave = form.label.value.trim().length > 0 && check.ok;
+  const isAuto = !form.manualFormat.value;
 
   const onValueInput = (next: string) => {
     form.value.value = next;
     // Keep the format in sync with the value until the user picks one by hand.
     if (!form.manualFormat.value) form.format.value = detectFormat(next);
+  };
+
+  const pickAuto = () => {
+    form.manualFormat.value = false;
+    form.format.value = detectFormat(form.value.value);
   };
 
   const pickFormat = (f: BarcodeFormat) => {
@@ -108,10 +126,19 @@ export function CardForm(
       <div class="flex flex-col">
         <label class={fieldLabel}>Barcode type</label>
         <div class="flex gap-2 overflow-x-auto pr-1 pb-1">
+          <Chip
+            selected={isAuto}
+            leadingCheck={false}
+            onClick={pickAuto}
+          >
+            {isAuto && trimmed.length > 0
+              ? `Auto · ${formatLabel(format)}`
+              : "Auto"}
+          </Chip>
           {SUPPORTED_FORMATS.map((f) => (
             <Chip
               key={f.format}
-              selected={format === f.format}
+              selected={!isAuto && format === f.format}
               leadingCheck={false}
               onClick={() => pickFormat(f.format)}
             >
@@ -185,12 +212,12 @@ export function CardForm(
         <Button
           variant="filled"
           full
-          icon="plus"
+          icon={submitIcon}
           disabled={!canSave}
           loading={saving}
           onClick={onSubmit}
         >
-          Save card
+          {submitLabel}
         </Button>
       </div>
     </div>

--- a/components/cards/CardPresent.tsx
+++ b/components/cards/CardPresent.tsx
@@ -8,15 +8,18 @@ import { formatLabel } from "@/utils/barcode.ts";
 interface CardPresentProps {
   card: LoyaltyCardInterface;
   onClose: () => void;
+  onEdit: (card: LoyaltyCardInterface) => void;
   onDelete: (id: string) => void;
 }
 
 /**
  * Full-screen "show at the till" view: a large, high-contrast barcode on white
- * so in-store scanners read it reliably, plus the label, number and a
- * confirm-guarded remove action.
+ * so in-store scanners read it reliably, plus the label, number and
+ * confirm-guarded edit/remove actions.
  */
-export function CardPresent({ card, onClose, onDelete }: CardPresentProps) {
+export function CardPresent(
+  { card, onClose, onEdit, onDelete }: CardPresentProps,
+) {
   const confirming = useSignal(false);
   const isQr = card.format === "qrcode";
 
@@ -28,11 +31,18 @@ export function CardPresent({ card, onClose, onDelete }: CardPresentProps) {
       >
         <IconButton name="back" aria-label="Close" onClick={onClose} />
         <span class="md-title-medium truncate px-2">{card.label}</span>
-        <IconButton
-          name="trash"
-          aria-label="Remove card"
-          onClick={() => (confirming.value = true)}
-        />
+        <div class="flex items-center shrink-0">
+          <IconButton
+            name="edit"
+            aria-label="Edit card"
+            onClick={() => onEdit(card)}
+          />
+          <IconButton
+            name="trash"
+            aria-label="Remove card"
+            onClick={() => (confirming.value = true)}
+          />
+        </div>
       </div>
 
       <div class="flex-1 min-h-0 flex flex-col items-center justify-center gap-6 px-6">

--- a/hooks/useLoyaltyCards.test.ts
+++ b/hooks/useLoyaltyCards.test.ts
@@ -89,3 +89,42 @@ Deno.test("refresh — re-pulls cards from the API", async () => {
   }
   assertEquals(hook.cards.value.map((c) => c.label), ["Fresh", "New"]);
 });
+
+Deno.test("updateCard — optimistic: adopts the server-returned card", async () => {
+  const server = { ...card("1", "Colruyt"), color: "rose" };
+  const update = stub(api.cards, "update", () => Promise.resolve(server));
+  const hook = useLoyaltyCards([card("1", "Aldi"), card("2", "Lidl")]);
+  try {
+    const result = await hook.updateCard("1", {
+      label: "Colruyt",
+      value: "9520123456788",
+      format: "ean13",
+      color: "rose",
+    });
+    assertEquals(result, server);
+    const one = hook.cards.value.find((c) => c.id === "1");
+    assertEquals(one?.label, "Colruyt");
+    assertEquals(one?.color, "rose");
+    assertEquals(update.calls.length, 1);
+  } finally {
+    update.restore();
+  }
+});
+
+Deno.test("updateCard — rolls back and returns null on failure", async () => {
+  const update = stub(api.cards, "update", () => Promise.resolve(null));
+  const original = card("1", "Aldi");
+  const hook = useLoyaltyCards([original, card("2", "Lidl")]);
+  try {
+    const result = await hook.updateCard("1", {
+      label: "Broken",
+      value: "bad",
+      format: "ean13",
+    });
+    assertEquals(result, null);
+    // Local state is restored to the pre-edit card.
+    assertEquals(hook.cards.value.find((c) => c.id === "1")?.label, "Aldi");
+  } finally {
+    update.restore();
+  }
+});

--- a/hooks/useLoyaltyCards.ts
+++ b/hooks/useLoyaltyCards.ts
@@ -42,6 +42,28 @@ export function useLoyaltyCards(initialCards: LoyaltyCardInterface[]) {
     }
   };
 
+  const updateCard = async (
+    id: string,
+    input: LoyaltyCardInput,
+  ): Promise<LoyaltyCardInterface | null> => {
+    // Optimistic: apply the edit locally now, snapshot for rollback.
+    const snapshot = cards.value;
+    cards.value = cards.value.map((c) => c.id === id ? { ...c, ...input } : c);
+    startPending();
+    try {
+      const updated = await api.cards.update(id, input);
+      if (!updated) {
+        cards.value = snapshot; // rollback
+        return null;
+      }
+      // Adopt the server's canonical card (in case it normalised anything).
+      cards.value = cards.value.map((c) => (c.id === id ? updated : c));
+      return updated;
+    } finally {
+      endPending();
+    }
+  };
+
   const removeCard = async (id: string): Promise<void> => {
     cards.value = cards.value.filter((c) => c.id !== id);
     startPending();
@@ -63,5 +85,13 @@ export function useLoyaltyCards(initialCards: LoyaltyCardInterface[]) {
     }
   };
 
-  return { cards, pendingCount, sorted, addCard, removeCard, refresh };
+  return {
+    cards,
+    pendingCount,
+    sorted,
+    addCard,
+    updateCard,
+    removeCard,
+    refresh,
+  };
 }

--- a/islands/cards/LoyaltyWallet.tsx
+++ b/islands/cards/LoyaltyWallet.tsx
@@ -36,12 +36,14 @@ function maskValue(value: string): string {
 
 export default function LoyaltyWallet({ initialCards }: Props) {
   // useMemo([]) so the hook's signals are created once from SSR props.
-  const { sorted, cards, addCard, removeCard, refresh } = useMemo(
+  const { sorted, cards, addCard, updateCard, removeCard, refresh } = useMemo(
     () => useLoyaltyCards(initialCards),
     [],
   );
 
-  const addOpen = useSignal(false);
+  const sheetOpen = useSignal(false);
+  // null while adding; the card id while editing an existing card.
+  const editingId = useSignal<string | null>(null);
   const scannerOpen = useSignal(false);
   const present = useSignal<LoyaltyCardInterface | null>(null);
   const saving = useSignal(false);
@@ -67,12 +69,24 @@ export default function LoyaltyWallet({ initialCards }: Props) {
   };
 
   const openAdd = () => {
+    editingId.value = null;
     form.label.value = "";
     form.value.value = "";
     form.format.value = "code128";
     form.color.value = nextColor(cards.value.length);
-    form.manualFormat.value = false;
-    addOpen.value = true;
+    form.manualFormat.value = false; // start in Auto
+    sheetOpen.value = true;
+  };
+
+  const openEdit = (card: LoyaltyCardInterface) => {
+    editingId.value = card.id;
+    form.label.value = card.label;
+    form.value.value = card.value;
+    form.format.value = card.format;
+    form.color.value = card.color ?? DEFAULT_CARD_COLOR;
+    form.manualFormat.value = true; // show the stored type as selected
+    present.value = null;
+    sheetOpen.value = true;
   };
 
   const onScanDetect = (value: string, format: BarcodeFormat) => {
@@ -82,20 +96,26 @@ export default function LoyaltyWallet({ initialCards }: Props) {
     scannerOpen.value = false;
   };
 
-  const handleSave = async () => {
-    saving.value = true;
-    const created = await addCard({
+  const handleSubmit = async () => {
+    const input = {
       label: form.label.value.trim(),
       value: form.value.value.trim(),
       format: form.format.value,
       color: form.color.value,
-    });
+    };
+    saving.value = true;
+    const id = editingId.value;
+    const saved = id ? await updateCard(id, input) : await addCard(input);
     saving.value = false;
-    if (!created) {
-      toast("Couldn't save that card — try again.");
+    if (!saved) {
+      toast(
+        id
+          ? "Couldn't save your changes — try again."
+          : "Couldn't save that card — try again.",
+      );
       return;
     }
-    addOpen.value = false;
+    sheetOpen.value = false;
   };
 
   const handleDelete = (id: string) => {
@@ -105,6 +125,7 @@ export default function LoyaltyWallet({ initialCards }: Props) {
   };
 
   const list = sorted.value;
+  const editing = editingId.value !== null;
 
   return (
     <PullToRefresh onRefresh={refresh}>
@@ -179,17 +200,19 @@ export default function LoyaltyWallet({ initialCards }: Props) {
       </div>
 
       <Sheet
-        open={addOpen.value}
-        onClose={() => (addOpen.value = false)}
-        title="Add a card"
+        open={sheetOpen.value}
+        onClose={() => (sheetOpen.value = false)}
+        title={editing ? "Edit card" : "Add a card"}
       >
         <CardForm
           form={form}
           scannerAvailable={scannerAvailable.value}
           saving={saving.value}
+          submitLabel={editing ? "Save changes" : "Save card"}
+          submitIcon={editing ? "check" : "plus"}
           onScan={() => (scannerOpen.value = true)}
-          onSubmit={handleSave}
-          onCancel={() => (addOpen.value = false)}
+          onSubmit={handleSubmit}
+          onCancel={() => (sheetOpen.value = false)}
         />
       </Sheet>
 
@@ -205,6 +228,7 @@ export default function LoyaltyWallet({ initialCards }: Props) {
         <CardPresent
           card={present.value}
           onClose={() => (present.value = null)}
+          onEdit={openEdit}
           onDelete={handleDelete}
         />
       )}

--- a/routes/api/cards/index.test.ts
+++ b/routes/api/cards/index.test.ts
@@ -37,6 +37,13 @@ const del = (body: unknown) =>
     body: JSON.stringify(body),
   });
 
+const patch = (body: unknown) =>
+  new Request("http://x/api/cards", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
 const validCard = {
   label: "Delhaize",
   value: "9520123456788",
@@ -153,5 +160,98 @@ Deno.test({
       ctx(new Request("http://x/api/cards"), AUTH),
     )).json();
     assertEquals(list, []);
+  },
+});
+
+Deno.test({
+  name: "PATCH updates a card's fields (200) and persists them",
+  sanitizeResources: false,
+  async fn() {
+    await clearCards();
+    const created = await (await handler.POST(ctx(post(validCard), AUTH)))
+      .json();
+    const res = await handler.PATCH(
+      ctx(
+        patch({
+          id: created.id,
+          label: "Delhaize Plus",
+          value: "4006381333931",
+          format: "ean13",
+          color: "rose",
+        }),
+        AUTH,
+      ),
+    );
+    assertEquals(res.status, 200);
+    const updated = await res.json();
+    assertEquals(updated.label, "Delhaize Plus");
+    assertEquals(updated.value, "4006381333931");
+    assertEquals(updated.color, "rose");
+    // id/householdId are untouched.
+    assertEquals(updated.id, created.id);
+    assertEquals(updated.householdId, "h1");
+
+    const list = await (await handler.GET(
+      ctx(new Request("http://x/api/cards"), AUTH),
+    )).json();
+    assertEquals(list.length, 1);
+    assertEquals(list[0].label, "Delhaize Plus");
+  },
+});
+
+Deno.test({
+  name: "PATCH requires a household (401) and an id (400)",
+  sanitizeResources: false,
+  async fn() {
+    await clearCards();
+    assertEquals(
+      (await handler.PATCH(ctx(patch({ ...validCard, id: "x" })))).status,
+      401,
+    );
+    assertEquals(
+      (await handler.PATCH(ctx(patch({ ...validCard }), AUTH))).status,
+      400,
+    );
+  },
+});
+
+Deno.test({
+  name: "PATCH rejects an invalid value (400)",
+  sanitizeResources: false,
+  async fn() {
+    await clearCards();
+    const created = await (await handler.POST(ctx(post(validCard), AUTH)))
+      .json();
+    const res = await handler.PATCH(
+      ctx(
+        patch({ ...validCard, id: created.id, value: "9520123456789" }),
+        AUTH,
+      ),
+    );
+    assertEquals(res.status, 400);
+  },
+});
+
+Deno.test({
+  name: "PATCH returns 404 for an unknown id and never crosses households",
+  sanitizeResources: false,
+  async fn() {
+    await clearCards();
+    // Unknown id.
+    assertEquals(
+      (await handler.PATCH(ctx(patch({ ...validCard, id: "nope" }), AUTH)))
+        .status,
+      404,
+    );
+    // A card owned by another household must be invisible to this one.
+    const theirs = await (await handler.POST(
+      ctx(post(validCard), { userId: "u2", householdId: "h2" }),
+    )).json();
+    assertEquals(
+      (await handler.PATCH(
+        ctx(patch({ ...validCard, id: theirs.id, label: "Hijacked" }), AUTH),
+      )).status,
+      404,
+    );
   },
 });

--- a/routes/api/cards/index.ts
+++ b/routes/api/cards/index.ts
@@ -55,6 +55,35 @@ export const handler = define.handlers({
     return json(card, 201);
   },
 
+  async PATCH(ctx) {
+    const householdId = ctx.state.householdId;
+    if (!householdId) return new Response("Unauthorized", { status: 401 });
+    const body = await ctx.req.json();
+    const id = body.id ? String(body.id) : "";
+    if (!id) return new Response("ID is required", { status: 400 });
+
+    const label = String(body.label ?? "").trim();
+    const value = String(body.value ?? "").trim();
+    const format = body.format as BarcodeFormat;
+    const color = body.color ? String(body.color) : undefined;
+
+    if (!label) return new Response("label required", { status: 400 });
+    if (!FORMATS.has(format)) {
+      return new Response("invalid format", { status: 400 });
+    }
+    const check = validateBarcode(value, format);
+    if (!check.ok) return new Response(check.message, { status: 400 });
+
+    const updated = await LoyaltyCardRepo.update(householdId, id, {
+      label,
+      value,
+      format,
+      color,
+    });
+    if (!updated) return new Response("Card not found", { status: 404 });
+    return json(updated, 200);
+  },
+
   async DELETE(ctx) {
     const householdId = ctx.state.householdId;
     if (!householdId) return new Response("Unauthorized", { status: 401 });

--- a/services/api.ts
+++ b/services/api.ts
@@ -225,6 +225,18 @@ export const api = {
       if (!res.ok) return null;
       return res.json();
     },
+    update: async (
+      id: string,
+      card: LoyaltyCardInput,
+    ): Promise<LoyaltyCardInterface | null> => {
+      const res = await fetch("/api/cards", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id, ...card }),
+      });
+      if (!res.ok) return null;
+      return res.json();
+    },
     delete: async (id: string): Promise<void> => {
       await fetch("/api/cards", {
         method: "DELETE",


### PR DESCRIPTION
Follow-up to the loyalty-cards module (#16, merged in #56) adding two requested features.

## 1. Edit an existing card (all fields)

- An **Edit** (pencil) action in the full-screen card view reopens the form **pre-filled** — "Edit card" title, "Save changes" button. Name, number, type and colour are all editable; changing the number/type regenerates the barcode.
- New **`PATCH /api/cards`** — household-scoped (`401` without a household, `400` on invalid label/format/value, **`404` for an unknown or cross-household id**), reusing the existing `LoyaltyCardRepo.update` (no model/repo change).
- `useLoyaltyCards.updateCard` is **optimistic**: it patches locally, adopts the server's canonical card on success, and **rolls back + shows a Snackbar** on failure — matching the documented mutation conventions.

## 2. Explicit "Auto" format option

- The barcode-type selector now leads with a first-class **"Auto"** chip, selected by default. It re-detects the symbology from the number live and shows what it resolved to (e.g. `Auto · EAN-13`); picking a concrete type overrides it, and tapping Auto restores live detection.
- Storage still holds a **concrete** format (what bwip-js needs) — "Auto" is a form mode only, so nothing changes in the model, repo, or persisted data.

## Testing

TDD — **6 new tests** (4 PATCH endpoint cases incl. the cross-household `404`; 2 `updateCard` optimistic/rollback). Full suite **330 passing**, `deno task check` green.

Live-verified on mobile: edited a card's name and colour (persisted — confirmed via API and SSR reload), and the Auto chip resolved `Auto · EAN-13` live and deselected correctly when a type was chosen manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)