### PR TITLE
feat(pwa): keep the screen awake while shopping (wake lock)

### DIFF
--- a/docs/superpowers/plans/2026-08-11-wake-lock.md
+++ b/docs/superpowers/plans/2026-08-11-wake-lock.md
@@ -1,0 +1,325 @@
+# Wake Lock While Shopping Implementation Plan (issue #73)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The screen stays awake while a shopping list with unchecked items is
+open, and releases when the trip is done, the tab hides, or the member leaves.
+
+**Architecture:** A reusable `hooks/useWakeLock.ts` owns the whole wake-lock
+lifecycle (capability probe, sentinel, visibility handling, cleanup) behind a
+one-argument API driven by a boolean signal; a pure exported decision function
+carries the testable logic. `islands/items.tsx` integrates with one computed
+signal over `useShoppingList`'s existing state. No UI anywhere.
+
+**Tech Stack:** Deno + Fresh 2 + Preact signals; Screen Wake Lock API
+(`WakeLockSentinel` types are already in Deno's DOM lib — verified with
+`deno check`; no ambient declarations needed).
+
+**Spec:** `docs/superpowers/specs/2026-08-11-wake-lock-design.md`
+
+## Global Constraints
+
+- **Invisible enhancement (§11):** no UI, no copy, no snackbar. Unsupported
+  browsers and rejected `request()`s degrade silently (`console.debug` only).
+- **Naming note:** the spec says the island's condition comes from
+  `useShoppingList`'s unchecked-items signal — that signal is named **`list`**
+  in `hooks/useShoppingList.ts` (`list` = unchecked, `checkedItems` =
+  checked). Use `list`.
+- **Scope:** exactly three files change (`hooks/useWakeLock.ts` + its test +
+  `hooks/index.ts` in Task 1; `islands/items.tsx` in Task 2). No other
+  screens get the lock.
+- The hook's effects never run during SSR (`useEffect` semantics), so no
+  `typeof document` guard is needed inside the effect — but nothing may touch
+  browser globals outside it.
+- Commits follow Conventional Commits; `deno task check` and the full
+  `deno task test` must pass before every commit.
+- Branch: `feature/wake-lock-73` (already checked out in the worktree). The
+  PR closes #73.
+
+---
+
+### Task 1: `useWakeLock` hook + unit tests
+
+**Files:**
+
+- Create: `hooks/useWakeLock.ts`
+- Test: `hooks/useWakeLock.test.ts` (create)
+- Modify: `hooks/index.ts` (add one export line)
+
+**Interfaces:**
+
+- Consumes: nothing from other tasks.
+- Produces: `shouldRequestLock(probes: { supported: boolean; visible:
+  boolean; wanted: boolean }): boolean` and
+  `useWakeLock(shouldHold: ReadonlySignal<boolean>): void`, both exported
+  from `hooks/index.ts` via the barrel.
+
+- [ ] **Step 1: Write the failing unit test**
+
+Create `hooks/useWakeLock.test.ts`:
+
+```ts
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import { shouldRequestLock } from "./useWakeLock.ts";
+
+Deno.test("shouldRequestLock — holds only when supported, visible and wanted", () => {
+  assertEquals(
+    shouldRequestLock({ supported: true, visible: true, wanted: true }),
+    true,
+  );
+});
+
+Deno.test("shouldRequestLock — any missing leg refuses the lock", () => {
+  assertEquals(
+    shouldRequestLock({ supported: false, visible: true, wanted: true }),
+    false,
+  );
+  assertEquals(
+    shouldRequestLock({ supported: true, visible: false, wanted: true }),
+    false,
+  );
+  assertEquals(
+    shouldRequestLock({ supported: true, visible: true, wanted: false }),
+    false,
+  );
+  assertEquals(
+    shouldRequestLock({ supported: false, visible: false, wanted: false }),
+    false,
+  );
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `deno test --unstable-kv -A hooks/useWakeLock.test.ts`
+
+Expected: FAIL — module `./useWakeLock.ts` not found.
+
+- [ ] **Step 3: Create `hooks/useWakeLock.ts`**
+
+```ts
+import { type ReadonlySignal } from "@preact/signals";
+import { useEffect } from "preact/hooks";
+
+interface WakeLockProbes {
+  supported: boolean;
+  visible: boolean;
+  wanted: boolean;
+}
+
+/** Pure decision — exported for unit tests. */
+export function shouldRequestLock(probes: WakeLockProbes): boolean {
+  return probes.supported && probes.visible && probes.wanted;
+}
+
+/**
+ * Holds a screen wake lock while `shouldHold` is true and the tab is
+ * visible. Invisible enhancement (docs/ui-ux-patterns.md §11): unsupported
+ * browsers and rejected requests degrade silently — the screen simply times
+ * out like it always did.
+ *
+ * The browser force-releases the lock whenever the tab hides (and may
+ * release it on its own for battery saving); the `release` listener drops
+ * the stale sentinel so the next visibility/signal change re-requests.
+ */
+export function useWakeLock(shouldHold: ReadonlySignal<boolean>): void {
+  useEffect(() => {
+    if (!("wakeLock" in navigator)) return;
+
+    let sentinel: WakeLockSentinel | null = null;
+    let requesting = false;
+    let disposed = false;
+
+    const sync = async () => {
+      const wanted = shouldRequestLock({
+        supported: true,
+        visible: document.visibilityState === "visible",
+        wanted: shouldHold.value,
+      });
+      if (wanted && !sentinel && !requesting) {
+        requesting = true;
+        try {
+          const s = await navigator.wakeLock.request("screen");
+          if (disposed || !shouldHold.value) {
+            await s.release();
+            return;
+          }
+          sentinel = s;
+          s.addEventListener("release", () => {
+            if (sentinel === s) sentinel = null;
+          });
+        } catch (err) {
+          console.debug("[wake-lock] request failed", err);
+        } finally {
+          requesting = false;
+        }
+      } else if (!wanted && sentinel) {
+        const s = sentinel;
+        sentinel = null;
+        await s.release();
+      }
+    };
+
+    // subscribe() runs the callback immediately with the current value, so
+    // the initial acquisition needs no separate kick-off.
+    const unsubscribe = shouldHold.subscribe(() => {
+      void sync();
+    });
+    const onVisibility = () => {
+      void sync();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      disposed = true;
+      unsubscribe();
+      document.removeEventListener("visibilitychange", onVisibility);
+      void sentinel?.release();
+      sentinel = null;
+    };
+  }, [shouldHold]);
+}
+```
+
+- [ ] **Step 4: Add the barrel export**
+
+In `hooks/index.ts`, add:
+
+```ts
+export * from "./useWakeLock.ts";
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `deno test --unstable-kv -A hooks/useWakeLock.test.ts`
+
+Expected: PASS — 2 tests.
+
+- [ ] **Step 6: Full suite, check, commit**
+
+```bash
+deno task test
+deno task check
+git add hooks/useWakeLock.ts hooks/useWakeLock.test.ts hooks/index.ts
+git commit -m "feat(pwa): add reusable useWakeLock hook"
+```
+
+---
+
+### Task 2: Hold the lock on the shopping list screen
+
+**Files:**
+
+- Modify: `islands/items.tsx` (two imports + two lines after the
+  `useShoppingList` destructure)
+
+**Interfaces:**
+
+- Consumes: `useWakeLock(shouldHold: ReadonlySignal<boolean>)` from
+  `@/hooks/index.ts` (Task 1); the `list` signal already destructured from
+  `useShoppingList` (it holds the UNCHECKED items — see Global Constraints).
+- Produces: nothing later tasks rely on.
+
+**No new unit test for this task** — the hook is effect-only, so the island's
+SSR output is byte-identical with or without it; there is nothing for a
+render-to-string test to observe (the spec anticipates this). The full suite
+still runs to prove nothing regressed, and the live acquisition/release
+behavior is verified in Task 3's browser pass.
+
+- [ ] **Step 1: Edit `islands/items.tsx`**
+
+Extend the two existing imports:
+
+```tsx
+import { useComputed, useSignal } from "@preact/signals";
+```
+
+(currently imports only `useSignal` from `@preact/signals`; keep `For` from
+`@preact/signals/utils` as is), and:
+
+```tsx
+import { useShoppingList, useWakeLock } from "@/hooks/index.ts";
+```
+
+Directly after the `useMemo(() => useShoppingList(...), [])` destructure
+block (after its closing `);`), add:
+
+```tsx
+  // Keep the screen awake mid-shop (#73): held while this list still has
+  // unchecked items — `list` holds the open ones — released when the trip
+  // is done, the tab hides, or the island unmounts.
+  const hasOpenItems = useComputed(() => list.value.length > 0);
+  useWakeLock(hasOpenItems);
+```
+
+- [ ] **Step 2: Full suite and check**
+
+Run: `deno task test`
+Expected: PASS — full suite, no count change from Task 1.
+
+Run: `deno task check`
+Expected: green (fmt + lint + types — `useComputed` and the hook resolve).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add islands/items.tsx
+git commit -m "feat(shopping): keep the screen awake while items remain unchecked"
+```
+
+---
+
+### Task 3: Browser verification + wrap up
+
+**Files:** none (verification only; controller-run — needs the browser pane).
+
+- [ ] **Step 1: Dev server**
+
+As in prior iterations: `.env` with `SEED_USERNAME`/`SEED_PASSWORD`/
+`KV_PATH=data/kv.db`, `deno task db:seed`, launch config `dev-wt`
+(port 5178), curl-cookie login.
+
+- [ ] **Step 2: Spy on the Wake Lock API, then exercise the transitions**
+
+The platform offers no "list current locks" API, so verification wraps
+`navigator.wakeLock.request` with a spy AFTER load, then forces the hook
+through its transitions with real interactions:
+
+```js
+// in the page console / javascript_tool:
+window.__wl = { requests: 0, releases: 0 };
+const orig = navigator.wakeLock.request.bind(navigator.wakeLock);
+navigator.wakeLock.request = async (type) => {
+  const s = await orig(type);
+  window.__wl.requests++;
+  s.addEventListener("release", () => window.__wl.releases++);
+  return s;
+};
+```
+
+Then, on a seeded list that has BOTH checked and unchecked items (Weekly
+Groceries, 4/10 done):
+
+1. Check off every remaining item (real clicks) → the hook's release path
+   runs (`window.__wl.releases` unchanged if the pre-spy sentinel was held —
+   the release of a pre-spy sentinel isn't counted; what matters next is:)
+2. Un-check one item (real click in the checked section) → `requests`
+   increments — the hook re-acquired through the spy.
+3. Check it off again → `releases` increments — the hook released when the
+   list emptied.
+
+Expected: `requests >= 1`, `releases >= 1`, console free of errors
+(`console.debug` messages are acceptable only if the pane denies wake locks —
+note it in the summary if so).
+
+- [ ] **Step 3: Wrap up the branch**
+
+Use the superpowers:finishing-a-development-branch skill (final whole-branch
+review first, per subagent-driven-development). The PR closes #73:
+
+```bash
+gh pr create --base main --title "feat(pwa): keep the screen awake while shopping (wake lock)" --body "Closes #73. Iteration 3 of the PWA roadmap (docs/superpowers/specs/2026-08-11-wake-lock-design.md)."
+```
+
+Real-device confirmation (screen genuinely not dimming mid-shop) rides on
+`deno task dev:mobile` as a PR follow-up note.

--- a/docs/superpowers/specs/2026-08-11-wake-lock-design.md
+++ b/docs/superpowers/specs/2026-08-11-wake-lock-design.md
@@ -1,0 +1,87 @@
+# Wake Lock While Shopping — Design
+
+**Date:** 2026-08-11\
+**Issue:** #73 (iteration 3 of the PWA roadmap,
+`docs/superpowers/specs/2026-08-08-pwa-roadmap-design.md`)\
+**Status:** Approved
+
+## Context
+
+Mid-shop, the screen keeps timing out — wet hands, gloves, a cart to push.
+The Screen Wake Lock API (Chrome, Safari 16.4+) can keep the display on while
+it matters. This is the roadmap's iteration 3; the deferred design question
+(always-on vs. toggle) is now decided.
+
+## Goal
+
+While a shopping list with unchecked items is open, the screen stays awake.
+When the last item is checked off, the member navigates away, or the tab is
+hidden, the lock is released. No UI, no settings — invisible when it works,
+invisible when the browser doesn't support it.
+
+## Decisions
+
+1. **Automatic, shopping-scoped (user-decided):** the lock is held exactly
+   while the open list has unchecked items. No toggle, no persistence, no
+   other screens.
+2. **Reusable hook (user-approved approach):** a generic `useWakeLock` in
+   `hooks/`, consumed by the shopping list island with a one-line condition.
+   Future modules (e.g. a cooking mode) reuse it unchanged.
+3. **Silent degradation:** unsupported browsers and rejected requests change
+   nothing visible. An invisible enhancement must not produce visible
+   complaints (§11 of `docs/ui-ux-patterns.md`; no snackbar).
+
+## Architecture
+
+| Unit | Responsibility |
+| --- | --- |
+| `hooks/useWakeLock.ts` | Everything wake-lock: capability probe, sentinel lifecycle, visibility handling, cleanup. Exposes `useWakeLock(shouldHold)` + a pure, exported decision function. |
+| `islands/items.tsx` | Contributes the condition: the open list has unchecked items (`useShoppingList` already maintains an `uncheckedItems` signal). One computed + one hook call. |
+
+### `useWakeLock(shouldHold: ReadonlySignal<boolean>)`
+
+- **Pure decision function** (exported for unit tests, mirroring
+  `detectInstallState`):
+  `shouldRequestLock(probes: { supported: boolean; visible: boolean; wanted: boolean }): boolean`
+  — true only when all three are true.
+- **Probes:** `supported` = `"wakeLock" in navigator`, evaluated client-side
+  only (§11 guard on `typeof document`, never `navigator` — Deno defines a
+  server-side navigator); `visible` = `document.visibilityState === "visible"`;
+  `wanted` = the consumer's signal.
+- **Lifecycle:** when the decision flips true, `navigator.wakeLock
+  .request("screen")` inside try/catch; hold the `WakeLockSentinel`. When it
+  flips false, `sentinel.release()`. The browser force-releases on tab hide —
+  listen for `visibilitychange` and re-acquire when visible again while
+  `wanted` still holds. Listen for the sentinel's own `release` event so a
+  browser-initiated release (battery saver) doesn't leave a stale reference.
+  Release + remove listeners on unmount.
+- **Failure:** a rejected `request()` is logged at debug level and otherwise
+  ignored; the decision re-evaluates on the next signal/visibility change, so
+  a temporary refusal (e.g. battery saver ends) self-heals without a retry
+  loop.
+- **SSR:** renders nothing, touches nothing server-side; deterministic no-op.
+
+### Shopping list integration
+
+In `islands/items.tsx`: a computed signal over `useShoppingList`'s
+`uncheckedItems` (`uncheckedItems.value.length > 0`), passed to
+`useWakeLock`. Nothing else changes — no UI, no copy.
+
+## Out of scope (YAGNI)
+
+A user toggle or any visible control; wake lock on other screens (catalogue,
+add-items, to-dos); Battery Status API integration; persisting a preference;
+any service-worker involvement.
+
+## Testing
+
+- **Unit:** `hooks/useWakeLock.test.ts` — `shouldRequestLock` across all
+  probe combinations (colocated, like the other hook tests).
+- **Render:** the shopping list island still SSRs deterministically with the
+  hook in place (extend the existing island test only if the change is
+  observable in SSR output — it should not be).
+- **Browser (controller):** on the dev server in desktop Chrome (which
+  supports wake lock): open a list with unchecked items and observe a held
+  sentinel; check off the last item and observe the release; hide/show the
+  tab and observe re-acquisition. Real-phone check rides on
+  `deno task dev:mobile` as a PR follow-up.

--- a/docs/ui-ux-patterns.md
+++ b/docs/ui-ux-patterns.md
@@ -671,6 +671,46 @@ return portalTarget ? createPortal(tree, portalTarget) : tree;
 
 ---
 
+## 18. Device-capability hooks publish real state, not intent
+
+**Rule:** A reusable hook wrapping a browser capability (wake lock,
+geolocation, sensors, …) belongs in `hooks/` behind a signal-driven API — it
+takes its inputs as `ReadonlySignal`s and returns one. Publish the
+capability's *actual, granted* state, not merely what was requested, and
+degrade silently when the capability is unsupported or refused (§11).
+
+**Why:** UI driven by intent instead of outcome lies. A "we want this" signal
+stays true even when the browser can't or won't grant it — an unsupported
+API, a request the OS refuses (battery saver, most commonly), or a grant the
+browser later revokes on its own — so any indicator built on it keeps
+claiming something is happening when it isn't.
+
+**How:** Track the granted state in its own `useSignal`, flip it at every
+point the underlying resource is acquired, released, revoked, or refused, and
+return *that* signal (not the input intent) for callers to render from.
+
+```ts
+// hooks/useWakeLock.ts
+export function useWakeLock(
+  shouldHold: ReadonlySignal<boolean>,
+): { held: ReadonlySignal<boolean> } { /* … */ }
+```
+
+```ts
+// islands/items.tsx
+const { held: screenAwake } = useWakeLock(hasOpenItems);
+// …
+{screenAwake.value && <span>… Screen awake</span>}
+```
+
+The Shop-mode chip renders from `held`, so it disappears the moment a browser
+refuses the lock (battery saver mid-shop) instead of claiming an awake screen
+that isn't there.
+
+**See:** `hooks/useWakeLock.ts`, `islands/items.tsx`.
+
+---
+
 ## Review checklist for user-facing changes
 
 Before merging anything the user sees, tick these (section refs in parens):

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -2,3 +2,4 @@ export * from "./useShoppingList.ts";
 export * from "./useSearchBox.ts";
 export * from "./useSearchInput.ts";
 export * from "./usePullToRefresh.ts";
+export * from "./useWakeLock.ts";

--- a/hooks/useWakeLock.test.ts
+++ b/hooks/useWakeLock.test.ts
@@ -25,4 +25,16 @@ Deno.test("shouldRequestLock — any missing leg refuses the lock", () => {
     shouldRequestLock({ supported: false, visible: false, wanted: false }),
     false,
   );
+  assertEquals(
+    shouldRequestLock({ supported: false, visible: false, wanted: true }),
+    false,
+  );
+  assertEquals(
+    shouldRequestLock({ supported: true, visible: false, wanted: false }),
+    false,
+  );
+  assertEquals(
+    shouldRequestLock({ supported: false, visible: true, wanted: false }),
+    false,
+  );
 });

--- a/hooks/useWakeLock.test.ts
+++ b/hooks/useWakeLock.test.ts
@@ -1,0 +1,28 @@
+import { assertEquals } from "jsr:@std/assert@^1.0.19";
+import { shouldRequestLock } from "./useWakeLock.ts";
+
+Deno.test("shouldRequestLock — holds only when supported, visible and wanted", () => {
+  assertEquals(
+    shouldRequestLock({ supported: true, visible: true, wanted: true }),
+    true,
+  );
+});
+
+Deno.test("shouldRequestLock — any missing leg refuses the lock", () => {
+  assertEquals(
+    shouldRequestLock({ supported: false, visible: true, wanted: true }),
+    false,
+  );
+  assertEquals(
+    shouldRequestLock({ supported: true, visible: false, wanted: true }),
+    false,
+  );
+  assertEquals(
+    shouldRequestLock({ supported: true, visible: true, wanted: false }),
+    false,
+  );
+  assertEquals(
+    shouldRequestLock({ supported: false, visible: false, wanted: false }),
+    false,
+  );
+});

--- a/hooks/useWakeLock.ts
+++ b/hooks/useWakeLock.ts
@@ -1,0 +1,81 @@
+import { type ReadonlySignal } from "@preact/signals";
+import { useEffect } from "preact/hooks";
+
+interface WakeLockProbes {
+  supported: boolean;
+  visible: boolean;
+  wanted: boolean;
+}
+
+/** Pure decision — exported for unit tests. */
+export function shouldRequestLock(probes: WakeLockProbes): boolean {
+  return probes.supported && probes.visible && probes.wanted;
+}
+
+/**
+ * Holds a screen wake lock while `shouldHold` is true and the tab is
+ * visible. Invisible enhancement (docs/ui-ux-patterns.md §11): unsupported
+ * browsers and rejected requests degrade silently — the screen simply times
+ * out like it always did.
+ *
+ * The browser force-releases the lock whenever the tab hides (and may
+ * release it on its own for battery saving); the `release` listener drops
+ * the stale sentinel so the next visibility/signal change re-requests.
+ */
+export function useWakeLock(shouldHold: ReadonlySignal<boolean>): void {
+  useEffect(() => {
+    if (!("wakeLock" in navigator)) return;
+
+    let sentinel: WakeLockSentinel | null = null;
+    let requesting = false;
+    let disposed = false;
+
+    const sync = async () => {
+      const wanted = shouldRequestLock({
+        supported: true,
+        visible: document.visibilityState === "visible",
+        wanted: shouldHold.value,
+      });
+      if (wanted && !sentinel && !requesting) {
+        requesting = true;
+        try {
+          const s = await navigator.wakeLock.request("screen");
+          if (disposed || !shouldHold.value) {
+            await s.release();
+            return;
+          }
+          sentinel = s;
+          s.addEventListener("release", () => {
+            if (sentinel === s) sentinel = null;
+          });
+        } catch (err) {
+          console.debug("[wake-lock] request failed", err);
+        } finally {
+          requesting = false;
+        }
+      } else if (!wanted && sentinel) {
+        const s = sentinel;
+        sentinel = null;
+        await s.release();
+      }
+    };
+
+    // subscribe() runs the callback immediately with the current value, so
+    // the initial acquisition needs no separate kick-off.
+    const unsubscribe = shouldHold.subscribe(() => {
+      void sync();
+    });
+    const onVisibility = () => {
+      void sync();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      disposed = true;
+      unsubscribe();
+      document.removeEventListener("visibilitychange", onVisibility);
+      void sentinel?.release();
+      sentinel = null;
+    };
+  }, [shouldHold]);
+}

--- a/hooks/useWakeLock.ts
+++ b/hooks/useWakeLock.ts
@@ -1,4 +1,4 @@
-import { type ReadonlySignal } from "@preact/signals";
+import { type ReadonlySignal, useSignal } from "@preact/signals";
 import { useEffect } from "preact/hooks";
 
 interface WakeLockProbes {
@@ -21,8 +21,17 @@ export function shouldRequestLock(probes: WakeLockProbes): boolean {
  * The browser force-releases the lock whenever the tab hides (and may
  * release it on its own for battery saving); the `release` listener drops
  * the stale sentinel so the next visibility/signal change re-requests.
+ *
+ * Returns `held`: whether a lock is actually held right now, not merely
+ * requested. It's false whenever the browser doesn't support wake locks,
+ * refuses a request (e.g. battery saver), or revokes a held lock on its
+ * own — so callers can render UI that reflects reality instead of intent.
  */
-export function useWakeLock(shouldHold: ReadonlySignal<boolean>): void {
+export function useWakeLock(
+  shouldHold: ReadonlySignal<boolean>,
+): { held: ReadonlySignal<boolean> } {
+  const held = useSignal(false);
+
   useEffect(() => {
     if (!("wakeLock" in navigator)) return;
 
@@ -45,18 +54,22 @@ export function useWakeLock(shouldHold: ReadonlySignal<boolean>): void {
             return;
           }
           sentinel = s;
+          held.value = true;
           s.addEventListener("release", () => {
             if (sentinel === s) sentinel = null;
+            held.value = false;
           });
         } catch (err) {
           console.debug("[wake-lock] request failed", err);
+          held.value = false;
         } finally {
           requesting = false;
         }
       } else if (!wanted && sentinel) {
         const s = sentinel;
         sentinel = null;
-        await s.release();
+        await s.release().catch(() => {});
+        held.value = false;
       }
     };
 
@@ -74,8 +87,11 @@ export function useWakeLock(shouldHold: ReadonlySignal<boolean>): void {
       disposed = true;
       unsubscribe();
       document.removeEventListener("visibilitychange", onVisibility);
-      void sentinel?.release();
+      void sentinel?.release().catch(() => {});
       sentinel = null;
+      held.value = false;
     };
   }, [shouldHold]);
+
+  return { held };
 }

--- a/hooks/useWakeLock.ts
+++ b/hooks/useWakeLock.ts
@@ -56,8 +56,12 @@ export function useWakeLock(
           sentinel = s;
           held.value = true;
           s.addEventListener("release", () => {
-            if (sentinel === s) sentinel = null;
-            held.value = false;
+            // Guarded: a stale sentinel's release must not clear the flag for a
+            // newer lock that is still held.
+            if (sentinel === s) {
+              sentinel = null;
+              held.value = false;
+            }
           });
         } catch (err) {
           console.debug("[wake-lock] request failed", err);

--- a/islands/items.tsx
+++ b/islands/items.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useMemo, useRef } from "preact/hooks";
-import { useSignal } from "@preact/signals";
+import { useComputed, useSignal } from "@preact/signals";
 import { For } from "@preact/signals/utils";
 import {
   CategoryInterface,
   ItemInterface,
   ShoppingListItemInterface,
 } from "@/models/index.ts";
-import { useShoppingList } from "@/hooks/index.ts";
+import { useShoppingList, useWakeLock } from "@/hooks/index.ts";
 import { api } from "@/services/api.ts";
 import { Segmented } from "@/components/md3/Segmented.tsx";
 import { Sheet } from "@/components/md3/Sheet.tsx";
@@ -69,6 +69,12 @@ export default function Items(
     () => useShoppingList(listId, catalog, shoppingList, initialCategories),
     [], // intentionally empty — signals are initialized once from SSR data
   );
+
+  // Keep the screen awake mid-shop (#73): held while this list still has
+  // unchecked items — `list` holds the open ones — released when the trip
+  // is done, the tab hides, or the island unmounts.
+  const hasOpenItems = useComputed(() => list.value.length > 0);
+  useWakeLock(hasOpenItems);
 
   // ── mode toggle ──────────────────────────────────────────────────────────
   const mode = useSignal<"plan" | "shop">("plan");

--- a/islands/items.tsx
+++ b/islands/items.tsx
@@ -303,10 +303,16 @@ export default function Items(
                 <span class="md-title-medium text-on-surface whitespace-nowrap">
                   {done} / {total} in cart
                 </span>
-                {/* NOTE: Wake Lock API is not implemented in this spike — this is a static label only */}
-                <span class="inline-flex items-center gap-1 md-label-small text-on-surface-variant whitespace-nowrap shrink-0">
-                  <Icon name="bolt" size={13} /> Screen awake
-                </span>
+                {
+                  /* Mirrors the wake lock actually requested by useWakeLock above:
+                    shown only while unchecked items remain, i.e. while the app
+                    is asking the device to keep the screen on. */
+                }
+                {hasOpenItems.value && (
+                  <span class="inline-flex items-center gap-1 md-label-small text-on-surface-variant whitespace-nowrap shrink-0">
+                    <Icon name="bolt" size={13} /> Screen awake
+                  </span>
+                )}
               </div>
               <Progress value={done} total={total} height={8} />
             </Card>

--- a/islands/items.tsx
+++ b/islands/items.tsx
@@ -72,9 +72,10 @@ export default function Items(
 
   // Keep the screen awake mid-shop (#73): held while this list still has
   // unchecked items — `list` holds the open ones — released when the trip
-  // is done, the tab hides, or the island unmounts.
+  // is done, the tab hides, or the island unmounts. The chip below follows
+  // the hook's `held` signal, i.e. the real lock state, not this intent.
   const hasOpenItems = useComputed(() => list.value.length > 0);
-  useWakeLock(hasOpenItems);
+  const { held: screenAwake } = useWakeLock(hasOpenItems);
 
   // ── mode toggle ──────────────────────────────────────────────────────────
   const mode = useSignal<"plan" | "shop">("plan");
@@ -304,11 +305,11 @@ export default function Items(
                   {done} / {total} in cart
                 </span>
                 {
-                  /* Mirrors the wake lock actually requested by useWakeLock above:
-                    shown only while unchecked items remain, i.e. while the app
-                    is asking the device to keep the screen on. */
+                  /* Mirrors the wake lock actually held by useWakeLock above:
+                    shown only while a lock is genuinely held, so it disappears
+                    if the browser refuses or revokes it (e.g. battery saver). */
                 }
-                {hasOpenItems.value && (
+                {screenAwake.value && (
                   <span class="inline-flex items-center gap-1 md-label-small text-on-surface-variant whitespace-nowrap shrink-0">
                     <Icon name="bolt" size={13} /> Screen awake
                   </span>


### PR DESCRIPTION
Closes #73. Iteration 3 of the PWA roadmap; design in `docs/superpowers/specs/2026-08-11-wake-lock-design.md`.

## What changed

- **`hooks/useWakeLock.ts`** — a reusable, signal-driven hook: `useWakeLock(shouldHold)` holds a screen wake lock while the caller's signal is true and the tab is visible, releasing on the trip finishing, tab hide, or unmount. It owns the whole lifecycle (capability probe, sentinel, re-acquire after the browser's force-release on hide, cleanup) and returns `{ held }` — whether a lock is *actually* granted. A pure `shouldRequestLock(probes)` carries the decision logic and is unit-tested across the full truth table.
- **`islands/items.tsx`** — two lines: the lock is wanted while the open list still has unchecked items (`list` holds the open ones). No new UI.

## Bug found & fixed along the way

The Shop-mode progress card already displayed a "⚡ Screen awake" chip — and it was **fake**. It came in with the original MD3 spike (`d7fbfe6`, long merged) and its own comment said so: "Wake Lock API is not implemented in this spike — this is a static label only". It rendered unconditionally, claiming an awake screen even on a fully-checked list.

It now renders from `held`, so it tells the truth in the cases that actually matter on a phone: it stays hidden when the browser has no Wake Lock API, when a request is **refused (battery saver — the likeliest case mid-shop)**, and when the browser revokes a held lock. Documented as §18 of `docs/ui-ux-patterns.md` (capability hooks publish real state, not intent).

## Verification

- 494/494 tests, `deno task check` green.
- Live browser: the hook demonstrably calls the real Wake Lock API at the right moments and degrades silently when refused (`[wake-lock] request failed … NotAllowedError` at debug level only, no UI). Chip behavior verified with real clicks — present only when a lock is genuinely held; with 6 open items but a refused lock it correctly stays hidden.
- **Not verifiable in this environment:** an actually-granted lock. The automation browser pane renders permanently `visibilityState: "hidden"`, and Chrome refuses wake locks for a never-visible page (confirmed with a direct API call). Needs a real window.
- Final whole-branch review traced the async lifecycle for sentinel leaks, double-acquires and hide/show storms and found none; its one should-fix (the chip overclaiming) is what the `held` signal resolves. A follow-up commit also guards the `held` flag against a stale sentinel's release event clobbering a newer lock.

## Manual follow-up

On a real device via `deno task dev:mobile`: confirm the screen genuinely stops dimming with items outstanding, and that the chip appears alongside it.

Note the lock is held in **Plan mode too**, not only Shop mode — per the spec's "while the open list has unchecked items", deliberately not mode-scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)