### PR TITLE
fix(auth): centralize session cookie handling and clear stale cookies

### DIFF
--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -2,7 +2,11 @@ import { Context } from "fresh";
 import { getCookies } from "$std/http/cookie.ts";
 import { SessionRepo } from "@/database/session.repo.ts";
 import { UserRepo } from "@/database/user.repo.ts";
-import { setSessionCookie } from "@/utils/index.ts";
+import {
+  deleteSessionCookie,
+  SESSION_COOKIE_NAME,
+  setSessionCookie,
+} from "@/utils/index.ts";
 
 interface State {
   userId?: string;
@@ -29,7 +33,7 @@ export async function handler(
 
   // 2. Session Check
   const cookies = getCookies(req.headers);
-  const sessionId = cookies.sessionId;
+  const sessionId = cookies[SESSION_COOKIE_NAME];
 
   if (sessionId) {
     const session = await SessionRepo.findById(sessionId);
@@ -64,6 +68,12 @@ export async function handler(
 
   // Redirect to login for page requests
   const headers = new Headers();
+  if (sessionId) {
+    // The cookie pointed at a dead session (expired, or dropped by e.g. a
+    // reseed). Clear it, or it causes a KV miss on every request for up to
+    // the cookie's 30-day lifetime.
+    deleteSessionCookie(headers);
+  }
   headers.set("location", "/login");
   return new Response(null, {
     status: 303,

--- a/routes/logout.ts
+++ b/routes/logout.ts
@@ -1,21 +1,19 @@
 import { Handlers } from "fresh/compat";
-import { deleteCookie, getCookies } from "$std/http/cookie.ts";
+import { getCookies } from "$std/http/cookie.ts";
 import { SessionRepo } from "../database/session.repo.ts";
+import { deleteSessionCookie, SESSION_COOKIE_NAME } from "@/utils/index.ts";
 
 export const handler: Handlers = {
   async GET(ctx) {
     const cookies = getCookies(ctx.req.headers);
-    const sessionId = cookies.sessionId;
+    const sessionId = cookies[SESSION_COOKIE_NAME];
 
     if (sessionId) {
       await SessionRepo.delete(sessionId);
     }
 
     const headers = new Headers();
-    // Must mirror the attributes used in utils/session-cookie.ts — a
-    // host-only cookie is only cleared by a host-only delete, so no
-    // `domain` here either.
-    deleteCookie(headers, "sessionId", { path: "/" });
+    deleteSessionCookie(headers);
     headers.set("location", "/login");
 
     return new Response(null, {

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -98,6 +98,35 @@ Deno.test({
 });
 
 Deno.test({
+  name:
+    "middleware — invalid session cookie gets cleared on the /login redirect",
+  sanitizeResources: false,
+  async fn() {
+    const response = await handler(fakeCtx(pageRequest("no-such-session")));
+
+    assertEquals(response.status, 303);
+    // Without this, a dead 30-day cookie causes a KV miss on every request.
+    const cookie = response.headers.get("set-cookie")!;
+    assertMatch(cookie, /^sessionId=;/);
+    assertMatch(cookie, /Expires=Thu, 01 Jan 1970 00:00:00 GMT/i);
+  },
+});
+
+Deno.test({
+  name:
+    "middleware — no Set-Cookie on the /login redirect without a session cookie",
+  sanitizeResources: false,
+  async fn() {
+    const response = await handler(
+      fakeCtx(new Request("http://localhost:8000/shopping")),
+    );
+
+    assertEquals(response.status, 303);
+    assertEquals(response.headers.get("set-cookie"), null);
+  },
+});
+
+Deno.test({
   name: "middleware — unknown session still gets 401 on /api",
   sanitizeResources: false,
   async fn() {

--- a/utils/session-cookie.test.ts
+++ b/utils/session-cookie.test.ts
@@ -1,5 +1,9 @@
 import { assertEquals, assertMatch } from "jsr:@std/assert@^1.0.19";
-import { setSessionCookie } from "@/utils/session-cookie.ts";
+import {
+  deleteSessionCookie,
+  SESSION_COOKIE_NAME,
+  setSessionCookie,
+} from "@/utils/session-cookie.ts";
 
 Deno.test("setSessionCookie — sets a secure, HttpOnly, host-only cookie", () => {
   const headers = new Headers();
@@ -13,5 +17,18 @@ Deno.test("setSessionCookie — sets a secure, HttpOnly, host-only cookie", () =
   assertMatch(cookie, /SameSite=Lax/i);
   assertMatch(cookie, /Path=\//i);
   // Host-only: no Domain attribute (see the comment in the helper).
+  assertEquals(/Domain=/i.test(cookie), false);
+});
+
+Deno.test("deleteSessionCookie — expires the cookie with matching name, path, and host-only scope", () => {
+  const headers = new Headers();
+  deleteSessionCookie(headers);
+
+  const cookie = headers.get("set-cookie")!;
+  // A cookie is only cleared when name, path, and domain scope all match
+  // what setSessionCookie used.
+  assertMatch(cookie, new RegExp(`^${SESSION_COOKIE_NAME}=;`));
+  assertMatch(cookie, /Path=\//i);
+  assertMatch(cookie, /Expires=Thu, 01 Jan 1970 00:00:00 GMT/i);
   assertEquals(/Domain=/i.test(cookie), false);
 });

--- a/utils/session-cookie.ts
+++ b/utils/session-cookie.ts
@@ -1,9 +1,10 @@
-import { setCookie } from "$std/http/cookie.ts";
+import { deleteCookie, setCookie } from "$std/http/cookie.ts";
+
+export const SESSION_COOKIE_NAME = "sessionId";
 
 /**
- * The single place that knows the session cookie's attributes. Login and
- * the auth middleware both go through here; routes/logout.ts must keep its
- * deleteCookie attributes in sync with these.
+ * The single place that knows the session cookie's attributes. Login, logout,
+ * and the auth middleware all go through here.
  */
 export function setSessionCookie(
   headers: Headers,
@@ -11,7 +12,7 @@ export function setSessionCookie(
   maxAgeSeconds: number,
 ): void {
   setCookie(headers, {
-    name: "sessionId",
+    name: SESSION_COOKIE_NAME,
     value: sessionId,
     maxAge: maxAgeSeconds,
     sameSite: "Lax",
@@ -27,4 +28,13 @@ export function setSessionCookie(
     // the iOS PWA).
     httpOnly: true,
   });
+}
+
+/**
+ * Browsers only clear a cookie when the delete's name, path, and domain
+ * scope match the original — so this must stay the mirror of
+ * setSessionCookie: same name, `Path=/`, and host-only (no `domain`).
+ */
+export function deleteSessionCookie(headers: Headers): void {
+  deleteCookie(headers, SESSION_COOKIE_NAME, { path: "/" });
 }


### PR DESCRIPTION
## Summary

Follow-up to #67 (sliding sessions), resolving the two Minor findings deferred from its final code review:

- **Single source of truth for the session cookie** — the cookie name `sessionId` was duplicated by convention across `utils/session-cookie.ts`, `routes/logout.ts`, and `routes/_middleware.ts`, and logout's `deleteCookie` attributes were only kept in sync with `setSessionCookie` via comments. `utils/session-cookie.ts` now exports `SESSION_COOKIE_NAME` and a `deleteSessionCookie(headers)` helper, adopted everywhere.
- **Stale cookies are cleared on the login redirect** — a request carrying a cookie for an expired/deleted session (e.g. after a reseed drops all sessions) was redirected to `/login` without clearing the cookie. With 30-day sliding cookies, that dead cookie caused a KV miss on every request for up to a month. The middleware now deletes it on the unauthorized page-redirect path.

## Tests

- `utils/session-cookie.test.ts`: `deleteSessionCookie` emits a delete with matching name, `Path=/`, and host-only scope (no `Domain`) — the attributes a browser needs to actually clear the cookie.
- `tests/middleware.test.ts`: an invalid session cookie gets cleared on the `/login` redirect; no `Set-Cookie` is emitted when the request carried no session cookie.
- `deno task check` and `deno task test` green (398 passed).
- Browser-verified end-to-end: with a bogus `sessionId` cookie, visiting `/shopping` redirects to `/login` and the cookie is gone afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)