### PR TITLE
fix(menu): merge dish tag groups duplicated by the migration race

### DIFF
--- a/.github/workflows/dedupe-prod-menu-tags.yml
+++ b/.github/workflows/dedupe-prod-menu-tags.yml
@@ -1,0 +1,65 @@
+name: Dedupe production menu tag groups
+
+# One-off / on-demand cleanup (see scripts/dedupe-dish-tag-groups.ts): merge
+# the duplicated dish tag groups ("Type", "Meal", "Side type") left behind when
+# lazy per-household seeding raced the issue-#42 catalogue migration.
+#
+# Dry run by default — it prints the merge plan and mutates nothing. Re-run
+# with "apply" checked (and DEDUPE typed in the confirm field) to commit.
+# Idempotent: once merged, re-runs find nothing to do.
+#
+# Uses the same production credentials as migrate-prod-kv.yml:
+#   vars.DENO_KV_DATABASE_ID / secrets.DENO_KV_ACCESS_TOKEN (Production
+#   environment).
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: "Apply the merge (unchecked = dry run, prints the plan only)"
+        required: false
+        default: false
+        type: boolean
+      confirm:
+        description: "Type DEDUPE to confirm when applying (ignored for dry runs)"
+        required: false
+        type: string
+
+# Never let two runs (or a run and the migration) touch the same KV at once.
+concurrency:
+  group: migrate-prod-kv
+  cancel-in-progress: false
+
+jobs:
+  dedupe:
+    name: Dedupe production menu tag groups
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Require explicit confirmation when applying
+        if: ${{ inputs.apply && inputs.confirm != 'DEDUPE' }}
+        run: |
+          echo "::error::Confirmation failed — re-run with DEDUPE typed in the confirm field."
+          exit 1
+
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Install Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Install dependencies
+        run: deno install
+
+      - name: Run dedupe against production KV
+        env:
+          # Locally (isDeploy=false) getKv() honors KV_PATH; an https:// value
+          # connects to the remote production KV via KV Connect.
+          KV_PATH: "https://api.deno.com/v2/databases/${{ vars.DENO_KV_DATABASE_ID }}/connect"
+          DENO_KV_ACCESS_TOKEN: ${{ secrets.DENO_KV_ACCESS_TOKEN }}
+        run: |
+          deno run --unstable-kv -A scripts/dedupe-dish-tag-groups.ts \
+            ${{ inputs.apply && '--apply' || '' }}

--- a/deno.json
+++ b/deno.json
@@ -11,6 +11,7 @@
     "db:migrate": "deno run --env-file --unstable-kv -A scripts/migrate.ts",
     "db:view": "deno run --env-file --unstable-kv -A scripts/db-viewer.ts",
     "db:login": "deno run --env-file --unstable-kv -A scripts/provision-login.ts",
+    "db:dedupe-menu-tags": "deno run --env-file --unstable-kv -A scripts/dedupe-dish-tag-groups.ts",
     "update": "deno run -A -r jsr:@fresh/update ."
   },
   "lint": {

--- a/docs/running-migrations.md
+++ b/docs/running-migrations.md
@@ -70,6 +70,24 @@ Locally `getKv()` honors `KV_PATH`; the `https://` value connects to the remote
 production KV. A successful run logs `Migration complete … Catalogue: scoped to
 household …`; a re-run logs `no global entries to scope (skipped)`.
 
+## Cleanup: duplicated dish tag groups
+
+In production the catalogue migration was raced by lazy per-household seeding
+(`DishTagGroupRepo.ensureDefaults`): a `/menu` visit before the migration
+seeded fresh default tag groups, and the migration then moved the old global
+groups under the same household — duplicating "Type", "Meal" and "Side type".
+
+`scripts/dedupe-dish-tag-groups.ts` (`deno task db:dedupe-menu-tags`) merges
+them: per household, same-label groups collapse into the copy dishes reference
+most, dishes pointing at a dropped value are rewritten to the keeper's
+same-label value, and custom values are preserved. **Dry run by default** —
+pass `--apply` to commit. Idempotent.
+
+Against production, use the **Dedupe production menu tag groups** workflow
+(`.github/workflows/dedupe-prod-menu-tags.yml`): run it once as a dry run,
+check the printed plan, then re-run with "apply" checked and `DEDUPE` typed in
+the confirm field.
+
 ## Local development
 
 Against the local file KV, `deno task db:migrate` reads `.env`. For a fresh dev

--- a/scripts/dedupe-dish-tag-groups.test.ts
+++ b/scripts/dedupe-dish-tag-groups.test.ts
@@ -1,0 +1,231 @@
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+
+// Isolated in-memory KV for this test process.
+Deno.env.set("KV_PATH", ":memory:");
+
+import { getKv } from "@/database/db.ts";
+import { DishInterface, DishTagGroupInterface } from "@/models/index.ts";
+import { dedupeDishTagGroups, planDedupe } from "./dedupe-dish-tag-groups.ts";
+
+function group(
+  id: string,
+  label: string,
+  values: { id: string; label: string }[],
+  order = 0,
+): DishTagGroupInterface {
+  return { id, label, order, values };
+}
+
+function dish(id: string, tagValueIds: string[]): DishInterface {
+  return { id, name: `dish-${id}`, ingredientIds: [], tagValueIds };
+}
+
+Deno.test("planDedupe — no duplicate labels → empty plan", () => {
+  const groups = [
+    group("g1", "Type", [{ id: "v1", label: "Meat" }]),
+    group("g2", "Meal", [{ id: "v2", label: "Lunch" }]),
+  ];
+  assertEquals(planDedupe(groups, []), []);
+});
+
+Deno.test("planDedupe — keeps the copy whose values dishes reference", () => {
+  const migrated = group("g-old", "Type", [
+    { id: "v-old-1", label: "Vegetarian" },
+    { id: "v-old-2", label: "Meat" },
+  ], 0);
+  const seeded = group("g-new", "Type", [
+    { id: "v-new-1", label: "Vegetarian" },
+    { id: "v-new-2", label: "Meat" },
+  ], 0);
+  const dishes = [dish("d1", ["v-old-2"])];
+
+  const plan = planDedupe([seeded, migrated], dishes);
+  assertEquals(plan.length, 1);
+  assertEquals(plan[0].keepId, "g-old");
+  assertEquals(plan[0].deleteIds, ["g-new"]);
+  // Same-label values of the pristine copy are dropped, not merged.
+  assertEquals(plan[0].keptGroup.values, migrated.values);
+  assertEquals(plan[0].dishRewrites, []);
+});
+
+Deno.test("planDedupe — moves custom (unmatched-label) values into the keeper", () => {
+  const migrated = group("g-old", "Side type", [
+    { id: "v-old-1", label: "Rice" },
+  ]);
+  const seeded = group("g-new", "Side type", [
+    { id: "v-new-1", label: "Rice" },
+    { id: "v-custom", label: "Couscous" }, // user-added on the losing copy
+  ]);
+  const dishes = [dish("d1", ["v-old-1"])];
+
+  const plan = planDedupe([migrated, seeded], dishes);
+  assertEquals(plan[0].keepId, "g-old");
+  assertEquals(plan[0].keptGroup.values, [
+    { id: "v-old-1", label: "Rice" },
+    { id: "v-custom", label: "Couscous" },
+  ]);
+});
+
+Deno.test("planDedupe — rewrites dishes referencing a dropped same-label value", () => {
+  const migrated = group("g-old", "Type", [
+    { id: "v-old-meat", label: "Meat" },
+  ]);
+  const seeded = group("g-new", "Type", [
+    { id: "v-new-meat", label: "Meat" },
+  ]);
+  // Two dishes tagged via the migrated copy, one via the seeded copy: the
+  // migrated copy wins (most dish references) and the odd one out is rewritten.
+  const dishes = [
+    dish("d1", ["v-old-meat"]),
+    dish("d2", ["v-old-meat"]),
+    dish("d3", ["v-new-meat", "unrelated-id"]),
+  ];
+
+  const plan = planDedupe([migrated, seeded], dishes);
+  assertEquals(plan[0].keepId, "g-old");
+  assertEquals(plan[0].dishRewrites, [
+    { dishId: "d3", tagValueIds: ["v-old-meat", "unrelated-id"] },
+  ]);
+});
+
+Deno.test("planDedupe — a dish referencing both copies ends with one deduped id", () => {
+  // Symmetric references (one each) → tie broken by lowest group id: g-a wins.
+  const a = group("g-a", "Type", [{ id: "va", label: "Meat" }]);
+  const b = group("g-b", "Type", [{ id: "vb", label: "Meat" }]);
+  const dishes = [dish("d1", ["va", "vb"])];
+
+  const plan = planDedupe([a, b], dishes);
+  assertEquals(plan[0].keepId, "g-a");
+  assertEquals(plan[0].dishRewrites, [
+    { dishId: "d1", tagValueIds: ["va"] },
+  ]);
+});
+
+Deno.test("planDedupe — no references at all → keeps exactly one copy deterministically", () => {
+  const a = group("g-a", "Meal", [{ id: "va", label: "Lunch" }], 1);
+  const b = group("g-b", "Meal", [{ id: "vb", label: "Lunch" }], 1);
+
+  const plan = planDedupe([a, b], []);
+  assertEquals(plan.length, 1);
+  // Tie on references and value count → lowest id wins for determinism.
+  assertEquals(plan[0].keepId, "g-a");
+  assertEquals(plan[0].deleteIds, ["g-b"]);
+  assertEquals(plan[0].keptGroup.values, [{ id: "va", label: "Lunch" }]);
+});
+
+Deno.test("planDedupe — matches group labels case-insensitively and trimmed", () => {
+  const a = group("g-a", "Type", [{ id: "va", label: "Meat" }]);
+  const b = group("g-b", " type ", [{ id: "vb", label: "meat" }]);
+
+  const plan = planDedupe([a, b], [dish("d1", ["va"])]);
+  assertEquals(plan.length, 1);
+  assertEquals(plan[0].keepId, "g-a");
+  // "meat" matches "Meat" → dropped, not duplicated into the keeper.
+  assertEquals(plan[0].keptGroup.values, [{ id: "va", label: "Meat" }]);
+});
+
+async function clearMenuData() {
+  const kv = await getKv();
+  for (const c of ["dishes", "dish_tag_groups"]) {
+    for await (const e of kv.list({ prefix: [c] })) await kv.delete(e.key);
+  }
+}
+
+async function seedDuplicatedHousehold(householdId: string) {
+  const kv = await getKv();
+  await kv.set(
+    ["dish_tag_groups", householdId, "g-old"],
+    group("g-old", "Type", [
+      { id: "v-old-meat", label: "Meat" },
+    ]),
+  );
+  await kv.set(
+    ["dish_tag_groups", householdId, "g-new"],
+    group("g-new", "Type", [
+      { id: "v-new-meat", label: "Meat" },
+    ]),
+  );
+  // Two dishes on the migrated copy, one on the seeded copy.
+  await kv.set(["dishes", householdId, "d1"], dish("d1", ["v-old-meat"]));
+  await kv.set(["dishes", householdId, "d2"], dish("d2", ["v-old-meat"]));
+  await kv.set(["dishes", householdId, "d3"], dish("d3", ["v-new-meat"]));
+}
+
+Deno.test({
+  name:
+    "dedupeDishTagGroups — dry run (apply=false) reports but mutates nothing",
+  sanitizeResources: false,
+  async fn() {
+    const kv = await getKv();
+    await clearMenuData();
+    await seedDuplicatedHousehold("hh-1");
+
+    const report = await dedupeDishTagGroups(kv, false);
+    assertEquals(Object.keys(report), ["hh-1"]);
+    assertEquals(report["hh-1"].length, 1);
+    assertEquals(report["hh-1"][0].deleteIds, ["g-new"]);
+
+    // Nothing changed.
+    assertEquals(
+      ((await kv.get(["dish_tag_groups", "hh-1", "g-new"])).value as
+        | DishTagGroupInterface
+        | null)?.id,
+      "g-new",
+    );
+    assertEquals(
+      ((await kv.get(["dishes", "hh-1", "d3"])).value as DishInterface)
+        .tagValueIds,
+      ["v-new-meat"],
+    );
+  },
+});
+
+Deno.test({
+  name:
+    "dedupeDishTagGroups — apply merges groups, deletes losers, rewrites dishes",
+  sanitizeResources: false,
+  async fn() {
+    const kv = await getKv();
+    await clearMenuData();
+    await seedDuplicatedHousehold("hh-1");
+
+    await dedupeDishTagGroups(kv, true);
+
+    assertEquals(
+      (await kv.get(["dish_tag_groups", "hh-1", "g-new"])).value,
+      null,
+    );
+    const kept = (await kv.get(["dish_tag_groups", "hh-1", "g-old"]))
+      .value as DishTagGroupInterface;
+    assertEquals(kept.values, [{ id: "v-old-meat", label: "Meat" }]);
+    // The dish tagged via the deleted copy is remapped; the others untouched.
+    const d3 = (await kv.get(["dishes", "hh-1", "d3"])).value as DishInterface;
+    assertEquals(d3.tagValueIds, ["v-old-meat"]);
+    const d1 = (await kv.get(["dishes", "hh-1", "d1"])).value as DishInterface;
+    assertEquals(d1.tagValueIds, ["v-old-meat"]);
+
+    // Idempotent: a second pass finds nothing to do.
+    const again = await dedupeDishTagGroups(kv, false);
+    assertEquals(again, {});
+  },
+});
+
+Deno.test({
+  name: "dedupeDishTagGroups — households without duplicates are untouched",
+  sanitizeResources: false,
+  async fn() {
+    const kv = await getKv();
+    await clearMenuData();
+    await seedDuplicatedHousehold("hh-1");
+    await kv.set(
+      ["dish_tag_groups", "hh-2", "g-solo"],
+      group("g-solo", "Type", [{ id: "v1", label: "Fish" }]),
+    );
+
+    const report = await dedupeDishTagGroups(kv, true);
+    assertEquals(Object.keys(report), ["hh-1"]);
+    const solo = (await kv.get(["dish_tag_groups", "hh-2", "g-solo"]))
+      .value as DishTagGroupInterface;
+    assertEquals(solo.values, [{ id: "v1", label: "Fish" }]);
+  },
+});

--- a/scripts/dedupe-dish-tag-groups.ts
+++ b/scripts/dedupe-dish-tag-groups.ts
@@ -1,0 +1,273 @@
+// scripts/dedupe-dish-tag-groups.ts
+//
+// One-off, manually-run cleanup for duplicated dish tag groups ("Type",
+// "Meal", "Side type"). The issue-#42 catalogue migration warned that lazy
+// per-household seeding (DishTagGroupRepo.ensureDefaults) could race the
+// catalogue move: a /menu visit before the migration seeded fresh default
+// groups, and the migration then moved the old global groups under the same
+// household — leaving two copies of each group.
+//
+// For every household, groups with the same (trimmed, case-insensitive) label
+// are merged into one keeper — the copy whose values dishes actually
+// reference. Same-label values of the losing copies are dropped (dishes
+// referencing them are rewritten to the keeper's value), and values with a
+// label the keeper lacks (user-added customs) are moved into the keeper.
+//
+// DRY RUN by default: prints the plan and mutates nothing. Pass --apply to
+// commit. Idempotent — after an apply, a re-run finds nothing to do.
+//
+// Environment: the usual KV selection (KV_PATH / DENO_KV_ACCESS_TOKEN for a
+// remote KV Connect run — see docs/running-migrations.md).
+import { getKv } from "@/database/db.ts";
+import {
+  DishInterface,
+  DishTagGroupInterface,
+  DishTagValueInterface,
+} from "@/models/index.ts";
+
+export interface DishRewrite {
+  dishId: string;
+  tagValueIds: string[];
+}
+
+export interface GroupMergePlan {
+  label: string;
+  keepId: string;
+  deleteIds: string[];
+  /** The keeper with the losers' unmatched values merged in. */
+  keptGroup: DishTagGroupInterface;
+  /** Loser values dropped because the keeper has a same-label value. */
+  droppedValues: DishTagValueInterface[];
+  /** Loser values moved into the keeper (label not present there). */
+  movedValues: DishTagValueInterface[];
+  /** Dishes whose tagValueIds change, with their final (fully-remapped) ids. */
+  dishRewrites: DishRewrite[];
+}
+
+const norm = (s: string) => s.trim().toLowerCase();
+
+/**
+ * Plans the merge of same-label dish tag groups for one household. Pure —
+ * mutates nothing. The keeper of each label is the copy with the most
+ * dish-referenced values (ties: more values, lower order, lower id).
+ * `dishRewrites` carry each dish's final ids across ALL merged labels, so
+ * applying the rewrites of any one plan entry never undoes another's.
+ */
+export function planDedupe(
+  groups: DishTagGroupInterface[],
+  dishes: DishInterface[],
+): GroupMergePlan[] {
+  // How many dishes reference each value id — the keeper of a duplicated
+  // label is the copy with the most dish references (fewest rewrites).
+  const referenceCount = new Map<string, number>();
+  for (const d of dishes) {
+    for (const id of d.tagValueIds) {
+      referenceCount.set(id, (referenceCount.get(id) ?? 0) + 1);
+    }
+  }
+  const buckets = new Map<string, DishTagGroupInterface[]>();
+  for (const g of groups) {
+    const key = norm(g.label);
+    buckets.set(key, [...(buckets.get(key) ?? []), g]);
+  }
+
+  // dropped value id → keeper value id, across all duplicated labels.
+  const remap = new Map<string, string>();
+  // plan entry → the dropped ids that belong to it, to attach rewrites below.
+  const droppedIdsByPlan: Set<string>[] = [];
+  const plans: GroupMergePlan[] = [];
+
+  for (const copies of buckets.values()) {
+    if (copies.length < 2) continue;
+    const refCount = (g: DishTagGroupInterface) =>
+      g.values.reduce((sum, v) => sum + (referenceCount.get(v.id) ?? 0), 0);
+    const ranked = [...copies].sort((a, b) =>
+      refCount(b) - refCount(a) ||
+      b.values.length - a.values.length ||
+      (a.order ?? 0) - (b.order ?? 0) ||
+      a.id.localeCompare(b.id)
+    );
+    const [keeper, ...losers] = ranked;
+
+    const mergedValues = [...keeper.values];
+    const droppedValues: DishTagValueInterface[] = [];
+    const movedValues: DishTagValueInterface[] = [];
+    const droppedIds = new Set<string>();
+    for (const loser of losers) {
+      for (const value of loser.values) {
+        const match = mergedValues.find((v) =>
+          norm(v.label) === norm(value.label)
+        );
+        if (match) {
+          remap.set(value.id, match.id);
+          droppedIds.add(value.id);
+          droppedValues.push(value);
+        } else {
+          mergedValues.push(value);
+          movedValues.push(value);
+        }
+      }
+    }
+
+    droppedIdsByPlan.push(droppedIds);
+    plans.push({
+      label: keeper.label,
+      keepId: keeper.id,
+      deleteIds: losers.map((l) => l.id),
+      keptGroup: { ...keeper, values: mergedValues },
+      droppedValues,
+      movedValues,
+      dishRewrites: [],
+    });
+  }
+
+  // Rewrite dishes once, against the global remap, then attach each rewrite
+  // to every plan entry whose dropped values the dish referenced.
+  for (const d of dishes) {
+    const next: string[] = [];
+    for (const id of d.tagValueIds) {
+      const mapped = remap.get(id) ?? id;
+      if (!next.includes(mapped)) next.push(mapped);
+    }
+    const changed = next.length !== d.tagValueIds.length ||
+      next.some((id, i) => id !== d.tagValueIds[i]);
+    if (!changed) continue;
+    const rewrite: DishRewrite = { dishId: d.id, tagValueIds: next };
+    plans.forEach((plan, i) => {
+      if (d.tagValueIds.some((id) => droppedIdsByPlan[i].has(id))) {
+        plan.dishRewrites.push(rewrite);
+      }
+    });
+  }
+
+  return plans;
+}
+
+/**
+ * Plans (and with `apply` set, commits) the dedupe for every household that
+ * has duplicated tag-group labels. Returns the plans keyed by household id;
+ * households with nothing to merge are omitted.
+ */
+export async function dedupeDishTagGroups(
+  kv: Deno.Kv,
+  apply: boolean,
+): Promise<Record<string, GroupMergePlan[]>> {
+  const groupsByHousehold = new Map<string, DishTagGroupInterface[]>();
+  for await (
+    const entry of kv.list<DishTagGroupInterface>({
+      prefix: ["dish_tag_groups"],
+    })
+  ) {
+    // Keys are ["dish_tag_groups", householdId, groupId]; an unscoped
+    // (length-2) key would predate the issue-#42 migration — leave it alone.
+    if (entry.key.length !== 3) {
+      console.warn(`  Skipping unscoped key ${JSON.stringify(entry.key)}`);
+      continue;
+    }
+    const householdId = entry.key[1] as string;
+    groupsByHousehold.set(householdId, [
+      ...(groupsByHousehold.get(householdId) ?? []),
+      entry.value,
+    ]);
+  }
+
+  const report: Record<string, GroupMergePlan[]> = {};
+  for (const [householdId, groups] of groupsByHousehold) {
+    const dishes: DishInterface[] = [];
+    for await (
+      const entry of kv.list<DishInterface>({ prefix: ["dishes", householdId] })
+    ) dishes.push(entry.value);
+
+    const plans = planDedupe(groups, dishes);
+    if (plans.length === 0) continue;
+    report[householdId] = plans;
+
+    if (!apply) continue;
+    let atomic = kv.atomic();
+    const rewrittenDishes = new Map<string, string[]>();
+    for (const plan of plans) {
+      atomic = atomic.set(
+        ["dish_tag_groups", householdId, plan.keepId],
+        plan.keptGroup,
+      );
+      for (const id of plan.deleteIds) {
+        atomic = atomic.delete(["dish_tag_groups", householdId, id]);
+      }
+      for (const rw of plan.dishRewrites) {
+        rewrittenDishes.set(rw.dishId, rw.tagValueIds);
+      }
+    }
+    for (const [dishId, tagValueIds] of rewrittenDishes) {
+      const dish = dishes.find((d) => d.id === dishId);
+      if (!dish) continue;
+      atomic = atomic.set(["dishes", householdId, dishId], {
+        ...dish,
+        tagValueIds,
+      });
+    }
+    const ok = await atomic.commit();
+    if (!ok.ok) {
+      throw new Error(`Dedupe commit failed for household ${householdId}.`);
+    }
+  }
+  return report;
+}
+
+async function main() {
+  const apply = Deno.args.includes("--apply");
+  const kv = await getKv();
+  try {
+    const report = await dedupeDishTagGroups(kv, apply);
+    const households = Object.keys(report);
+    if (households.length === 0) {
+      console.log("No duplicated dish tag groups found. Nothing to do.");
+      return;
+    }
+    for (const householdId of households) {
+      console.log(`\nHousehold ${householdId}:`);
+      for (const plan of report[householdId]) {
+        console.log(
+          `  "${plan.label}": keep ${plan.keepId}, delete ${
+            plan.deleteIds.join(", ")
+          }`,
+        );
+        console.log(
+          `    values kept: ${
+            plan.keptGroup.values.map((v) => v.label).join(", ")
+          }`,
+        );
+        if (plan.movedValues.length > 0) {
+          console.log(
+            `    moved from losing copy: ${
+              plan.movedValues.map((v) => v.label).join(", ")
+            }`,
+          );
+        }
+        if (plan.droppedValues.length > 0) {
+          console.log(
+            `    dropped duplicates: ${plan.droppedValues.length} value(s)`,
+          );
+        }
+        for (const rw of plan.dishRewrites) {
+          console.log(
+            `    rewrite dish ${rw.dishId} → [${rw.tagValueIds.join(", ")}]`,
+          );
+        }
+      }
+    }
+    console.log(
+      apply
+        ? "\nApplied. Re-run without --apply to verify nothing remains."
+        : "\nDRY RUN — nothing was changed. Re-run with --apply to commit.",
+    );
+  } finally {
+    kv.close();
+  }
+}
+
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error("Dedupe failed:", err);
+    Deno.exit(1);
+  });
+}


### PR DESCRIPTION
## Problem

In production the menu feature shows every dish tag group twice ("Type", "Meal", "Side type"). Root cause: the race the issue-#42 migration itself warned about ([scripts/migrate.ts](../blob/main/scripts/migrate.ts) lines 15–17) — a `/menu` visit **before** the manual migration ran triggered `DishTagGroupRepo.ensureDefaults`, which saw an empty household-scoped collection and seeded fresh default groups; the migration then moved the old global groups under the same household, leaving two copies of each.

## Fix

- **`scripts/dedupe-dish-tag-groups.ts`** (`deno task db:dedupe-menu-tags`): per household, same-label groups merge into the copy dishes reference most; dishes pointing at a dropped duplicate value are rewritten to the keeper's same-label value; custom (unmatched-label) values are moved into the keeper. **Dry run by default**, `--apply` to commit, idempotent, atomic per household.
- **`.github/workflows/dedupe-prod-menu-tags.yml`**: `workflow_dispatch`-only runner against the production KV, reusing the Production environment credentials from the migrate workflow. Shares the `migrate-prod-kv` concurrency group so it can never race the migration.
- Ops notes added to `docs/running-migrations.md`.

## Testing

- 10 new KV-backed tests (`scripts/dedupe-dish-tag-groups.test.ts`) — written first, watched fail, then implemented.
- `deno task check` and the full suite (383 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)